### PR TITLE
fix: TypeError when there are no versions in a doc

### DIFF
--- a/src/backend/discovery/discovery.lambda.ts
+++ b/src/backend/discovery/discovery.lambda.ts
@@ -256,7 +256,7 @@ function getRelevantVersionInfos(changes: readonly Change[]): readonly UpdatedVe
   const result = new Array<UpdatedVersion>();
   for (const change of changes) {
     // Sometimes, there are no versions in the document. We skip those.
-    if (Object.keys(change.doc.versions).length === 0) {
+    if (change.doc.versions == null) {
       console.error(`[${change.seq}] Changed document contains no 'versions': ${JSON.stringify(change, null, 2)}`);
       continue;
     }


### PR DESCRIPTION
The check for the presence of versions in the doc was
not correctly handling the case it was trying to handle.
The `Object.keys(v).length === 0` approach fails if
`v` is `null` or `undefined`, which is precisely what
this test was attempting to protect against.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*