### PR TITLE
chore(deps): exclude cdk dependencies from upgrade

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -2,92 +2,74 @@
   "dependencies": [
     {
       "name": "@aws-cdk/assert",
-      "version": "1.108.0",
       "type": "build"
     },
     {
       "name": "@aws-cdk/aws-certificatemanager",
-      "version": "1.108.0",
-      "type": "build"
-    },
-    {
-      "name": "@aws-cdk/aws-cloudfront-origins",
-      "version": "1.108.0",
       "type": "build"
     },
     {
       "name": "@aws-cdk/aws-cloudfront",
-      "version": "1.108.0",
       "type": "build"
     },
     {
-      "name": "@aws-cdk/aws-cloudwatch-actions",
-      "version": "1.108.0",
+      "name": "@aws-cdk/aws-cloudfront-origins",
       "type": "build"
     },
     {
       "name": "@aws-cdk/aws-cloudwatch",
-      "version": "1.108.0",
       "type": "build"
     },
     {
-      "name": "@aws-cdk/aws-events-targets",
-      "version": "1.108.0",
+      "name": "@aws-cdk/aws-cloudwatch-actions",
       "type": "build"
     },
     {
       "name": "@aws-cdk/aws-events",
-      "version": "1.108.0",
       "type": "build"
     },
     {
-      "name": "@aws-cdk/aws-lambda-event-sources",
-      "version": "1.108.0",
+      "name": "@aws-cdk/aws-events-targets",
       "type": "build"
     },
     {
       "name": "@aws-cdk/aws-lambda",
-      "version": "1.108.0",
+      "type": "build"
+    },
+    {
+      "name": "@aws-cdk/aws-lambda-event-sources",
       "type": "build"
     },
     {
       "name": "@aws-cdk/aws-logs",
-      "version": "1.108.0",
-      "type": "build"
-    },
-    {
-      "name": "@aws-cdk/aws-route53-targets",
-      "version": "1.108.0",
       "type": "build"
     },
     {
       "name": "@aws-cdk/aws-route53",
-      "version": "1.108.0",
       "type": "build"
     },
     {
-      "name": "@aws-cdk/aws-s3-deployment",
-      "version": "1.108.0",
+      "name": "@aws-cdk/aws-route53-targets",
       "type": "build"
     },
     {
       "name": "@aws-cdk/aws-s3",
-      "version": "1.108.0",
+      "type": "build"
+    },
+    {
+      "name": "@aws-cdk/aws-s3-deployment",
       "type": "build"
     },
     {
       "name": "@aws-cdk/aws-sns",
-      "version": "1.108.0",
       "type": "build"
     },
     {
       "name": "@aws-cdk/core",
-      "version": "1.108.0",
       "type": "build"
     },
     {
       "name": "@aws-cdk/cx-api",
-      "version": "1.108.0",
       "type": "build"
     },
     {
@@ -117,7 +99,6 @@
     },
     {
       "name": "aws-cdk",
-      "version": "1.108.0",
       "type": "build"
     },
     {
@@ -234,87 +215,70 @@
     },
     {
       "name": "@aws-cdk/aws-certificatemanager",
-      "version": "1.108.0",
-      "type": "peer"
-    },
-    {
-      "name": "@aws-cdk/aws-cloudfront-origins",
-      "version": "1.108.0",
       "type": "peer"
     },
     {
       "name": "@aws-cdk/aws-cloudfront",
-      "version": "1.108.0",
       "type": "peer"
     },
     {
-      "name": "@aws-cdk/aws-cloudwatch-actions",
-      "version": "1.108.0",
+      "name": "@aws-cdk/aws-cloudfront-origins",
       "type": "peer"
     },
     {
       "name": "@aws-cdk/aws-cloudwatch",
-      "version": "1.108.0",
       "type": "peer"
     },
     {
-      "name": "@aws-cdk/aws-events-targets",
-      "version": "1.108.0",
+      "name": "@aws-cdk/aws-cloudwatch-actions",
       "type": "peer"
     },
     {
       "name": "@aws-cdk/aws-events",
-      "version": "1.108.0",
       "type": "peer"
     },
     {
-      "name": "@aws-cdk/aws-lambda-event-sources",
-      "version": "1.108.0",
+      "name": "@aws-cdk/aws-events-targets",
       "type": "peer"
     },
     {
       "name": "@aws-cdk/aws-lambda",
-      "version": "1.108.0",
+      "type": "peer"
+    },
+    {
+      "name": "@aws-cdk/aws-lambda-event-sources",
       "type": "peer"
     },
     {
       "name": "@aws-cdk/aws-logs",
-      "version": "1.108.0",
-      "type": "peer"
-    },
-    {
-      "name": "@aws-cdk/aws-route53-targets",
-      "version": "1.108.0",
       "type": "peer"
     },
     {
       "name": "@aws-cdk/aws-route53",
-      "version": "1.108.0",
       "type": "peer"
     },
     {
-      "name": "@aws-cdk/aws-s3-deployment",
-      "version": "1.108.0",
+      "name": "@aws-cdk/aws-route53-targets",
       "type": "peer"
     },
     {
       "name": "@aws-cdk/aws-s3",
-      "version": "1.108.0",
+      "type": "peer"
+    },
+    {
+      "name": "@aws-cdk/aws-s3-deployment",
       "type": "peer"
     },
     {
       "name": "@aws-cdk/aws-sns",
-      "version": "1.108.0",
       "type": "peer"
     },
     {
       "name": "@aws-cdk/core",
-      "version": "1.108.0",
       "type": "peer"
     },
     {
       "name": "@aws-cdk/cx-api",
-      "version": "1.108.0",
       "type": "peer"
     },
     {
@@ -327,87 +291,70 @@
     },
     {
       "name": "@aws-cdk/aws-certificatemanager",
-      "version": "1.108.0",
-      "type": "runtime"
-    },
-    {
-      "name": "@aws-cdk/aws-cloudfront-origins",
-      "version": "1.108.0",
       "type": "runtime"
     },
     {
       "name": "@aws-cdk/aws-cloudfront",
-      "version": "1.108.0",
       "type": "runtime"
     },
     {
-      "name": "@aws-cdk/aws-cloudwatch-actions",
-      "version": "1.108.0",
+      "name": "@aws-cdk/aws-cloudfront-origins",
       "type": "runtime"
     },
     {
       "name": "@aws-cdk/aws-cloudwatch",
-      "version": "1.108.0",
       "type": "runtime"
     },
     {
-      "name": "@aws-cdk/aws-events-targets",
-      "version": "1.108.0",
+      "name": "@aws-cdk/aws-cloudwatch-actions",
       "type": "runtime"
     },
     {
       "name": "@aws-cdk/aws-events",
-      "version": "1.108.0",
       "type": "runtime"
     },
     {
-      "name": "@aws-cdk/aws-lambda-event-sources",
-      "version": "1.108.0",
+      "name": "@aws-cdk/aws-events-targets",
       "type": "runtime"
     },
     {
       "name": "@aws-cdk/aws-lambda",
-      "version": "1.108.0",
+      "type": "runtime"
+    },
+    {
+      "name": "@aws-cdk/aws-lambda-event-sources",
       "type": "runtime"
     },
     {
       "name": "@aws-cdk/aws-logs",
-      "version": "1.108.0",
-      "type": "runtime"
-    },
-    {
-      "name": "@aws-cdk/aws-route53-targets",
-      "version": "1.108.0",
       "type": "runtime"
     },
     {
       "name": "@aws-cdk/aws-route53",
-      "version": "1.108.0",
       "type": "runtime"
     },
     {
-      "name": "@aws-cdk/aws-s3-deployment",
-      "version": "1.108.0",
+      "name": "@aws-cdk/aws-route53-targets",
       "type": "runtime"
     },
     {
       "name": "@aws-cdk/aws-s3",
-      "version": "1.108.0",
+      "type": "runtime"
+    },
+    {
+      "name": "@aws-cdk/aws-s3-deployment",
       "type": "runtime"
     },
     {
       "name": "@aws-cdk/aws-sns",
-      "version": "1.108.0",
       "type": "runtime"
     },
     {
       "name": "@aws-cdk/core",
-      "version": "1.108.0",
       "type": "runtime"
     },
     {
       "name": "@aws-cdk/cx-api",
-      "version": "1.108.0",
       "type": "runtime"
     },
     {

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -152,13 +152,13 @@
       },
       "steps": [
         {
-          "exec": "npm-check-updates --upgrade --target=minor"
+          "exec": "npm-check-updates --upgrade --target=minor --reject='@aws-cdk/aws-certificatemanager,@aws-cdk/aws-cloudfront-origins,@aws-cdk/aws-cloudfront,@aws-cdk/aws-cloudwatch-actions,@aws-cdk/aws-cloudwatch,@aws-cdk/aws-events-targets,@aws-cdk/aws-events,@aws-cdk/aws-lambda-event-sources,@aws-cdk/aws-lambda,@aws-cdk/aws-logs,@aws-cdk/aws-route53-targets,@aws-cdk/aws-route53,@aws-cdk/aws-s3-deployment,@aws-cdk/aws-s3,@aws-cdk/aws-sns,@aws-cdk/core,@aws-cdk/cx-api,cdk-watchful,constructs'"
         },
         {
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade"
+          "exec": "yarn upgrade @aws-cdk/assert @types/aws-lambda @types/fs-extra @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser aws-cdk aws-sdk aws-sdk-mock construct-hub-webapp esbuild eslint eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import fs-extra glob got jest jest-junit jsii jsii-diff jsii-docgen jsii-pacmak jsii-rosetta json-schema npm-check-updates pascal-case projen standard-version typescript yaml"
         },
         {
           "exec": "npx projen"

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -1,26 +1,26 @@
 const { basename, join, dirname, relative } = require('path');
 const glob = require('glob');
 const { pascalCase } = require('pascal-case');
-const { SourceCode, FileBase, JsonFile, JsiiProject } = require('projen');
+const { SourceCode, FileBase, JsonFile, JsiiProject, DependenciesUpgradeMechanism } = require('projen');
 
 const cdkDeps = [
-  '@aws-cdk/aws-certificatemanager@1.108.0',
-  '@aws-cdk/aws-cloudfront-origins@1.108.0',
-  '@aws-cdk/aws-cloudfront@1.108.0',
-  '@aws-cdk/aws-cloudwatch-actions@1.108.0',
-  '@aws-cdk/aws-cloudwatch@1.108.0',
-  '@aws-cdk/aws-events-targets@1.108.0',
-  '@aws-cdk/aws-events@1.108.0',
-  '@aws-cdk/aws-lambda-event-sources@1.108.0',
-  '@aws-cdk/aws-lambda@1.108.0',
-  '@aws-cdk/aws-logs@1.108.0',
-  '@aws-cdk/aws-route53-targets@1.108.0',
-  '@aws-cdk/aws-route53@1.108.0',
-  '@aws-cdk/aws-s3-deployment@1.108.0',
-  '@aws-cdk/aws-s3@1.108.0',
-  '@aws-cdk/aws-sns@1.108.0',
-  '@aws-cdk/core@1.108.0',
-  '@aws-cdk/cx-api@1.108.0',
+  '@aws-cdk/aws-certificatemanager',
+  '@aws-cdk/aws-cloudfront-origins',
+  '@aws-cdk/aws-cloudfront',
+  '@aws-cdk/aws-cloudwatch-actions',
+  '@aws-cdk/aws-cloudwatch',
+  '@aws-cdk/aws-events-targets',
+  '@aws-cdk/aws-events',
+  '@aws-cdk/aws-lambda-event-sources',
+  '@aws-cdk/aws-lambda',
+  '@aws-cdk/aws-logs',
+  '@aws-cdk/aws-route53-targets',
+  '@aws-cdk/aws-route53',
+  '@aws-cdk/aws-s3-deployment',
+  '@aws-cdk/aws-s3',
+  '@aws-cdk/aws-sns',
+  '@aws-cdk/core',
+  '@aws-cdk/cx-api',
   'cdk-watchful',
   'constructs',
 ];
@@ -36,19 +36,16 @@ const project = new JsiiProject({
   homepage: 'https://github.com/cdklabs',
   defaultReleaseBranch: 'main',
   mergify: false,
-  dependabot: false,
 
   author: 'Amazon Web Services, Inc.',
   authorAddress: 'construct-ecosystem-team@amazon.com',
   authorOrganization: true,
 
-  cdkVersion: '1.100.0',
-
   devDeps: [
-    '@aws-cdk/assert@1.108.0',
+    '@aws-cdk/assert',
     '@types/aws-lambda',
     '@types/fs-extra',
-    'aws-cdk@1.108.0',
+    'aws-cdk',
     'aws-sdk-mock',
     'aws-sdk',
     'esbuild',
@@ -106,6 +103,17 @@ const project = new JsiiProject({
     secret: 'GITHUB_TOKEN',
   },
   autoApproveUpgrades: true,
+  depsUpgrade: DependenciesUpgradeMechanism.githubWorkflow({
+    exclude: cdkDeps,
+    ignoreProjen: false,
+    workflowOptions: {
+      labels: ['auto-approve'],
+      secret: 'CDK_AUTOMATION_GITHUB_TOKEN',
+      container: {
+        image: 'jsii/superchain',
+      },
+    },
+  }),
 });
 
 // Required while we vendor-in jsii-rosetta to a pre-release version


### PR DESCRIPTION
This [PR](https://github.com/cdklabs/construct-hub/pull/80) locked our CDK version to `1.108.0` in `package.json`. It however did not disable those deps from being upgraded by `ncu` in the upgrade workflow. 

The reason we didn't see cdk upgrades since is actually because the upgrade workflow is [failing](https://github.com/cdklabs/construct-hub/actions/runs/934146327).

```console
warning "construct-hub-webapp > @emotion/styled > @emotion/babel-plugin > @babel/plugin-syntax-jsx@7.14.5" has unmet peer dependency "@babel/core@^7.0.0-0".
error An unexpected error occurred: "expected hoisted manifest for \"cdk-watchful#@aws-cdk/aws-cloudwatch#@aws-cdk/core\"".
```

This is the same error we thought would be resolved after [ejecting from the `AwsCdkLibrary`](https://github.com/cdklabs/construct-hub/pull/72) - but apparently it didn't solve it. 

Long story short, this PR makes it so the upgrade workflow doesn't try to upgrade cdk deps, enforcing the lock, and coincidentally bypassing the `yarn` problem (which we still need to figure out).

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*