### PR TITLE
chore: temporarily disable maven publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,29 +77,6 @@ jobs:
           NPM_REGISTRY: registry.npmjs.org
     container:
       image: jsii/superchain
-  release_maven:
-    name: Release to Maven
-    needs: release
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Download build artifacts
-        uses: actions/download-artifact@v2
-        with:
-          name: dist
-          path: dist
-      - name: Release
-        run: npx -p jsii-release@latest jsii-release-maven
-        env:
-          MAVEN_ENDPOINT: https://aws.oss.sonatype.org
-          MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-          MAVEN_GPG_PRIVATE_KEY_PASSPHRASE: ${{ secrets.MAVEN_GPG_PRIVATE_KEY_PASSPHRASE }}
-          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
-          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
-          MAVEN_STAGING_PROFILE_ID: ${{ secrets.MAVEN_STAGING_PROFILE_ID }}
-    container:
-      image: jsii/superchain
   release_pypi:
     name: Release to PyPi
     needs: release

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -71,16 +71,20 @@ const project = new AwsCdkConstructLibrary({
   //publishToGo: {
   //  moduleName: 'github.com/cdklabs/construct-hub-go',
   //},
-  publishToMaven: {
-    javaPackage: 'software.amazon.constructhub',
-    mavenArtifactId: 'software.amazon.constructhub',
-    mavenGroupId: 'construct-hub',
-    mavenEndpoint: 'https://aws.oss.sonatype.org',
-  },
+
+  // see https://github.com/cdklabs/construct-hub/issues/60
+  // publishToMaven: {
+  //   javaPackage: 'software.amazon.constructhub',
+  //   mavenArtifactId: 'software.amazon.constructhub',
+  //   mavenGroupId: 'construct-hub',
+  //   mavenEndpoint: 'https://aws.oss.sonatype.org',
+  // },
+
   //publishToNuget: {
   //  dotNetNamespace: 'Construct.Hub',
   //  packageId: 'Construct.Hub',
   //},
+
   publishToPypi: {
     distName: 'construct-hub',
     module: 'construct_hub',

--- a/package.json
+++ b/package.json
@@ -158,13 +158,6 @@
   "jsii": {
     "outdir": "dist",
     "targets": {
-      "java": {
-        "package": "software.amazon.constructhub",
-        "maven": {
-          "groupId": "construct-hub",
-          "artifactId": "software.amazon.constructhub"
-        }
-      },
       "python": {
         "distName": "construct-hub",
         "module": "construct_hub"


### PR DESCRIPTION
Maven publishing is broken and fails all our releases. In the meantime, just disable it until we have time to investigate

See https://github.com/cdklabs/construct-hub/issues/60


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*