### PR TITLE
feat: high severity dashboard

### DIFF
--- a/API.md
+++ b/API.md
@@ -37,7 +37,7 @@ new ConstructHub(scope: Construct, id: string, props: ConstructHubProps)
 * **id** (<code>string</code>)  *No description*
 * **props** (<code>[ConstructHubProps](#construct-hub-constructhubprops)</code>)  *No description*
   * **alarmActions** (<code>[AlarmActions](#construct-hub-alarmactions)</code>)  Actions to perform when alarms are set. 
-  * **dashboardName** (<code>string</code>)  The name of the CloudWatch Dashboard created to observe this application. __*Default*__: the path to this construct is used as the dashboard name.
+  * **dashboardName** (<code>string</code>)  The name of the CloudWatch Dashboard created to observe this application. __*Default*__: "construct-hub"
   * **domain** (<code>[Domain](#construct-hub-domain)</code>)  Connect the hub to a domain (requires a hosted zone and a certificate). __*Optional*__
 
 
@@ -67,7 +67,7 @@ Props for `ConstructHub`.
 Name | Type | Description 
 -----|------|-------------
 **alarmActions**🔹 | <code>[AlarmActions](#construct-hub-alarmactions)</code> | Actions to perform when alarms are set.
-**dashboardName**?🔹 | <code>string</code> | The name of the CloudWatch Dashboard created to observe this application.<br/>__*Default*__: the path to this construct is used as the dashboard name.
+**dashboardName**?🔹 | <code>string</code> | The name of the CloudWatch Dashboard created to observe this application.<br/>__*Default*__: "construct-hub"
 **domain**?🔹 | <code>[Domain](#construct-hub-domain)</code> | Connect the hub to a domain (requires a hosted zone and a certificate).<br/>__*Optional*__
 
 

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -277,6 +277,38 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
+    "ConstructHubMonitoringDashboard78E057C8": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"widgets\\":[{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"https://",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ConstructHubWebAppDistribution1F181DC9",
+                  "DomainName",
+                ],
+              },
+              "\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ConstructHubMonitoringWebCanaryHomePageErrorsE7BB4002",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}}]}",
+            ],
+          ],
+        },
+        "DashboardName": "construct-hub-high-severity",
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
     "ConstructHubMonitoringWatchfulDashboardB8493D55": Object {
       "Properties": Object {
         "DashboardBody": Object {
@@ -1609,6 +1641,38 @@ Object {
         ],
       },
       "Type": "AWS::IAM::Role",
+    },
+    "ConstructHubMonitoringDashboard78E057C8": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"widgets\\":[{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"https://",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ConstructHubWebAppDistribution1F181DC9",
+                  "DomainName",
+                ],
+              },
+              "\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ConstructHubMonitoringWebCanaryHomePageErrorsE7BB4002",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}}]}",
+            ],
+          ],
+        },
+        "DashboardName": "construct-hub-high-severity",
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
     },
     "ConstructHubMonitoringWatchfulDashboardB8493D55": Object {
       "Properties": Object {

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -33,16 +33,16 @@ Object {
     },
   },
   "Parameters": Object {
-    "AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfArtifactHash1F231F75": Object {
-      "Description": "Artifact hash for asset \\"0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebf\\"",
+    "AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103ArtifactHash2ABB7EC3": Object {
+      "Description": "Artifact hash for asset \\"3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103\\"",
       "Type": "String",
     },
-    "AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfS3BucketC25A2F72": Object {
-      "Description": "S3 bucket for asset \\"0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebf\\"",
+    "AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103S3Bucket3FDF578C": Object {
+      "Description": "S3 bucket for asset \\"3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103\\"",
       "Type": "String",
     },
-    "AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfS3VersionKey5FA6C0D3": Object {
-      "Description": "S3 key for asset version \\"0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebf\\"",
+    "AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103S3VersionKeyF08BDB71": Object {
+      "Description": "S3 key for asset version \\"3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103\\"",
       "Type": "String",
     },
     "AssetParameters82d882471cef8cd692b3c0bd36c8deee2c7a6ba4db029780d6b05de0e2c1ad4bArtifactHash297EEE8C": Object {
@@ -283,14 +283,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"widgets\\":[{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"https://",
-              Object {
-                "Fn::GetAtt": Array [
-                  "ConstructHubWebAppDistribution1F181DC9",
-                  "DomainName",
-                ],
-              },
-              "\\",\\"region\\":\\"",
+              "{\\"widgets\\":[{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Home Page Canary\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -583,7 +576,7 @@ Object {
                   "DomainName",
                 ],
               },
-              " (HomePage)",
+              " (Home Page)",
             ],
           ],
         },
@@ -592,7 +585,21 @@ Object {
         "Metrics": Array [
           Object {
             "Id": "m1",
-            "Label": "HomePage",
+            "Label": Object {
+              "Fn::Join": Array [
+                "",
+                Array [
+                  "https://",
+                  Object {
+                    "Fn::GetAtt": Array [
+                      "ConstructHubWebAppDistribution1F181DC9",
+                      "DomainName",
+                    ],
+                  },
+                  " Errors",
+                ],
+              ],
+            },
             "MetricStat": Object {
               "Metric": Object {
                 "Dimensions": Array [
@@ -671,7 +678,7 @@ Object {
                   "DomainName",
                 ],
               },
-              ": HomePage",
+              ": Home Page",
             ],
           ],
         },
@@ -834,7 +841,7 @@ Object {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfS3BucketC25A2F72",
+            "Ref": "AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103S3Bucket3FDF578C",
           },
         ],
         "SourceObjectKeys": Array [
@@ -849,7 +856,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfS3VersionKey5FA6C0D3",
+                          "Ref": "AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103S3VersionKeyF08BDB71",
                         },
                       ],
                     },
@@ -862,7 +869,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfS3VersionKey5FA6C0D3",
+                          "Ref": "AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103S3VersionKeyF08BDB71",
                         },
                       ],
                     },
@@ -1114,7 +1121,7 @@ Object {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfS3BucketC25A2F72",
+                        "Ref": "AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103S3Bucket3FDF578C",
                       },
                     ],
                   ],
@@ -1129,7 +1136,7 @@ Object {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfS3BucketC25A2F72",
+                        "Ref": "AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103S3Bucket3FDF578C",
                       },
                       "/*",
                     ],
@@ -1237,16 +1244,16 @@ Object {
     },
   },
   "Parameters": Object {
-    "AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfArtifactHash1F231F75": Object {
-      "Description": "Artifact hash for asset \\"0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebf\\"",
+    "AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103ArtifactHash2ABB7EC3": Object {
+      "Description": "Artifact hash for asset \\"3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103\\"",
       "Type": "String",
     },
-    "AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfS3BucketC25A2F72": Object {
-      "Description": "S3 bucket for asset \\"0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebf\\"",
+    "AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103S3Bucket3FDF578C": Object {
+      "Description": "S3 bucket for asset \\"3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103\\"",
       "Type": "String",
     },
-    "AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfS3VersionKey5FA6C0D3": Object {
-      "Description": "S3 key for asset version \\"0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebf\\"",
+    "AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103S3VersionKeyF08BDB71": Object {
+      "Description": "S3 key for asset version \\"3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103\\"",
       "Type": "String",
     },
     "AssetParameters7af6295e521fd55af94332393ceffb3e866aac4dc4956321f7918f21e72199e4ArtifactHash5E28809B": Object {
@@ -1648,14 +1655,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"widgets\\":[{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"https://",
-              Object {
-                "Fn::GetAtt": Array [
-                  "ConstructHubWebAppDistribution1F181DC9",
-                  "DomainName",
-                ],
-              },
-              "\\",\\"region\\":\\"",
+              "{\\"widgets\\":[{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Home Page Canary\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -1948,7 +1948,7 @@ Object {
                   "DomainName",
                 ],
               },
-              " (HomePage)",
+              " (Home Page)",
             ],
           ],
         },
@@ -1957,7 +1957,21 @@ Object {
         "Metrics": Array [
           Object {
             "Id": "m1",
-            "Label": "HomePage",
+            "Label": Object {
+              "Fn::Join": Array [
+                "",
+                Array [
+                  "https://",
+                  Object {
+                    "Fn::GetAtt": Array [
+                      "ConstructHubWebAppDistribution1F181DC9",
+                      "DomainName",
+                    ],
+                  },
+                  " Errors",
+                ],
+              ],
+            },
             "MetricStat": Object {
               "Metric": Object {
                 "Dimensions": Array [
@@ -2036,7 +2050,7 @@ Object {
                   "DomainName",
                 ],
               },
-              ": HomePage",
+              ": Home Page",
             ],
           ],
         },
@@ -2251,7 +2265,7 @@ Object {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfS3BucketC25A2F72",
+            "Ref": "AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103S3Bucket3FDF578C",
           },
         ],
         "SourceObjectKeys": Array [
@@ -2266,7 +2280,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfS3VersionKey5FA6C0D3",
+                          "Ref": "AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103S3VersionKeyF08BDB71",
                         },
                       ],
                     },
@@ -2279,7 +2293,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfS3VersionKey5FA6C0D3",
+                          "Ref": "AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103S3VersionKeyF08BDB71",
                         },
                       ],
                     },
@@ -2544,7 +2558,7 @@ Object {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfS3BucketC25A2F72",
+                        "Ref": "AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103S3Bucket3FDF578C",
                       },
                     ],
                   ],
@@ -2559,7 +2573,7 @@ Object {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfS3BucketC25A2F72",
+                        "Ref": "AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103S3Bucket3FDF578C",
                       },
                       "/*",
                     ],

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -33,16 +33,16 @@ Object {
     },
   },
   "Parameters": Object {
-    "AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103ArtifactHash2ABB7EC3": Object {
-      "Description": "Artifact hash for asset \\"3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103\\"",
+    "AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfArtifactHash1F231F75": Object {
+      "Description": "Artifact hash for asset \\"0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebf\\"",
       "Type": "String",
     },
-    "AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103S3Bucket3FDF578C": Object {
-      "Description": "S3 bucket for asset \\"3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103\\"",
+    "AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfS3BucketC25A2F72": Object {
+      "Description": "S3 bucket for asset \\"0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebf\\"",
       "Type": "String",
     },
-    "AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103S3VersionKeyF08BDB71": Object {
-      "Description": "S3 key for asset version \\"3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103\\"",
+    "AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfS3VersionKey5FA6C0D3": Object {
+      "Description": "S3 key for asset version \\"0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebf\\"",
       "Type": "String",
     },
     "AssetParameters82d882471cef8cd692b3c0bd36c8deee2c7a6ba4db029780d6b05de0e2c1ad4bArtifactHash297EEE8C": Object {
@@ -841,7 +841,7 @@ Object {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103S3Bucket3FDF578C",
+            "Ref": "AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfS3BucketC25A2F72",
           },
         ],
         "SourceObjectKeys": Array [
@@ -856,7 +856,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103S3VersionKeyF08BDB71",
+                          "Ref": "AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfS3VersionKey5FA6C0D3",
                         },
                       ],
                     },
@@ -869,7 +869,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103S3VersionKeyF08BDB71",
+                          "Ref": "AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfS3VersionKey5FA6C0D3",
                         },
                       ],
                     },
@@ -1121,7 +1121,7 @@ Object {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103S3Bucket3FDF578C",
+                        "Ref": "AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfS3BucketC25A2F72",
                       },
                     ],
                   ],
@@ -1136,7 +1136,7 @@ Object {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103S3Bucket3FDF578C",
+                        "Ref": "AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfS3BucketC25A2F72",
                       },
                       "/*",
                     ],
@@ -1244,16 +1244,16 @@ Object {
     },
   },
   "Parameters": Object {
-    "AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103ArtifactHash2ABB7EC3": Object {
-      "Description": "Artifact hash for asset \\"3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103\\"",
+    "AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfArtifactHash1F231F75": Object {
+      "Description": "Artifact hash for asset \\"0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebf\\"",
       "Type": "String",
     },
-    "AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103S3Bucket3FDF578C": Object {
-      "Description": "S3 bucket for asset \\"3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103\\"",
+    "AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfS3BucketC25A2F72": Object {
+      "Description": "S3 bucket for asset \\"0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebf\\"",
       "Type": "String",
     },
-    "AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103S3VersionKeyF08BDB71": Object {
-      "Description": "S3 key for asset version \\"3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103\\"",
+    "AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfS3VersionKey5FA6C0D3": Object {
+      "Description": "S3 key for asset version \\"0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebf\\"",
       "Type": "String",
     },
     "AssetParameters7af6295e521fd55af94332393ceffb3e866aac4dc4956321f7918f21e72199e4ArtifactHash5E28809B": Object {
@@ -2265,7 +2265,7 @@ Object {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103S3Bucket3FDF578C",
+            "Ref": "AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfS3BucketC25A2F72",
           },
         ],
         "SourceObjectKeys": Array [
@@ -2280,7 +2280,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103S3VersionKeyF08BDB71",
+                          "Ref": "AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfS3VersionKey5FA6C0D3",
                         },
                       ],
                     },
@@ -2293,7 +2293,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103S3VersionKeyF08BDB71",
+                          "Ref": "AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfS3VersionKey5FA6C0D3",
                         },
                       ],
                     },
@@ -2558,7 +2558,7 @@ Object {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103S3Bucket3FDF578C",
+                        "Ref": "AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfS3BucketC25A2F72",
                       },
                     ],
                   ],
@@ -2573,7 +2573,7 @@ Object {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103S3Bucket3FDF578C",
+                        "Ref": "AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfS3BucketC25A2F72",
                       },
                       "/*",
                     ],

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -506,7 +506,7 @@ Resources:
           - CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536
           - Arn
       SourceBucketNames:
-        - Ref: AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103S3Bucket3FDF578C
+        - Ref: AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfS3BucketC25A2F72
       SourceObjectKeys:
         - Fn::Join:
             - ""
@@ -514,12 +514,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103S3VersionKeyF08BDB71
+                      - Ref: AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfS3VersionKey5FA6C0D3
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103S3VersionKeyF08BDB71
+                      - Ref: AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfS3VersionKey5FA6C0D3
       DestinationBucketName:
         Ref: ConstructHubWebAppWebsiteBucket4B2B9DB2
       Prune: true
@@ -559,13 +559,13 @@ Resources:
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103S3Bucket3FDF578C
+                    - Ref: AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfS3BucketC25A2F72
               - Fn::Join:
                   - ""
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103S3Bucket3FDF578C
+                    - Ref: AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfS3BucketC25A2F72
                     - /*
           - Action:
               - s3:GetObject*
@@ -690,18 +690,18 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "c24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cf"
-  AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103S3Bucket3FDF578C:
+  AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfS3BucketC25A2F72:
     Type: String
     Description: S3 bucket for asset
-      "3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103"
-  AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103S3VersionKeyF08BDB71:
+      "0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebf"
+  AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfS3VersionKey5FA6C0D3:
     Type: String
     Description: S3 key for asset version
-      "3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103"
-  AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103ArtifactHash2ABB7EC3:
+      "0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebf"
+  AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfArtifactHash1F231F75:
     Type: String
     Description: Artifact hash for asset
-      "3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103"
+      "0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebf"
   AssetParametersc297ce933562ff3d10ec3921d0b6dc79a10b86a7efeb58631ce7e45f76fc61acS3BucketEEBDAFEE:
     Type: String
     Description: S3 bucket for asset

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -180,6 +180,24 @@ Resources:
             Stat: p99
           ReturnData: true
       Threshold: 2000
+  ConstructHubMonitoringDashboard78E057C8:
+    Type: AWS::CloudWatch::Dashboard
+    Properties:
+      DashboardBody:
+        Fn::Join:
+          - ""
+          - - '{"widgets":[{"type":"metric","width":24,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"https://'
+            - Fn::GetAtt:
+                - ConstructHubWebAppDistribution1F181DC9
+                - DomainName
+            - '","region":"'
+            - Ref: AWS::Region
+            - '","annotations":{"alarms":["'
+            - Fn::GetAtt:
+                - ConstructHubMonitoringWebCanaryHomePageErrorsE7BB4002
+                - Arn
+            - '"]},"yAxis":{}}}]}'
+      DashboardName: construct-hub-high-severity
   ConstructHubMonitoringWebCanaryHomePageHttpGetFunctionServiceRole9AAAD93C:
     Type: AWS::IAM::Role
     Properties:

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -186,11 +186,8 @@ Resources:
       DashboardBody:
         Fn::Join:
           - ""
-          - - '{"widgets":[{"type":"metric","width":24,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"https://'
-            - Fn::GetAtt:
-                - ConstructHubWebAppDistribution1F181DC9
-                - DomainName
-            - '","region":"'
+          - - '{"widgets":[{"type":"metric","width":24,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"Home
+              Page Canary","region":"'
             - Ref: AWS::Region
             - '","annotations":{"alarms":["'
             - Fn::GetAtt:
@@ -244,7 +241,7 @@ Resources:
             - Fn::GetAtt:
                 - ConstructHubWebAppDistribution1F181DC9
                 - DomainName
-            - ": HomePage"
+            - ": Home Page"
       Environment:
         Variables:
           URL:
@@ -296,10 +293,17 @@ Resources:
             - Fn::GetAtt:
                 - ConstructHubWebAppDistribution1F181DC9
                 - DomainName
-            - " (HomePage)"
+            - " (Home Page)"
       Metrics:
         - Id: m1
-          Label: HomePage
+          Label:
+            Fn::Join:
+              - ""
+              - - https://
+                - Fn::GetAtt:
+                    - ConstructHubWebAppDistribution1F181DC9
+                    - DomainName
+                - " Errors"
           MetricStat:
             Metric:
               Dimensions:
@@ -502,7 +506,7 @@ Resources:
           - CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536
           - Arn
       SourceBucketNames:
-        - Ref: AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfS3BucketC25A2F72
+        - Ref: AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103S3Bucket3FDF578C
       SourceObjectKeys:
         - Fn::Join:
             - ""
@@ -510,12 +514,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfS3VersionKey5FA6C0D3
+                      - Ref: AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103S3VersionKeyF08BDB71
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfS3VersionKey5FA6C0D3
+                      - Ref: AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103S3VersionKeyF08BDB71
       DestinationBucketName:
         Ref: ConstructHubWebAppWebsiteBucket4B2B9DB2
       Prune: true
@@ -555,13 +559,13 @@ Resources:
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfS3BucketC25A2F72
+                    - Ref: AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103S3Bucket3FDF578C
               - Fn::Join:
                   - ""
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfS3BucketC25A2F72
+                    - Ref: AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103S3Bucket3FDF578C
                     - /*
           - Action:
               - s3:GetObject*
@@ -686,18 +690,18 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "c24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cf"
-  AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfS3BucketC25A2F72:
+  AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103S3Bucket3FDF578C:
     Type: String
     Description: S3 bucket for asset
-      "0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebf"
-  AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfS3VersionKey5FA6C0D3:
+      "3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103"
+  AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103S3VersionKeyF08BDB71:
     Type: String
     Description: S3 key for asset version
-      "0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebf"
-  AssetParameters0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebfArtifactHash1F231F75:
+      "3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103"
+  AssetParameters3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103ArtifactHash2ABB7EC3:
     Type: String
     Description: Artifact hash for asset
-      "0be9e7f639543b70086aec14af3ad7265b13fa354fcafec79f6d07d0b2597ebf"
+      "3cd2c7ab44327ca3f59ce81dc71b90767d3c04f7239edf27da8fc1cc29623103"
   AssetParametersc297ce933562ff3d10ec3921d0b6dc79a10b86a7efeb58631ce7e45f76fc61acS3BucketEEBDAFEE:
     Type: String
     Description: S3 bucket for asset

--- a/src/__tests__/monitoring.test.ts
+++ b/src/__tests__/monitoring.test.ts
@@ -101,12 +101,14 @@ test('web canaries can ping URLs and raise high severity alarms', () => {
   expect(stack).toHaveResource('AWS::CloudWatch::Alarm', {
     ComparisonOperator: 'GreaterThanOrEqualToThreshold',
     EvaluationPeriods: 1,
-    AlarmActions: ['arn:aws:sns:us-east-1:123456789012:high'],
+    AlarmActions: [
+      'arn:aws:sns:us-east-1:123456789012:high',
+    ],
     AlarmDescription: '80% error rate for https://ping1 (Ping1)',
     Metrics: [
       {
         Id: 'm1',
-        Label: 'Ping1',
+        Label: 'https://ping1 Errors',
         MetricStat: {
           Metric: {
             Dimensions: [

--- a/src/__tests__/monitoring.test.ts
+++ b/src/__tests__/monitoring.test.ts
@@ -15,7 +15,10 @@ test('minimal', () => {
   const stack = new Stack();
 
   // WHEN
-  new Monitoring(stack, 'Monitoring', { alarmActions: actions });
+  new Monitoring(stack, 'Monitoring', {
+    alarmActions: actions,
+    dashboardName: 'construct-hub',
+  });
 
   // a dashboard is automatically created
   expect(stack).toHaveResource('AWS::CloudWatch::Dashboard');
@@ -29,7 +32,10 @@ test('watchful can be used for setting up automatic monitoring', () => {
     code: lambda.Code.fromInline('foo'),
     handler: 'index.handler',
   });
-  const monitoring = new Monitoring(stack, 'Monitoring', { alarmActions: actions });
+  const monitoring = new Monitoring(stack, 'Monitoring', {
+    alarmActions: actions,
+    dashboardName: 'construct-hub',
+  });
 
   // WHEN
   monitoring.watchful.watchLambdaFunction('My Function', fn);
@@ -48,22 +54,45 @@ test('high severity alarms trigger the correct action', () => {
   // GIVEN
   const stack = new Stack();
   const topic = new sns.Topic(stack, 'Topic');
-  const monitoring = new Monitoring(stack, 'Monitoring', { alarmActions: actions });
+  const monitoring = new Monitoring(stack, 'Monitoring', {
+    alarmActions: actions,
+    dashboardName: 'construct-hub',
+  });
+  const alarm = topic.metricNumberOfNotificationsFailed().createAlarm(stack, 'Alarm', { threshold: 1, evaluationPeriods: 1 });
 
   // WHEN
-  monitoring.addHighSeverityAlarm(topic.metricNumberOfNotificationsFailed().createAlarm(stack, 'Alarm', { threshold: 1, evaluationPeriods: 1 }));
+  monitoring.addHighSeverityAlarm('My Alarm', alarm);
 
   // a dashboard is automatically created
   expect(stack).toHaveResource('AWS::CloudWatch::Alarm', {
     AlarmActions: ['arn:aws:sns:us-east-1:123456789012:high'],
     Dimensions: [{ Name: 'TopicName', Value: { 'Fn::GetAtt': ['TopicBFC7AF6E', 'TopicName'] } }],
   });
+
+  expect(stack).toHaveResource('AWS::CloudWatch::Dashboard', {
+    DashboardBody: {
+      'Fn::Join': [
+        '',
+        [
+          '{"widgets":[{"type":"metric","width":24,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"My Alarm","region":"',
+          { Ref: 'AWS::Region' },
+          '","annotations":{"alarms":["',
+          { 'Fn::GetAtt': ['Alarm7103F465', 'Arn'] },
+          '"]},"yAxis":{}}}]}',
+        ],
+      ],
+    },
+    DashboardName: 'construct-hub-high-severity',
+  });
 });
 
 test('web canaries can ping URLs and raise high severity alarms', () => {
   // GIVEN
   const stack = new Stack();
-  const monitoring = new Monitoring(stack, 'Monitoring', { alarmActions: actions });
+  const monitoring = new Monitoring(stack, 'Monitoring', {
+    alarmActions: actions,
+    dashboardName: 'construct-hub',
+  });
 
   // WHEN
   monitoring.addWebCanary('Ping1', 'https://ping1');

--- a/src/construct-hub.ts
+++ b/src/construct-hub.ts
@@ -17,7 +17,9 @@ export interface ConstructHubProps {
   /**
    * The name of the CloudWatch Dashboard created to observe this application.
    *
-   * @default - the path to this construct is used as the dashboard name.
+   * Must only contain alphanumerics, dash (-) and underscore (_).
+   *
+   * @default "construct-hub"
    */
   readonly dashboardName?: string;
 
@@ -36,7 +38,7 @@ export class ConstructHub extends CoreConstruct {
 
     const monitoring = new Monitoring(this, 'Monitoring', {
       alarmActions: props.alarmActions,
-      dashboardName: props.dashboardName,
+      dashboardName: props.dashboardName ?? 'construct-hub',
     });
 
     // add some dummy resources so that we have _something_ to monitor.

--- a/src/monitoring/web-canary.ts
+++ b/src/monitoring/web-canary.ts
@@ -49,7 +49,7 @@ export class WebCanary extends Construct {
     const errors = ping.metricErrors({
       period: Duration.minutes(5),
       statistic: 'sum',
-      label: display,
+      label: `${url} Errors`,
     });
 
     // alarm if 4 or more pings have failed within a period of 5 minutes (80% failure rate)

--- a/src/webapp/index.ts
+++ b/src/webapp/index.ts
@@ -76,6 +76,6 @@ export class WebApp extends Construct {
     });
 
     // add a canary that pings our home page and alarms if it returns errors.
-    props.monitoring.addWebCanary('HomePage', `https://${this.distribution.domainName}`);
+    props.monitoring.addWebCanary('Home Page', `https://${this.distribution.domainName}`);
   }
 }


### PR DESCRIPTION
Add another dashboard which displays high severity alarms (canaries at this point).

When high severity alarms are added, they will automatically be included in this dashboard. Web canaries will include information about the URL and the name of the canary.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*