### PR TITLE
fix: proxy path for catalog file to awscdk.io

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -859,6 +859,13 @@ Object {
               "TargetOriginId": "TestConstructHubWebAppDistributionOrigin276090F90",
               "ViewerProtocolPolicy": "allow-all",
             },
+            Object {
+              "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
+              "Compress": true,
+              "PathPattern": "/index/packages.json",
+              "TargetOriginId": "TestConstructHubWebAppDistributionOrigin276090F90",
+              "ViewerProtocolPolicy": "allow-all",
+            },
           ],
           "CustomErrorResponses": Array [
             Object {
@@ -2248,6 +2255,13 @@ Object {
               "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
               "Compress": true,
               "PathPattern": "/packages/*",
+              "TargetOriginId": "TestConstructHubWebAppDistributionOrigin276090F90",
+              "ViewerProtocolPolicy": "allow-all",
+            },
+            Object {
+              "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
+              "Compress": true,
+              "PathPattern": "/index/packages.json",
               "TargetOriginId": "TestConstructHubWebAppDistributionOrigin276090F90",
               "ViewerProtocolPolicy": "allow-all",
             },

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -336,6 +336,11 @@ Resources:
             PathPattern: /packages/*
             TargetOriginId: devConstructHubWebAppDistributionOrigin2A726FD66
             ViewerProtocolPolicy: allow-all
+          - CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6
+            Compress: true
+            PathPattern: /index/packages.json
+            TargetOriginId: devConstructHubWebAppDistributionOrigin2A726FD66
+            ViewerProtocolPolicy: allow-all
         CustomErrorResponses:
           - ErrorCode: 404
             ResponseCode: 200

--- a/src/webapp/index.ts
+++ b/src/webapp/index.ts
@@ -44,6 +44,7 @@ export class WebApp extends Construct {
 
     const jsiiObjOrigin = new origins.HttpOrigin('awscdk.io');
     this.distribution.addBehavior('/packages/*', jsiiObjOrigin);
+    this.distribution.addBehavior('/index/packages.json', jsiiObjOrigin);
 
     // if we use a domain, and A records with a CloudFront alias
     if (props.domain) {


### PR DESCRIPTION
Adds a behavior to the cloudfront distribution to allow access to the
catalog in awskcdk.io from the webapp. This fixes the broken search
functionality on the frontend.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*