### PR TITLE
chore(discovery): smaller batch size

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -33,6 +33,18 @@ Object {
     },
   },
   "Parameters": Object {
+    "AssetParameters136f1f0babf03d6a2a9e907eef4b4f0a8846b1ae1000cec5e2dfa52638be8b6dArtifactHashC2D81A21": Object {
+      "Description": "Artifact hash for asset \\"136f1f0babf03d6a2a9e907eef4b4f0a8846b1ae1000cec5e2dfa52638be8b6d\\"",
+      "Type": "String",
+    },
+    "AssetParameters136f1f0babf03d6a2a9e907eef4b4f0a8846b1ae1000cec5e2dfa52638be8b6dS3Bucket6160C51C": Object {
+      "Description": "S3 bucket for asset \\"136f1f0babf03d6a2a9e907eef4b4f0a8846b1ae1000cec5e2dfa52638be8b6d\\"",
+      "Type": "String",
+    },
+    "AssetParameters136f1f0babf03d6a2a9e907eef4b4f0a8846b1ae1000cec5e2dfa52638be8b6dS3VersionKeyA0AFA1A9": Object {
+      "Description": "S3 key for asset version \\"136f1f0babf03d6a2a9e907eef4b4f0a8846b1ae1000cec5e2dfa52638be8b6d\\"",
+      "Type": "String",
+    },
     "AssetParameters67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24ArtifactHashBA91B77F": Object {
       "Description": "Artifact hash for asset \\"67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24\\"",
       "Type": "String",
@@ -67,18 +79,6 @@ Object {
     },
     "AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92S3VersionKeyEBE33688": Object {
       "Description": "S3 key for asset version \\"7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92\\"",
-      "Type": "String",
-    },
-    "AssetParameters84f77af86bf091027b60cd0952861d2d5a53fff5963b082775ec8485f0b28b29ArtifactHashCD3F587B": Object {
-      "Description": "Artifact hash for asset \\"84f77af86bf091027b60cd0952861d2d5a53fff5963b082775ec8485f0b28b29\\"",
-      "Type": "String",
-    },
-    "AssetParameters84f77af86bf091027b60cd0952861d2d5a53fff5963b082775ec8485f0b28b29S3Bucket8A3C08E9": Object {
-      "Description": "S3 bucket for asset \\"84f77af86bf091027b60cd0952861d2d5a53fff5963b082775ec8485f0b28b29\\"",
-      "Type": "String",
-    },
-    "AssetParameters84f77af86bf091027b60cd0952861d2d5a53fff5963b082775ec8485f0b28b29S3VersionKeyABFA4D60": Object {
-      "Description": "S3 key for asset version \\"84f77af86bf091027b60cd0952861d2d5a53fff5963b082775ec8485f0b28b29\\"",
       "Type": "String",
     },
     "AssetParametersc24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cfArtifactHash85F58E48": Object {
@@ -468,7 +468,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters84f77af86bf091027b60cd0952861d2d5a53fff5963b082775ec8485f0b28b29S3Bucket8A3C08E9",
+            "Ref": "AssetParameters136f1f0babf03d6a2a9e907eef4b4f0a8846b1ae1000cec5e2dfa52638be8b6dS3Bucket6160C51C",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -481,7 +481,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters84f77af86bf091027b60cd0952861d2d5a53fff5963b082775ec8485f0b28b29S3VersionKeyABFA4D60",
+                          "Ref": "AssetParameters136f1f0babf03d6a2a9e907eef4b4f0a8846b1ae1000cec5e2dfa52638be8b6dS3VersionKeyA0AFA1A9",
                         },
                       ],
                     },
@@ -494,7 +494,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters84f77af86bf091027b60cd0952861d2d5a53fff5963b082775ec8485f0b28b29S3VersionKeyABFA4D60",
+                          "Ref": "AssetParameters136f1f0babf03d6a2a9e907eef4b4f0a8846b1ae1000cec5e2dfa52638be8b6dS3VersionKeyA0AFA1A9",
                         },
                       ],
                     },
@@ -2132,6 +2132,18 @@ Object {
     },
   },
   "Parameters": Object {
+    "AssetParameters136f1f0babf03d6a2a9e907eef4b4f0a8846b1ae1000cec5e2dfa52638be8b6dArtifactHashC2D81A21": Object {
+      "Description": "Artifact hash for asset \\"136f1f0babf03d6a2a9e907eef4b4f0a8846b1ae1000cec5e2dfa52638be8b6d\\"",
+      "Type": "String",
+    },
+    "AssetParameters136f1f0babf03d6a2a9e907eef4b4f0a8846b1ae1000cec5e2dfa52638be8b6dS3Bucket6160C51C": Object {
+      "Description": "S3 bucket for asset \\"136f1f0babf03d6a2a9e907eef4b4f0a8846b1ae1000cec5e2dfa52638be8b6d\\"",
+      "Type": "String",
+    },
+    "AssetParameters136f1f0babf03d6a2a9e907eef4b4f0a8846b1ae1000cec5e2dfa52638be8b6dS3VersionKeyA0AFA1A9": Object {
+      "Description": "S3 key for asset version \\"136f1f0babf03d6a2a9e907eef4b4f0a8846b1ae1000cec5e2dfa52638be8b6d\\"",
+      "Type": "String",
+    },
     "AssetParameters67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24ArtifactHashBA91B77F": Object {
       "Description": "Artifact hash for asset \\"67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24\\"",
       "Type": "String",
@@ -2178,18 +2190,6 @@ Object {
     },
     "AssetParameters7af6295e521fd55af94332393ceffb3e866aac4dc4956321f7918f21e72199e4S3VersionKey326451BC": Object {
       "Description": "S3 key for asset version \\"7af6295e521fd55af94332393ceffb3e866aac4dc4956321f7918f21e72199e4\\"",
-      "Type": "String",
-    },
-    "AssetParameters84f77af86bf091027b60cd0952861d2d5a53fff5963b082775ec8485f0b28b29ArtifactHashCD3F587B": Object {
-      "Description": "Artifact hash for asset \\"84f77af86bf091027b60cd0952861d2d5a53fff5963b082775ec8485f0b28b29\\"",
-      "Type": "String",
-    },
-    "AssetParameters84f77af86bf091027b60cd0952861d2d5a53fff5963b082775ec8485f0b28b29S3Bucket8A3C08E9": Object {
-      "Description": "S3 bucket for asset \\"84f77af86bf091027b60cd0952861d2d5a53fff5963b082775ec8485f0b28b29\\"",
-      "Type": "String",
-    },
-    "AssetParameters84f77af86bf091027b60cd0952861d2d5a53fff5963b082775ec8485f0b28b29S3VersionKeyABFA4D60": Object {
-      "Description": "S3 key for asset version \\"84f77af86bf091027b60cd0952861d2d5a53fff5963b082775ec8485f0b28b29\\"",
       "Type": "String",
     },
     "AssetParametersc24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cfArtifactHash85F58E48": Object {
@@ -2728,7 +2728,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters84f77af86bf091027b60cd0952861d2d5a53fff5963b082775ec8485f0b28b29S3Bucket8A3C08E9",
+            "Ref": "AssetParameters136f1f0babf03d6a2a9e907eef4b4f0a8846b1ae1000cec5e2dfa52638be8b6dS3Bucket6160C51C",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -2741,7 +2741,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters84f77af86bf091027b60cd0952861d2d5a53fff5963b082775ec8485f0b28b29S3VersionKeyABFA4D60",
+                          "Ref": "AssetParameters136f1f0babf03d6a2a9e907eef4b4f0a8846b1ae1000cec5e2dfa52638be8b6dS3VersionKeyA0AFA1A9",
                         },
                       ],
                     },
@@ -2754,7 +2754,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters84f77af86bf091027b60cd0952861d2d5a53fff5963b082775ec8485f0b28b29S3VersionKeyABFA4D60",
+                          "Ref": "AssetParameters136f1f0babf03d6a2a9e907eef4b4f0a8846b1ae1000cec5e2dfa52638be8b6dS3VersionKeyA0AFA1A9",
                         },
                       ],
                     },

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -457,7 +457,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters84f77af86bf091027b60cd0952861d2d5a53fff5963b082775ec8485f0b28b29S3Bucket8A3C08E9
+          Ref: AssetParameters136f1f0babf03d6a2a9e907eef4b4f0a8846b1ae1000cec5e2dfa52638be8b6dS3Bucket6160C51C
         S3Key:
           Fn::Join:
             - ""
@@ -465,12 +465,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters84f77af86bf091027b60cd0952861d2d5a53fff5963b082775ec8485f0b28b29S3VersionKeyABFA4D60
+                      - Ref: AssetParameters136f1f0babf03d6a2a9e907eef4b4f0a8846b1ae1000cec5e2dfa52638be8b6dS3VersionKeyA0AFA1A9
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters84f77af86bf091027b60cd0952861d2d5a53fff5963b082775ec8485f0b28b29S3VersionKeyABFA4D60
+                      - Ref: AssetParameters136f1f0babf03d6a2a9e907eef4b4f0a8846b1ae1000cec5e2dfa52638be8b6dS3VersionKeyA0AFA1A9
       Role:
         Fn::GetAtt:
           - ConstructHubDiscoveryServiceRole1B3CFF96
@@ -1151,18 +1151,18 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "e09b0afc2cf095a5d39afbf164f1543cceb5f4748e562876d79cf1d3b3f7d597"
-  AssetParameters84f77af86bf091027b60cd0952861d2d5a53fff5963b082775ec8485f0b28b29S3Bucket8A3C08E9:
+  AssetParameters136f1f0babf03d6a2a9e907eef4b4f0a8846b1ae1000cec5e2dfa52638be8b6dS3Bucket6160C51C:
     Type: String
     Description: S3 bucket for asset
-      "84f77af86bf091027b60cd0952861d2d5a53fff5963b082775ec8485f0b28b29"
-  AssetParameters84f77af86bf091027b60cd0952861d2d5a53fff5963b082775ec8485f0b28b29S3VersionKeyABFA4D60:
+      "136f1f0babf03d6a2a9e907eef4b4f0a8846b1ae1000cec5e2dfa52638be8b6d"
+  AssetParameters136f1f0babf03d6a2a9e907eef4b4f0a8846b1ae1000cec5e2dfa52638be8b6dS3VersionKeyA0AFA1A9:
     Type: String
     Description: S3 key for asset version
-      "84f77af86bf091027b60cd0952861d2d5a53fff5963b082775ec8485f0b28b29"
-  AssetParameters84f77af86bf091027b60cd0952861d2d5a53fff5963b082775ec8485f0b28b29ArtifactHashCD3F587B:
+      "136f1f0babf03d6a2a9e907eef4b4f0a8846b1ae1000cec5e2dfa52638be8b6d"
+  AssetParameters136f1f0babf03d6a2a9e907eef4b4f0a8846b1ae1000cec5e2dfa52638be8b6dArtifactHashC2D81A21:
     Type: String
     Description: Artifact hash for asset
-      "84f77af86bf091027b60cd0952861d2d5a53fff5963b082775ec8485f0b28b29"
+      "136f1f0babf03d6a2a9e907eef4b4f0a8846b1ae1000cec5e2dfa52638be8b6d"
   AssetParametersf571294ae268bb9a6c61cd3df245c69279d4fcc5e481065702bcd6aa484199aeS3Bucket94B451B0:
     Type: String
     Description: S3 bucket for asset

--- a/src/backend/discovery/discovery.lambda.ts
+++ b/src/backend/discovery/discovery.lambda.ts
@@ -49,6 +49,7 @@ export async function handler(event: ScheduledEvent, context: Context) {
     selector: {
       name: { $gt: null },
     },
+    batchSize: 30,
   };
 
   const nano = Nano(NPM_REPLICA_REGISTRY_URL);
@@ -78,7 +79,9 @@ export async function handler(event: ScheduledEvent, context: Context) {
           updatedMarker = lastSeq;
 
           // If we have enough time left before timeout, proceed with the next batch, otherwise we're done here.
-          if (context.getRemainingTimeInMillis() >= 120_000 /* 2 minutes */) {
+          // Since the distribution of the time it takes to process each package/batch is non uniform, this is a best
+          // effort, and we expect the function to timeout in some invocations, we rely on the downstream idempotency to handle this.
+          if (context.getRemainingTimeInMillis() >= 30_000 /* 30 seconds */) {
             console.log('There is still time, requesting the next batch...');
             // Note: the `resume` function is missing from the `nano` type definitions, but is there...
             (db.changesReader as any).resume();


### PR DESCRIPTION
Changing the batch size used when issuing a request to `couchdb`. This is done to reduce the memory size required during the function execution. Since smaller batch size means lower (average) batch processing time, this PR also reduce the time we require to remain in the Lambda execution in order to request an additional batch.

As mentioned in the code, checking for the time left in the function execution is a best effort, as the distribution of the time it takes to process a package/batch is non uniform, thus we expect the function to time out in some invocations and rely on the downstream idempotency.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*