### PR TITLE
fix: cloudfront spa routing

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -63,7 +63,7 @@
       "description": "Only compile",
       "steps": [
         {
-          "exec": "mv node_modules/construct-hub-webapp/build ./website"
+          "exec": "cp -r ./node_modules/construct-hub-webapp/build ./website"
         },
         {
           "exec": "jsii --silence-warnings=reserved-word --no-fix-peer-dependencies"

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -208,7 +208,7 @@ function discoverLambdas() {
 // and bundle it with this library. this way, we are only taking a
 // dev-dependency on the webapp instead of a normal/bundled dependency.
 project.addDevDeps('construct-hub-webapp');
-project.compileTask.prependExec('mv node_modules/construct-hub-webapp/build ./website');
+project.compileTask.prependExec('cp -r ./node_modules/construct-hub-webapp/build ./website');
 project.npmignore.addPatterns('!/website'); // <-- include in tarball
 project.gitignore.addPatterns('/website'); // <-- don't commit
 

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -630,6 +630,18 @@ Object {
     "ConstructHubWebAppDistribution1F181DC9": Object {
       "Properties": Object {
         "DistributionConfig": Object {
+          "CustomErrorResponses": Array [
+            Object {
+              "ErrorCode": 404,
+              "ResponseCode": 200,
+              "ResponsePagePath": "/index.html",
+            },
+            Object {
+              "ErrorCode": 403,
+              "ResponseCode": 200,
+              "ResponsePagePath": "/index.html",
+            },
+          ],
           "DefaultCacheBehavior": Object {
             "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
             "Compress": true,
@@ -1769,6 +1781,18 @@ Object {
         "DistributionConfig": Object {
           "Aliases": Array [
             "my.construct.hub",
+          ],
+          "CustomErrorResponses": Array [
+            Object {
+              "ErrorCode": 404,
+              "ResponseCode": 200,
+              "ResponsePagePath": "/index.html",
+            },
+            Object {
+              "ErrorCode": 403,
+              "ResponseCode": 200,
+              "ResponsePagePath": "/index.html",
+            },
           ],
           "DefaultCacheBehavior": Object {
             "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -123,6 +123,13 @@ Resources:
     Type: AWS::CloudFront::Distribution
     Properties:
       DistributionConfig:
+        CustomErrorResponses:
+          - ErrorCode: 404
+            ResponseCode: 200
+            ResponsePagePath: /index.html
+          - ErrorCode: 403
+            ResponseCode: 200
+            ResponsePagePath: /index.html
         DefaultCacheBehavior:
           CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6
           Compress: true

--- a/src/webapp/index.ts
+++ b/src/webapp/index.ts
@@ -23,12 +23,16 @@ export class WebApp extends Construct {
     super(scope, id);
 
     this.bucket = new s3.Bucket(this, 'WebsiteBucket');
-
     this.distribution = new cloudfront.Distribution(this, 'Distribution', {
       defaultBehavior: { origin: new origins.S3Origin(this.bucket) },
       domainNames: props.domain ? [props.domain.zone.zoneName] : undefined,
       certificate: props.domain ? props.domain.cert : undefined,
       defaultRootObject: 'index.html',
+      errorResponses: [404, 403].map(httpStatus => ( {
+        httpStatus,
+        responseHttpStatus: 200,
+        responsePagePath: '/index.html',
+      })),
     });
 
     // if we use a domain, and A records with a CloudFront alias


### PR DESCRIPTION
Adds error response config to cloudfront distribution to always return
index.html. This is standard for single page apps deployed on cloudfront
and S3 so that all routing can he handled client side including error
responses.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*