### PR TITLE
feat: add origin for jsii assembly access

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -630,6 +630,15 @@ Object {
     "ConstructHubWebAppDistribution1F181DC9": Object {
       "Properties": Object {
         "DistributionConfig": Object {
+          "CacheBehaviors": Array [
+            Object {
+              "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
+              "Compress": true,
+              "PathPattern": "/packages/*",
+              "TargetOriginId": "TestConstructHubWebAppDistributionOrigin276090F90",
+              "ViewerProtocolPolicy": "allow-all",
+            },
+          ],
           "CustomErrorResponses": Array [
             Object {
               "ErrorCode": 404,
@@ -674,6 +683,16 @@ Object {
                   ],
                 },
               },
+            },
+            Object {
+              "CustomOriginConfig": Object {
+                "OriginProtocolPolicy": "https-only",
+                "OriginSSLProtocols": Array [
+                  "TLSv1.2",
+                ],
+              },
+              "DomainName": "awscdk.io",
+              "Id": "TestConstructHubWebAppDistributionOrigin276090F90",
             },
           ],
         },
@@ -1782,6 +1801,15 @@ Object {
           "Aliases": Array [
             "my.construct.hub",
           ],
+          "CacheBehaviors": Array [
+            Object {
+              "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
+              "Compress": true,
+              "PathPattern": "/packages/*",
+              "TargetOriginId": "TestConstructHubWebAppDistributionOrigin276090F90",
+              "ViewerProtocolPolicy": "allow-all",
+            },
+          ],
           "CustomErrorResponses": Array [
             Object {
               "ErrorCode": 404,
@@ -1826,6 +1854,16 @@ Object {
                   ],
                 },
               },
+            },
+            Object {
+              "CustomOriginConfig": Object {
+                "OriginProtocolPolicy": "https-only",
+                "OriginSSLProtocols": Array [
+                  "TLSv1.2",
+                ],
+              },
+              "DomainName": "awscdk.io",
+              "Id": "TestConstructHubWebAppDistributionOrigin276090F90",
             },
           ],
           "ViewerCertificate": Object {

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -123,6 +123,12 @@ Resources:
     Type: AWS::CloudFront::Distribution
     Properties:
       DistributionConfig:
+        CacheBehaviors:
+          - CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6
+            Compress: true
+            PathPattern: /packages/*
+            TargetOriginId: devConstructHubWebAppDistributionOrigin2A726FD66
+            ViewerProtocolPolicy: allow-all
         CustomErrorResponses:
           - ErrorCode: 404
             ResponseCode: 200
@@ -151,6 +157,12 @@ Resources:
                   - ""
                   - - origin-access-identity/cloudfront/
                     - Ref: ConstructHubWebAppDistributionOrigin1S3Origin694AF937
+          - CustomOriginConfig:
+              OriginProtocolPolicy: https-only
+              OriginSSLProtocols:
+                - TLSv1.2
+            DomainName: awscdk.io
+            Id: devConstructHubWebAppDistributionOrigin2A726FD66
   ConstructHubWebAppDeployWebsiteAwsCliLayer23CFFBC1:
     Type: AWS::Lambda::LayerVersion
     Properties:

--- a/src/webapp/index.ts
+++ b/src/webapp/index.ts
@@ -23,6 +23,7 @@ export class WebApp extends Construct {
     super(scope, id);
 
     this.bucket = new s3.Bucket(this, 'WebsiteBucket');
+
     this.distribution = new cloudfront.Distribution(this, 'Distribution', {
       defaultBehavior: { origin: new origins.S3Origin(this.bucket) },
       domainNames: props.domain ? [props.domain.zone.zoneName] : undefined,
@@ -34,6 +35,9 @@ export class WebApp extends Construct {
         responsePagePath: '/index.html',
       })),
     });
+
+    const jsiiObjOrigin = new origins.HttpOrigin('awscdk.io');
+    this.distribution.addBehavior('/packages/*', jsiiObjOrigin);
 
     // if we use a domain, and A records with a CloudFront alias
     if (props.domain) {


### PR DESCRIPTION
Adds an http origin to cloudfront to allow accessing files from the
construct-catalog bucket so we can read the jsii assemblies and readme
files for each package.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*