### PR TITLE
fix: colliding case-insensitive filesystem filenames

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,0 @@
-
-----
-
-*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,4 @@
+
+----
+
+*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,0 @@
-
-----
-
-*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*


### PR DESCRIPTION
```shell
gh repo clone cdklabs/construct-hub foo
Cloning into 'foo'...
remote: Enumerating objects: 490, done.
remote: Counting objects: 100% (490/490), done.
remote: Compressing objects: 100% (277/277), done.
remote: Total 490 (delta 278), reused 362 (delta 179), pack-reused 0
Receiving objects: 100% (490/490), 518.07 KiB | 5.34 MiB/s, done.
Resolving deltas: 100% (278/278), done.
warning: the following paths have collided (e.g. case-sensitive paths
on a case-insensitive filesystem) and only one from the same
colliding group is in the working tree:

  '.github/PULL_REQUEST_TEMPLATE.md'
  '.github/pull_request_template.md'
```