### PR TITLE
revert: move to dedicated backend

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -1345,45 +1345,6 @@ Object {
       },
       "Type": "Custom::S3BucketNotifications",
     },
-    "ConstructHubPackageDataPolicy4615475A": Object {
-      "Properties": Object {
-        "Bucket": Object {
-          "Ref": "ConstructHubPackageDataDC5EF35E",
-        },
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "s3:GetObject",
-              "Effect": "Allow",
-              "Principal": Object {
-                "CanonicalUser": Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubWebAppDistributionOrigin2S3OriginDA7E7FF4",
-                    "S3CanonicalUserId",
-                  ],
-                },
-              },
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "ConstructHubPackageDataDC5EF35E",
-                        "Arn",
-                      ],
-                    },
-                    "/*",
-                  ],
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-      },
-      "Type": "AWS::S3::BucketPolicy",
-    },
     "ConstructHubTransliterator9C48708A": Object {
       "DependsOn": Array [
         "ConstructHubTransliteratorServiceRoleDefaultPolicyB9C4BE06",
@@ -1692,14 +1653,14 @@ Object {
             Object {
               "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
               "Compress": true,
-              "PathPattern": "/data/*",
+              "PathPattern": "/packages/*",
               "TargetOriginId": "TestConstructHubWebAppDistributionOrigin276090F90",
               "ViewerProtocolPolicy": "allow-all",
             },
             Object {
               "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
               "Compress": true,
-              "PathPattern": "/catalog.json",
+              "PathPattern": "/index/packages.json",
               "TargetOriginId": "TestConstructHubWebAppDistributionOrigin276090F90",
               "ViewerProtocolPolicy": "allow-all",
             },
@@ -1750,26 +1711,14 @@ Object {
               },
             },
             Object {
-              "DomainName": Object {
-                "Fn::GetAtt": Array [
-                  "ConstructHubPackageDataDC5EF35E",
-                  "RegionalDomainName",
+              "CustomOriginConfig": Object {
+                "OriginProtocolPolicy": "https-only",
+                "OriginSSLProtocols": Array [
+                  "TLSv1.2",
                 ],
               },
+              "DomainName": "awscdk.io",
               "Id": "TestConstructHubWebAppDistributionOrigin276090F90",
-              "S3OriginConfig": Object {
-                "OriginAccessIdentity": Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "origin-access-identity/cloudfront/",
-                      Object {
-                        "Ref": "ConstructHubWebAppDistributionOrigin2S3OriginDA7E7FF4",
-                      },
-                    ],
-                  ],
-                },
-              },
             },
           ],
         },
@@ -1780,14 +1729,6 @@ Object {
       "Properties": Object {
         "CloudFrontOriginAccessIdentityConfig": Object {
           "Comment": "Identity for TestConstructHubWebAppDistributionOrigin171FF58D3",
-        },
-      },
-      "Type": "AWS::CloudFront::CloudFrontOriginAccessIdentity",
-    },
-    "ConstructHubWebAppDistributionOrigin2S3OriginDA7E7FF4": Object {
-      "Properties": Object {
-        "CloudFrontOriginAccessIdentityConfig": Object {
-          "Comment": "Identity for TestConstructHubWebAppDistributionOrigin276090F90",
         },
       },
       "Type": "AWS::CloudFront::CloudFrontOriginAccessIdentity",
@@ -3664,45 +3605,6 @@ Object {
       },
       "Type": "Custom::S3BucketNotifications",
     },
-    "ConstructHubPackageDataPolicy4615475A": Object {
-      "Properties": Object {
-        "Bucket": Object {
-          "Ref": "ConstructHubPackageDataDC5EF35E",
-        },
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "s3:GetObject",
-              "Effect": "Allow",
-              "Principal": Object {
-                "CanonicalUser": Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubWebAppDistributionOrigin2S3OriginDA7E7FF4",
-                    "S3CanonicalUserId",
-                  ],
-                },
-              },
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "ConstructHubPackageDataDC5EF35E",
-                        "Arn",
-                      ],
-                    },
-                    "/*",
-                  ],
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-      },
-      "Type": "AWS::S3::BucketPolicy",
-    },
     "ConstructHubTransliterator9C48708A": Object {
       "DependsOn": Array [
         "ConstructHubTransliteratorServiceRoleDefaultPolicyB9C4BE06",
@@ -4066,14 +3968,14 @@ Object {
             Object {
               "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
               "Compress": true,
-              "PathPattern": "/data/*",
+              "PathPattern": "/packages/*",
               "TargetOriginId": "TestConstructHubWebAppDistributionOrigin276090F90",
               "ViewerProtocolPolicy": "allow-all",
             },
             Object {
               "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
               "Compress": true,
-              "PathPattern": "/catalog.json",
+              "PathPattern": "/index/packages.json",
               "TargetOriginId": "TestConstructHubWebAppDistributionOrigin276090F90",
               "ViewerProtocolPolicy": "allow-all",
             },
@@ -4124,26 +4026,14 @@ Object {
               },
             },
             Object {
-              "DomainName": Object {
-                "Fn::GetAtt": Array [
-                  "ConstructHubPackageDataDC5EF35E",
-                  "RegionalDomainName",
+              "CustomOriginConfig": Object {
+                "OriginProtocolPolicy": "https-only",
+                "OriginSSLProtocols": Array [
+                  "TLSv1.2",
                 ],
               },
+              "DomainName": "awscdk.io",
               "Id": "TestConstructHubWebAppDistributionOrigin276090F90",
-              "S3OriginConfig": Object {
-                "OriginAccessIdentity": Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "origin-access-identity/cloudfront/",
-                      Object {
-                        "Ref": "ConstructHubWebAppDistributionOrigin2S3OriginDA7E7FF4",
-                      },
-                    ],
-                  ],
-                },
-              },
             },
           ],
           "ViewerCertificate": Object {
@@ -4164,14 +4054,6 @@ Object {
       "Properties": Object {
         "CloudFrontOriginAccessIdentityConfig": Object {
           "Comment": "Identity for TestConstructHubWebAppDistributionOrigin171FF58D3",
-        },
-      },
-      "Type": "AWS::CloudFront::CloudFrontOriginAccessIdentity",
-    },
-    "ConstructHubWebAppDistributionOrigin2S3OriginDA7E7FF4": Object {
-      "Properties": Object {
-        "CloudFrontOriginAccessIdentityConfig": Object {
-          "Comment": "Identity for TestConstructHubWebAppDistributionOrigin276090F90",
         },
       },
       "Type": "AWS::CloudFront::CloudFrontOriginAccessIdentity",

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -243,28 +243,6 @@ Resources:
         Fn::GetAtt:
           - ConstructHubPackageDataDC5EF35E
           - Arn
-  ConstructHubPackageDataPolicy4615475A:
-    Type: AWS::S3::BucketPolicy
-    Properties:
-      Bucket:
-        Ref: ConstructHubPackageDataDC5EF35E
-      PolicyDocument:
-        Statement:
-          - Action: s3:GetObject
-            Effect: Allow
-            Principal:
-              CanonicalUser:
-                Fn::GetAtt:
-                  - ConstructHubWebAppDistributionOrigin2S3OriginDA7E7FF4
-                  - S3CanonicalUserId
-            Resource:
-              Fn::Join:
-                - ""
-                - - Fn::GetAtt:
-                      - ConstructHubPackageDataDC5EF35E
-                      - Arn
-                  - /*
-        Version: 2012-10-17
   ConstructHubIngestionQueue1AD94CA3:
     Type: AWS::SQS::Queue
     Properties:
@@ -787,12 +765,12 @@ Resources:
         CacheBehaviors:
           - CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6
             Compress: true
-            PathPattern: /data/*
+            PathPattern: /packages/*
             TargetOriginId: devConstructHubWebAppDistributionOrigin2A726FD66
             ViewerProtocolPolicy: allow-all
           - CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6
             Compress: true
-            PathPattern: /catalog.json
+            PathPattern: /index/packages.json
             TargetOriginId: devConstructHubWebAppDistributionOrigin2A726FD66
             ViewerProtocolPolicy: allow-all
         CustomErrorResponses:
@@ -823,22 +801,12 @@ Resources:
                   - ""
                   - - origin-access-identity/cloudfront/
                     - Ref: ConstructHubWebAppDistributionOrigin1S3Origin694AF937
-          - DomainName:
-              Fn::GetAtt:
-                - ConstructHubPackageDataDC5EF35E
-                - RegionalDomainName
+          - CustomOriginConfig:
+              OriginProtocolPolicy: https-only
+              OriginSSLProtocols:
+                - TLSv1.2
+            DomainName: awscdk.io
             Id: devConstructHubWebAppDistributionOrigin2A726FD66
-            S3OriginConfig:
-              OriginAccessIdentity:
-                Fn::Join:
-                  - ""
-                  - - origin-access-identity/cloudfront/
-                    - Ref: ConstructHubWebAppDistributionOrigin2S3OriginDA7E7FF4
-  ConstructHubWebAppDistributionOrigin2S3OriginDA7E7FF4:
-    Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
-    Properties:
-      CloudFrontOriginAccessIdentityConfig:
-        Comment: Identity for devConstructHubWebAppDistributionOrigin2A726FD66
   ConstructHubWebAppDeployWebsiteAwsCliLayer23CFFBC1:
     Type: AWS::Lambda::LayerVersion
     Properties:

--- a/src/construct-hub.ts
+++ b/src/construct-hub.ts
@@ -72,7 +72,6 @@ export class ConstructHub extends CoreConstruct implements iam.IGrantable {
     new WebApp(this, 'WebApp', {
       domain: props.domain,
       monitoring: monitoring,
-      packageDataBucket: packageData,
     });
   }
 

--- a/src/webapp/index.ts
+++ b/src/webapp/index.ts
@@ -20,11 +20,6 @@ export interface WebAppProps {
    * Monitoring system.
    */
   readonly monitoring: Monitoring;
-
-  /**
-   * The bucket containig package data.
-   */
-  readonly packageDataBucket: s3.IBucket;
 }
 
 export class WebApp extends Construct {
@@ -47,9 +42,9 @@ export class WebApp extends Construct {
       })),
     });
 
-    const jsiiObjOrigin = new origins.S3Origin(props.packageDataBucket);
-    this.distribution.addBehavior('/data/*', jsiiObjOrigin);
-    this.distribution.addBehavior('/catalog.json', jsiiObjOrigin);
+    const jsiiObjOrigin = new origins.HttpOrigin('awscdk.io');
+    this.distribution.addBehavior('/packages/*', jsiiObjOrigin);
+    this.distribution.addBehavior('/index/packages.json', jsiiObjOrigin);
 
     // if we use a domain, and A records with a CloudFront alias
     if (props.domain) {


### PR DESCRIPTION
Reverts cdklabs/construct-hub#109.

We are still not really ready to consume data from this backend since a lot of packages are missing. 