### PR TITLE
chore(deps): exclude constructs from upgrade

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,9 +8,12 @@
 /.github/workflows/build.yml                   	linguist-generated
 /.github/workflows/release.yml                 	linguist-generated
 /.github/workflows/upgrade-dependencies.yml    	linguist-generated
+/.gitignore                                    	linguist-generated
 /.npmignore                                    	linguist-generated
 /.projen/**                                    	linguist-generated
+/.projen/deps.json                             	linguist-generated
 /.projen/jest-snapshot-resolver.js             	linguist-generated
+/.projen/tasks.json                            	linguist-generated
 /lib/__tests__/devapp/cdk.json                 	linguist-generated
 /LICENSE                                       	linguist-generated
 /package.json                                  	linguist-generated

--- a/.gitattributes
+++ b/.gitattributes
@@ -8,12 +8,9 @@
 /.github/workflows/build.yml                   	linguist-generated
 /.github/workflows/release.yml                 	linguist-generated
 /.github/workflows/upgrade-dependencies.yml    	linguist-generated
-/.gitignore                                    	linguist-generated
 /.npmignore                                    	linguist-generated
 /.projen/**                                    	linguist-generated
-/.projen/deps.json                             	linguist-generated
 /.projen/jest-snapshot-resolver.js             	linguist-generated
-/.projen/tasks.json                            	linguist-generated
 /lib/__tests__/devapp/cdk.json                 	linguist-generated
 /LICENSE                                       	linguist-generated
 /package.json                                  	linguist-generated

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -214,7 +214,6 @@
     },
     {
       "name": "projen",
-      "version": "^0.22.15",
       "type": "build"
     },
     {
@@ -392,6 +391,10 @@
     },
     {
       "name": "cdk-watchful",
+      "type": "runtime"
+    },
+    {
+      "name": "constructs",
       "type": "runtime"
     }
   ],

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -214,6 +214,7 @@
     },
     {
       "name": "projen",
+      "version": "^0.22.15",
       "type": "build"
     },
     {

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -158,13 +158,13 @@
       },
       "steps": [
         {
-          "exec": "npm-check-updates --upgrade --target=minor --reject='@aws-cdk/aws-certificatemanager,@aws-cdk/aws-cloudfront-origins,@aws-cdk/aws-cloudfront,@aws-cdk/aws-cloudwatch-actions,@aws-cdk/aws-cloudwatch,@aws-cdk/aws-events-targets,@aws-cdk/aws-events,@aws-cdk/aws-lambda-event-sources,@aws-cdk/aws-lambda,@aws-cdk/aws-logs,@aws-cdk/aws-route53-targets,@aws-cdk/aws-route53,@aws-cdk/aws-s3-deployment,@aws-cdk/aws-s3,@aws-cdk/aws-sns,@aws-cdk/core,@aws-cdk/aws-sqs,@aws-cdk/cx-api,cdk-watchful,@aws-cdk/assert,aws-cdk'"
+          "exec": "npm-check-updates --upgrade --target=minor --reject='@aws-cdk/aws-certificatemanager,@aws-cdk/aws-cloudfront-origins,@aws-cdk/aws-cloudfront,@aws-cdk/aws-cloudwatch-actions,@aws-cdk/aws-cloudwatch,@aws-cdk/aws-events-targets,@aws-cdk/aws-events,@aws-cdk/aws-lambda-event-sources,@aws-cdk/aws-lambda,@aws-cdk/aws-logs,@aws-cdk/aws-route53-targets,@aws-cdk/aws-route53,@aws-cdk/aws-s3-deployment,@aws-cdk/aws-s3,@aws-cdk/aws-sns,@aws-cdk/core,@aws-cdk/aws-sqs,@aws-cdk/cx-api,cdk-watchful,constructs,@aws-cdk/assert,aws-cdk'"
         },
         {
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade @types/aws-lambda @types/fs-extra @types/jest @types/node @types/semver @types/tar-stream @typescript-eslint/eslint-plugin @typescript-eslint/parser aws-sdk aws-sdk-mock construct-hub-webapp constructs esbuild eslint eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import fs-extra glob got jest jest-junit jsii jsii-diff jsii-docgen jsii-pacmak jsii-rosetta json-schema nano npm-check-updates pascal-case projen semver standard-version tar-stream typescript yaml constructs"
+          "exec": "yarn upgrade @types/aws-lambda @types/fs-extra @types/jest @types/node @types/semver @types/tar-stream @typescript-eslint/eslint-plugin @typescript-eslint/parser aws-sdk aws-sdk-mock construct-hub-webapp esbuild eslint eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import fs-extra glob got jest jest-junit jsii jsii-diff jsii-docgen jsii-pacmak jsii-rosetta json-schema nano npm-check-updates pascal-case projen semver standard-version tar-stream typescript yaml"
         },
         {
           "exec": "npx projen"

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -23,6 +23,7 @@ const cdkDeps = [
   '@aws-cdk/aws-sqs',
   '@aws-cdk/cx-api',
   'cdk-watchful',
+  'constructs',
 ];
 
 const cdkAssert = '@aws-cdk/assert';

--- a/package.json
+++ b/package.json
@@ -139,7 +139,8 @@
     "@aws-cdk/aws-sqs": "1.108.0",
     "@aws-cdk/core": "1.108.0",
     "@aws-cdk/cx-api": "1.108.0",
-    "cdk-watchful": "^0.5.154"
+    "cdk-watchful": "^0.5.154",
+    "constructs": "^3.3.77"
   },
   "bundledDependencies": [],
   "keywords": [


### PR DESCRIPTION
This was an oversight to https://github.com/cdklabs/construct-hub/pull/82 where we excluded cdk dependencies from upgrade.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*