### PR TITLE
chore: turn construct-hub-webapp to a dev dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 /dist
 /lib
 /test-reports/
+/website
 build/Release
 coverage
 jspm_packages/

--- a/.npmignore
+++ b/.npmignore
@@ -17,3 +17,4 @@ junit.xml
 !/lib
 !/lib/**/*.d.ts
 !/lib/**/*.js
+!/website

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -28,6 +28,10 @@
       "type": "build"
     },
     {
+      "name": "construct-hub-webapp",
+      "type": "build"
+    },
+    {
       "name": "esbuild",
       "type": "build"
     },
@@ -105,10 +109,6 @@
     {
       "name": "yaml",
       "type": "build"
-    },
-    {
-      "name": "construct-hub-webapp",
-      "type": "bundled"
     },
     {
       "name": "@aws-cdk/aws-certificatemanager",

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -63,6 +63,9 @@
       "description": "Only compile",
       "steps": [
         {
+          "exec": "mv node_modules/construct-hub-webapp/build ./website"
+        },
+        {
           "exec": "jsii --silence-warnings=reserved-word --no-fix-peer-dependencies"
         },
         {

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -50,10 +50,6 @@ const project = new AwsCdkConstructLibrary({
     'cdk-watchful@^0.5.129',
   ],
 
-  bundledDeps: [
-    'construct-hub-webapp',
-  ],
-
   minNodeVersion: '12.0.0',
 
   pullRequestTemplateContents: [
@@ -206,6 +202,14 @@ function discoverLambdas() {
     newLambdaHandler(entry);
   }
 }
+
+// extract the "build/" directory from "construct-hub-webapp" into "./website"
+// and bundle it with this library. this way, we are only taking a
+// dev-dependency on the webapp instead of a normal/bundled dependency.
+project.addDevDeps('construct-hub-webapp');
+project.compileTask.prependExec('mv node_modules/construct-hub-webapp/build ./website');
+project.npmignore.addPatterns('!/website'); // <-- include in tarball
+project.gitignore.addPatterns('/website'); // <-- don't commit
 
 addDevApp();
 discoverLambdas();

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/parser": "^4.22.0",
     "aws-cdk": "^1.100.0",
+    "construct-hub-webapp": "^0.1.4",
     "esbuild": "^0.11.18",
     "eslint": "^7.25.0",
     "eslint-import-resolver-node": "^0.3.4",
@@ -88,12 +89,9 @@
     "@aws-cdk/aws-sns": "^1.100.0",
     "@aws-cdk/core": "^1.100.0",
     "@aws-cdk/cx-api": "^1.100.0",
-    "cdk-watchful": "^0.5.129",
-    "construct-hub-webapp": "^0.1.4"
+    "cdk-watchful": "^0.5.129"
   },
-  "bundledDependencies": [
-    "construct-hub-webapp"
-  ],
+  "bundledDependencies": [],
   "keywords": [
     "aws",
     "aws-cdk",

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -172,7 +172,7 @@ Resources:
           - CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536
           - Arn
       SourceBucketNames:
-        - Ref: AssetParametersed22d707cab33a10dae20929f915213c820ba481d0bf67bf64dabbb37c923afeS3Bucket03955CD4
+        - Ref: AssetParameters8452a12da113d3e02da3aaf4b7c8d6e9cb77bd3a62a09a4105a7a6160cd3f410S3Bucket11A0D65B
       SourceObjectKeys:
         - Fn::Join:
             - ""
@@ -180,12 +180,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersed22d707cab33a10dae20929f915213c820ba481d0bf67bf64dabbb37c923afeS3VersionKeyD4C760A1
+                      - Ref: AssetParameters8452a12da113d3e02da3aaf4b7c8d6e9cb77bd3a62a09a4105a7a6160cd3f410S3VersionKey5E1C1FBA
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersed22d707cab33a10dae20929f915213c820ba481d0bf67bf64dabbb37c923afeS3VersionKeyD4C760A1
+                      - Ref: AssetParameters8452a12da113d3e02da3aaf4b7c8d6e9cb77bd3a62a09a4105a7a6160cd3f410S3VersionKey5E1C1FBA
       DestinationBucketName:
         Ref: ConstructHubWebAppWebsiteBucket4B2B9DB2
       Prune: true
@@ -401,13 +401,13 @@ Resources:
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParametersed22d707cab33a10dae20929f915213c820ba481d0bf67bf64dabbb37c923afeS3Bucket03955CD4
+                    - Ref: AssetParameters8452a12da113d3e02da3aaf4b7c8d6e9cb77bd3a62a09a4105a7a6160cd3f410S3Bucket11A0D65B
               - Fn::Join:
                   - ""
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParametersed22d707cab33a10dae20929f915213c820ba481d0bf67bf64dabbb37c923afeS3Bucket03955CD4
+                    - Ref: AssetParameters8452a12da113d3e02da3aaf4b7c8d6e9cb77bd3a62a09a4105a7a6160cd3f410S3Bucket11A0D65B
                     - /*
           - Action:
               - s3:GetObject*
@@ -532,17 +532,17 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "c24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cf"
-  AssetParametersed22d707cab33a10dae20929f915213c820ba481d0bf67bf64dabbb37c923afeS3Bucket03955CD4:
+  AssetParameters8452a12da113d3e02da3aaf4b7c8d6e9cb77bd3a62a09a4105a7a6160cd3f410S3Bucket11A0D65B:
     Type: String
     Description: S3 bucket for asset
-      "ed22d707cab33a10dae20929f915213c820ba481d0bf67bf64dabbb37c923afe"
-  AssetParametersed22d707cab33a10dae20929f915213c820ba481d0bf67bf64dabbb37c923afeS3VersionKeyD4C760A1:
+      "8452a12da113d3e02da3aaf4b7c8d6e9cb77bd3a62a09a4105a7a6160cd3f410"
+  AssetParameters8452a12da113d3e02da3aaf4b7c8d6e9cb77bd3a62a09a4105a7a6160cd3f410S3VersionKey5E1C1FBA:
     Type: String
     Description: S3 key for asset version
-      "ed22d707cab33a10dae20929f915213c820ba481d0bf67bf64dabbb37c923afe"
-  AssetParametersed22d707cab33a10dae20929f915213c820ba481d0bf67bf64dabbb37c923afeArtifactHash6225CDA7:
+      "8452a12da113d3e02da3aaf4b7c8d6e9cb77bd3a62a09a4105a7a6160cd3f410"
+  AssetParameters8452a12da113d3e02da3aaf4b7c8d6e9cb77bd3a62a09a4105a7a6160cd3f410ArtifactHash6E9B9D5B:
     Type: String
     Description: Artifact hash for asset
-      "ed22d707cab33a10dae20929f915213c820ba481d0bf67bf64dabbb37c923afe"
+      "8452a12da113d3e02da3aaf4b7c8d6e9cb77bd3a62a09a4105a7a6160cd3f410"
 
 `;

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -172,7 +172,7 @@ Resources:
           - CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536
           - Arn
       SourceBucketNames:
-        - Ref: AssetParameters8452a12da113d3e02da3aaf4b7c8d6e9cb77bd3a62a09a4105a7a6160cd3f410S3Bucket11A0D65B
+        - Ref: AssetParametersed22d707cab33a10dae20929f915213c820ba481d0bf67bf64dabbb37c923afeS3Bucket03955CD4
       SourceObjectKeys:
         - Fn::Join:
             - ""
@@ -180,12 +180,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters8452a12da113d3e02da3aaf4b7c8d6e9cb77bd3a62a09a4105a7a6160cd3f410S3VersionKey5E1C1FBA
+                      - Ref: AssetParametersed22d707cab33a10dae20929f915213c820ba481d0bf67bf64dabbb37c923afeS3VersionKeyD4C760A1
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters8452a12da113d3e02da3aaf4b7c8d6e9cb77bd3a62a09a4105a7a6160cd3f410S3VersionKey5E1C1FBA
+                      - Ref: AssetParametersed22d707cab33a10dae20929f915213c820ba481d0bf67bf64dabbb37c923afeS3VersionKeyD4C760A1
       DestinationBucketName:
         Ref: ConstructHubWebAppWebsiteBucket4B2B9DB2
       Prune: true
@@ -401,13 +401,13 @@ Resources:
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParameters8452a12da113d3e02da3aaf4b7c8d6e9cb77bd3a62a09a4105a7a6160cd3f410S3Bucket11A0D65B
+                    - Ref: AssetParametersed22d707cab33a10dae20929f915213c820ba481d0bf67bf64dabbb37c923afeS3Bucket03955CD4
               - Fn::Join:
                   - ""
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParameters8452a12da113d3e02da3aaf4b7c8d6e9cb77bd3a62a09a4105a7a6160cd3f410S3Bucket11A0D65B
+                    - Ref: AssetParametersed22d707cab33a10dae20929f915213c820ba481d0bf67bf64dabbb37c923afeS3Bucket03955CD4
                     - /*
           - Action:
               - s3:GetObject*
@@ -532,17 +532,17 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "c24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cf"
-  AssetParameters8452a12da113d3e02da3aaf4b7c8d6e9cb77bd3a62a09a4105a7a6160cd3f410S3Bucket11A0D65B:
+  AssetParametersed22d707cab33a10dae20929f915213c820ba481d0bf67bf64dabbb37c923afeS3Bucket03955CD4:
     Type: String
     Description: S3 bucket for asset
-      "8452a12da113d3e02da3aaf4b7c8d6e9cb77bd3a62a09a4105a7a6160cd3f410"
-  AssetParameters8452a12da113d3e02da3aaf4b7c8d6e9cb77bd3a62a09a4105a7a6160cd3f410S3VersionKey5E1C1FBA:
+      "ed22d707cab33a10dae20929f915213c820ba481d0bf67bf64dabbb37c923afe"
+  AssetParametersed22d707cab33a10dae20929f915213c820ba481d0bf67bf64dabbb37c923afeS3VersionKeyD4C760A1:
     Type: String
     Description: S3 key for asset version
-      "8452a12da113d3e02da3aaf4b7c8d6e9cb77bd3a62a09a4105a7a6160cd3f410"
-  AssetParameters8452a12da113d3e02da3aaf4b7c8d6e9cb77bd3a62a09a4105a7a6160cd3f410ArtifactHash6E9B9D5B:
+      "ed22d707cab33a10dae20929f915213c820ba481d0bf67bf64dabbb37c923afe"
+  AssetParametersed22d707cab33a10dae20929f915213c820ba481d0bf67bf64dabbb37c923afeArtifactHash6225CDA7:
     Type: String
     Description: Artifact hash for asset
-      "8452a12da113d3e02da3aaf4b7c8d6e9cb77bd3a62a09a4105a7a6160cd3f410"
+      "ed22d707cab33a10dae20929f915213c820ba481d0bf67bf64dabbb37c923afe"
 
 `;

--- a/src/webapp/index.ts
+++ b/src/webapp/index.ts
@@ -31,7 +31,7 @@ export class WebApp extends Construct {
 
     // since `construct-hub-web` does not have an index file, we need to resolve
     // a specific file inside the module.
-    const webappDir = path.dirname(require.resolve('construct-hub-webapp/build/index.html'));
+    const webappDir = path.join(__dirname, '..', '..', 'website');
     new s3deploy.BucketDeployment(this, 'DeployWebsite', {
       sources: [s3deploy.Source.asset(webappDir)],
       destinationBucket: this.bucket,


### PR DESCRIPTION
Since construct-hub-webapp currently takes a normal dependency on react-related libraries, bundling it using `bundledDeps` means we will bundle dozens of modules and the tarball size gets to 30MiB.

Instead, take a dev-dependency on it and just copy the `build/` directory from construct-hub-webapp to `website/`, which is then used as the asset.

We can add support in projen to change react-related deps to be dev-deps but this is a good solution for now.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*