### PR TITLE
feat: npm metadata in `metadata.json` file

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -45,6 +45,30 @@ Object {
       "Description": "S3 key for asset version \\"136f1f0babf03d6a2a9e907eef4b4f0a8846b1ae1000cec5e2dfa52638be8b6d\\"",
       "Type": "String",
     },
+    "AssetParameters5777e731045ef2e0c78841fc8eb602c8598e874ab6d78962d3612140cae8212aArtifactHash96151522": Object {
+      "Description": "Artifact hash for asset \\"5777e731045ef2e0c78841fc8eb602c8598e874ab6d78962d3612140cae8212a\\"",
+      "Type": "String",
+    },
+    "AssetParameters5777e731045ef2e0c78841fc8eb602c8598e874ab6d78962d3612140cae8212aS3BucketD3308BAE": Object {
+      "Description": "S3 bucket for asset \\"5777e731045ef2e0c78841fc8eb602c8598e874ab6d78962d3612140cae8212a\\"",
+      "Type": "String",
+    },
+    "AssetParameters5777e731045ef2e0c78841fc8eb602c8598e874ab6d78962d3612140cae8212aS3VersionKey9F229C4F": Object {
+      "Description": "S3 key for asset version \\"5777e731045ef2e0c78841fc8eb602c8598e874ab6d78962d3612140cae8212a\\"",
+      "Type": "String",
+    },
+    "AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62ArtifactHashA4A3AF68": Object {
+      "Description": "Artifact hash for asset \\"623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62\\"",
+      "Type": "String",
+    },
+    "AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62S3Bucket506CBFFD": Object {
+      "Description": "S3 bucket for asset \\"623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62\\"",
+      "Type": "String",
+    },
+    "AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62S3VersionKey9279072B": Object {
+      "Description": "S3 key for asset version \\"623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62\\"",
+      "Type": "String",
+    },
     "AssetParameters67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24ArtifactHashBA91B77F": Object {
       "Description": "Artifact hash for asset \\"67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24\\"",
       "Type": "String",
@@ -69,18 +93,6 @@ Object {
       "Description": "S3 key for asset version \\"7a2bbccc29d678a46137de4f305df8f456778031d8718123cbeb3c11a8badb79\\"",
       "Type": "String",
     },
-    "AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92ArtifactHashAC43CB57": Object {
-      "Description": "Artifact hash for asset \\"7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92\\"",
-      "Type": "String",
-    },
-    "AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92S3BucketF79EABC1": Object {
-      "Description": "S3 bucket for asset \\"7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92\\"",
-      "Type": "String",
-    },
-    "AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92S3VersionKeyEBE33688": Object {
-      "Description": "S3 key for asset version \\"7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92\\"",
-      "Type": "String",
-    },
     "AssetParametersc24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cfArtifactHash85F58E48": Object {
       "Description": "Artifact hash for asset \\"c24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cf\\"",
       "Type": "String",
@@ -103,18 +115,6 @@ Object {
     },
     "AssetParametersdcc427ad1a9c4d2a63344256acec911f0ef035359b814054fe1485aeb59e789dS3VersionKey4C7389DF": Object {
       "Description": "S3 key for asset version \\"dcc427ad1a9c4d2a63344256acec911f0ef035359b814054fe1485aeb59e789d\\"",
-      "Type": "String",
-    },
-    "AssetParameterse09b0afc2cf095a5d39afbf164f1543cceb5f4748e562876d79cf1d3b3f7d597ArtifactHash0CD4F030": Object {
-      "Description": "Artifact hash for asset \\"e09b0afc2cf095a5d39afbf164f1543cceb5f4748e562876d79cf1d3b3f7d597\\"",
-      "Type": "String",
-    },
-    "AssetParameterse09b0afc2cf095a5d39afbf164f1543cceb5f4748e562876d79cf1d3b3f7d597S3BucketCBE710FA": Object {
-      "Description": "S3 bucket for asset \\"e09b0afc2cf095a5d39afbf164f1543cceb5f4748e562876d79cf1d3b3f7d597\\"",
-      "Type": "String",
-    },
-    "AssetParameterse09b0afc2cf095a5d39afbf164f1543cceb5f4748e562876d79cf1d3b3f7d597S3VersionKey8A5F47CF": Object {
-      "Description": "S3 key for asset version \\"e09b0afc2cf095a5d39afbf164f1543cceb5f4748e562876d79cf1d3b3f7d597\\"",
       "Type": "String",
     },
     "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68ArtifactHashD9A515C3": Object {
@@ -690,7 +690,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameterse09b0afc2cf095a5d39afbf164f1543cceb5f4748e562876d79cf1d3b3f7d597S3BucketCBE710FA",
+            "Ref": "AssetParameters5777e731045ef2e0c78841fc8eb602c8598e874ab6d78962d3612140cae8212aS3BucketD3308BAE",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -703,7 +703,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameterse09b0afc2cf095a5d39afbf164f1543cceb5f4748e562876d79cf1d3b3f7d597S3VersionKey8A5F47CF",
+                          "Ref": "AssetParameters5777e731045ef2e0c78841fc8eb602c8598e874ab6d78962d3612140cae8212aS3VersionKey9F229C4F",
                         },
                       ],
                     },
@@ -716,7 +716,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameterse09b0afc2cf095a5d39afbf164f1543cceb5f4748e562876d79cf1d3b3f7d597S3VersionKey8A5F47CF",
+                          "Ref": "AssetParameters5777e731045ef2e0c78841fc8eb602c8598e874ab6d78962d3612140cae8212aS3VersionKey9F229C4F",
                         },
                       ],
                     },
@@ -1604,7 +1604,7 @@ Object {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92S3BucketF79EABC1",
+            "Ref": "AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62S3Bucket506CBFFD",
           },
         ],
         "SourceObjectKeys": Array [
@@ -1619,7 +1619,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92S3VersionKeyEBE33688",
+                          "Ref": "AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62S3VersionKey9279072B",
                         },
                       ],
                     },
@@ -1632,7 +1632,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92S3VersionKeyEBE33688",
+                          "Ref": "AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62S3VersionKey9279072B",
                         },
                       ],
                     },
@@ -1899,7 +1899,7 @@ Object {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92S3BucketF79EABC1",
+                        "Ref": "AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62S3Bucket506CBFFD",
                       },
                     ],
                   ],
@@ -1914,7 +1914,7 @@ Object {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92S3BucketF79EABC1",
+                        "Ref": "AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62S3Bucket506CBFFD",
                       },
                       "/*",
                     ],
@@ -2144,6 +2144,30 @@ Object {
       "Description": "S3 key for asset version \\"136f1f0babf03d6a2a9e907eef4b4f0a8846b1ae1000cec5e2dfa52638be8b6d\\"",
       "Type": "String",
     },
+    "AssetParameters5777e731045ef2e0c78841fc8eb602c8598e874ab6d78962d3612140cae8212aArtifactHash96151522": Object {
+      "Description": "Artifact hash for asset \\"5777e731045ef2e0c78841fc8eb602c8598e874ab6d78962d3612140cae8212a\\"",
+      "Type": "String",
+    },
+    "AssetParameters5777e731045ef2e0c78841fc8eb602c8598e874ab6d78962d3612140cae8212aS3BucketD3308BAE": Object {
+      "Description": "S3 bucket for asset \\"5777e731045ef2e0c78841fc8eb602c8598e874ab6d78962d3612140cae8212a\\"",
+      "Type": "String",
+    },
+    "AssetParameters5777e731045ef2e0c78841fc8eb602c8598e874ab6d78962d3612140cae8212aS3VersionKey9F229C4F": Object {
+      "Description": "S3 key for asset version \\"5777e731045ef2e0c78841fc8eb602c8598e874ab6d78962d3612140cae8212a\\"",
+      "Type": "String",
+    },
+    "AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62ArtifactHashA4A3AF68": Object {
+      "Description": "Artifact hash for asset \\"623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62\\"",
+      "Type": "String",
+    },
+    "AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62S3Bucket506CBFFD": Object {
+      "Description": "S3 bucket for asset \\"623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62\\"",
+      "Type": "String",
+    },
+    "AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62S3VersionKey9279072B": Object {
+      "Description": "S3 key for asset version \\"623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62\\"",
+      "Type": "String",
+    },
     "AssetParameters67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24ArtifactHashBA91B77F": Object {
       "Description": "Artifact hash for asset \\"67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24\\"",
       "Type": "String",
@@ -2166,18 +2190,6 @@ Object {
     },
     "AssetParameters7a2bbccc29d678a46137de4f305df8f456778031d8718123cbeb3c11a8badb79S3VersionKey1782299A": Object {
       "Description": "S3 key for asset version \\"7a2bbccc29d678a46137de4f305df8f456778031d8718123cbeb3c11a8badb79\\"",
-      "Type": "String",
-    },
-    "AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92ArtifactHashAC43CB57": Object {
-      "Description": "Artifact hash for asset \\"7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92\\"",
-      "Type": "String",
-    },
-    "AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92S3BucketF79EABC1": Object {
-      "Description": "S3 bucket for asset \\"7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92\\"",
-      "Type": "String",
-    },
-    "AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92S3VersionKeyEBE33688": Object {
-      "Description": "S3 key for asset version \\"7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92\\"",
       "Type": "String",
     },
     "AssetParameters7af6295e521fd55af94332393ceffb3e866aac4dc4956321f7918f21e72199e4ArtifactHash5E28809B": Object {
@@ -2214,18 +2226,6 @@ Object {
     },
     "AssetParametersdcc427ad1a9c4d2a63344256acec911f0ef035359b814054fe1485aeb59e789dS3VersionKey4C7389DF": Object {
       "Description": "S3 key for asset version \\"dcc427ad1a9c4d2a63344256acec911f0ef035359b814054fe1485aeb59e789d\\"",
-      "Type": "String",
-    },
-    "AssetParameterse09b0afc2cf095a5d39afbf164f1543cceb5f4748e562876d79cf1d3b3f7d597ArtifactHash0CD4F030": Object {
-      "Description": "Artifact hash for asset \\"e09b0afc2cf095a5d39afbf164f1543cceb5f4748e562876d79cf1d3b3f7d597\\"",
-      "Type": "String",
-    },
-    "AssetParameterse09b0afc2cf095a5d39afbf164f1543cceb5f4748e562876d79cf1d3b3f7d597S3BucketCBE710FA": Object {
-      "Description": "S3 bucket for asset \\"e09b0afc2cf095a5d39afbf164f1543cceb5f4748e562876d79cf1d3b3f7d597\\"",
-      "Type": "String",
-    },
-    "AssetParameterse09b0afc2cf095a5d39afbf164f1543cceb5f4748e562876d79cf1d3b3f7d597S3VersionKey8A5F47CF": Object {
-      "Description": "S3 key for asset version \\"e09b0afc2cf095a5d39afbf164f1543cceb5f4748e562876d79cf1d3b3f7d597\\"",
       "Type": "String",
     },
     "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68ArtifactHashD9A515C3": Object {
@@ -2950,7 +2950,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameterse09b0afc2cf095a5d39afbf164f1543cceb5f4748e562876d79cf1d3b3f7d597S3BucketCBE710FA",
+            "Ref": "AssetParameters5777e731045ef2e0c78841fc8eb602c8598e874ab6d78962d3612140cae8212aS3BucketD3308BAE",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -2963,7 +2963,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameterse09b0afc2cf095a5d39afbf164f1543cceb5f4748e562876d79cf1d3b3f7d597S3VersionKey8A5F47CF",
+                          "Ref": "AssetParameters5777e731045ef2e0c78841fc8eb602c8598e874ab6d78962d3612140cae8212aS3VersionKey9F229C4F",
                         },
                       ],
                     },
@@ -2976,7 +2976,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameterse09b0afc2cf095a5d39afbf164f1543cceb5f4748e562876d79cf1d3b3f7d597S3VersionKey8A5F47CF",
+                          "Ref": "AssetParameters5777e731045ef2e0c78841fc8eb602c8598e874ab6d78962d3612140cae8212aS3VersionKey9F229C4F",
                         },
                       ],
                     },
@@ -3916,7 +3916,7 @@ Object {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92S3BucketF79EABC1",
+            "Ref": "AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62S3Bucket506CBFFD",
           },
         ],
         "SourceObjectKeys": Array [
@@ -3931,7 +3931,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92S3VersionKeyEBE33688",
+                          "Ref": "AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62S3VersionKey9279072B",
                         },
                       ],
                     },
@@ -3944,7 +3944,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92S3VersionKeyEBE33688",
+                          "Ref": "AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62S3VersionKey9279072B",
                         },
                       ],
                     },
@@ -4224,7 +4224,7 @@ Object {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92S3BucketF79EABC1",
+                        "Ref": "AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62S3Bucket506CBFFD",
                       },
                     ],
                   ],
@@ -4239,7 +4239,7 @@ Object {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92S3BucketF79EABC1",
+                        "Ref": "AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62S3Bucket506CBFFD",
                       },
                       "/*",
                     ],

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -57,18 +57,6 @@ Object {
       "Description": "S3 key for asset version \\"5777e731045ef2e0c78841fc8eb602c8598e874ab6d78962d3612140cae8212a\\"",
       "Type": "String",
     },
-    "AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62ArtifactHashA4A3AF68": Object {
-      "Description": "Artifact hash for asset \\"623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62\\"",
-      "Type": "String",
-    },
-    "AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62S3Bucket506CBFFD": Object {
-      "Description": "S3 bucket for asset \\"623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62\\"",
-      "Type": "String",
-    },
-    "AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62S3VersionKey9279072B": Object {
-      "Description": "S3 key for asset version \\"623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62\\"",
-      "Type": "String",
-    },
     "AssetParameters67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24ArtifactHashBA91B77F": Object {
       "Description": "Artifact hash for asset \\"67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24\\"",
       "Type": "String",
@@ -91,6 +79,18 @@ Object {
     },
     "AssetParameters7a2bbccc29d678a46137de4f305df8f456778031d8718123cbeb3c11a8badb79S3VersionKey1782299A": Object {
       "Description": "S3 key for asset version \\"7a2bbccc29d678a46137de4f305df8f456778031d8718123cbeb3c11a8badb79\\"",
+      "Type": "String",
+    },
+    "AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92ArtifactHashAC43CB57": Object {
+      "Description": "Artifact hash for asset \\"7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92\\"",
+      "Type": "String",
+    },
+    "AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92S3BucketF79EABC1": Object {
+      "Description": "S3 bucket for asset \\"7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92\\"",
+      "Type": "String",
+    },
+    "AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92S3VersionKeyEBE33688": Object {
+      "Description": "S3 key for asset version \\"7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92\\"",
       "Type": "String",
     },
     "AssetParametersc24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cfArtifactHash85F58E48": Object {
@@ -1604,7 +1604,7 @@ Object {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62S3Bucket506CBFFD",
+            "Ref": "AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92S3BucketF79EABC1",
           },
         ],
         "SourceObjectKeys": Array [
@@ -1619,7 +1619,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62S3VersionKey9279072B",
+                          "Ref": "AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92S3VersionKeyEBE33688",
                         },
                       ],
                     },
@@ -1632,7 +1632,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62S3VersionKey9279072B",
+                          "Ref": "AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92S3VersionKeyEBE33688",
                         },
                       ],
                     },
@@ -1899,7 +1899,7 @@ Object {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62S3Bucket506CBFFD",
+                        "Ref": "AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92S3BucketF79EABC1",
                       },
                     ],
                   ],
@@ -1914,7 +1914,7 @@ Object {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62S3Bucket506CBFFD",
+                        "Ref": "AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92S3BucketF79EABC1",
                       },
                       "/*",
                     ],
@@ -2156,18 +2156,6 @@ Object {
       "Description": "S3 key for asset version \\"5777e731045ef2e0c78841fc8eb602c8598e874ab6d78962d3612140cae8212a\\"",
       "Type": "String",
     },
-    "AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62ArtifactHashA4A3AF68": Object {
-      "Description": "Artifact hash for asset \\"623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62\\"",
-      "Type": "String",
-    },
-    "AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62S3Bucket506CBFFD": Object {
-      "Description": "S3 bucket for asset \\"623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62\\"",
-      "Type": "String",
-    },
-    "AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62S3VersionKey9279072B": Object {
-      "Description": "S3 key for asset version \\"623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62\\"",
-      "Type": "String",
-    },
     "AssetParameters67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24ArtifactHashBA91B77F": Object {
       "Description": "Artifact hash for asset \\"67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24\\"",
       "Type": "String",
@@ -2190,6 +2178,18 @@ Object {
     },
     "AssetParameters7a2bbccc29d678a46137de4f305df8f456778031d8718123cbeb3c11a8badb79S3VersionKey1782299A": Object {
       "Description": "S3 key for asset version \\"7a2bbccc29d678a46137de4f305df8f456778031d8718123cbeb3c11a8badb79\\"",
+      "Type": "String",
+    },
+    "AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92ArtifactHashAC43CB57": Object {
+      "Description": "Artifact hash for asset \\"7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92\\"",
+      "Type": "String",
+    },
+    "AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92S3BucketF79EABC1": Object {
+      "Description": "S3 bucket for asset \\"7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92\\"",
+      "Type": "String",
+    },
+    "AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92S3VersionKeyEBE33688": Object {
+      "Description": "S3 key for asset version \\"7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92\\"",
       "Type": "String",
     },
     "AssetParameters7af6295e521fd55af94332393ceffb3e866aac4dc4956321f7918f21e72199e4ArtifactHash5E28809B": Object {
@@ -3916,7 +3916,7 @@ Object {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62S3Bucket506CBFFD",
+            "Ref": "AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92S3BucketF79EABC1",
           },
         ],
         "SourceObjectKeys": Array [
@@ -3931,7 +3931,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62S3VersionKey9279072B",
+                          "Ref": "AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92S3VersionKeyEBE33688",
                         },
                       ],
                     },
@@ -3944,7 +3944,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62S3VersionKey9279072B",
+                          "Ref": "AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92S3VersionKeyEBE33688",
                         },
                       ],
                     },
@@ -4224,7 +4224,7 @@ Object {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62S3Bucket506CBFFD",
+                        "Ref": "AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92S3BucketF79EABC1",
                       },
                     ],
                   ],
@@ -4239,7 +4239,7 @@ Object {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62S3Bucket506CBFFD",
+                        "Ref": "AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92S3BucketF79EABC1",
                       },
                       "/*",
                     ],

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -333,7 +333,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameterse09b0afc2cf095a5d39afbf164f1543cceb5f4748e562876d79cf1d3b3f7d597S3BucketCBE710FA
+          Ref: AssetParameters5777e731045ef2e0c78841fc8eb602c8598e874ab6d78962d3612140cae8212aS3BucketD3308BAE
         S3Key:
           Fn::Join:
             - ""
@@ -341,12 +341,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameterse09b0afc2cf095a5d39afbf164f1543cceb5f4748e562876d79cf1d3b3f7d597S3VersionKey8A5F47CF
+                      - Ref: AssetParameters5777e731045ef2e0c78841fc8eb602c8598e874ab6d78962d3612140cae8212aS3VersionKey9F229C4F
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameterse09b0afc2cf095a5d39afbf164f1543cceb5f4748e562876d79cf1d3b3f7d597S3VersionKey8A5F47CF
+                      - Ref: AssetParameters5777e731045ef2e0c78841fc8eb602c8598e874ab6d78962d3612140cae8212aS3VersionKey9F229C4F
       Role:
         Fn::GetAtt:
           - ConstructHubIngestionServiceRole6380BAB6
@@ -835,7 +835,7 @@ Resources:
           - CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536
           - Arn
       SourceBucketNames:
-        - Ref: AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92S3BucketF79EABC1
+        - Ref: AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62S3Bucket506CBFFD
       SourceObjectKeys:
         - Fn::Join:
             - ""
@@ -843,12 +843,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92S3VersionKeyEBE33688
+                      - Ref: AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62S3VersionKey9279072B
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92S3VersionKeyEBE33688
+                      - Ref: AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62S3VersionKey9279072B
       DestinationBucketName:
         Ref: ConstructHubWebAppWebsiteBucket4B2B9DB2
       Prune: true
@@ -1056,13 +1056,13 @@ Resources:
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92S3BucketF79EABC1
+                    - Ref: AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62S3Bucket506CBFFD
               - Fn::Join:
                   - ""
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92S3BucketF79EABC1
+                    - Ref: AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62S3Bucket506CBFFD
                     - /*
           - Action:
               - s3:GetObject*
@@ -1139,18 +1139,18 @@ Outputs:
     Export:
       Name: ConstructHubDomainName
 Parameters:
-  AssetParameterse09b0afc2cf095a5d39afbf164f1543cceb5f4748e562876d79cf1d3b3f7d597S3BucketCBE710FA:
+  AssetParameters5777e731045ef2e0c78841fc8eb602c8598e874ab6d78962d3612140cae8212aS3BucketD3308BAE:
     Type: String
     Description: S3 bucket for asset
-      "e09b0afc2cf095a5d39afbf164f1543cceb5f4748e562876d79cf1d3b3f7d597"
-  AssetParameterse09b0afc2cf095a5d39afbf164f1543cceb5f4748e562876d79cf1d3b3f7d597S3VersionKey8A5F47CF:
+      "5777e731045ef2e0c78841fc8eb602c8598e874ab6d78962d3612140cae8212a"
+  AssetParameters5777e731045ef2e0c78841fc8eb602c8598e874ab6d78962d3612140cae8212aS3VersionKey9F229C4F:
     Type: String
     Description: S3 key for asset version
-      "e09b0afc2cf095a5d39afbf164f1543cceb5f4748e562876d79cf1d3b3f7d597"
-  AssetParameterse09b0afc2cf095a5d39afbf164f1543cceb5f4748e562876d79cf1d3b3f7d597ArtifactHash0CD4F030:
+      "5777e731045ef2e0c78841fc8eb602c8598e874ab6d78962d3612140cae8212a"
+  AssetParameters5777e731045ef2e0c78841fc8eb602c8598e874ab6d78962d3612140cae8212aArtifactHash96151522:
     Type: String
     Description: Artifact hash for asset
-      "e09b0afc2cf095a5d39afbf164f1543cceb5f4748e562876d79cf1d3b3f7d597"
+      "5777e731045ef2e0c78841fc8eb602c8598e874ab6d78962d3612140cae8212a"
   AssetParameters136f1f0babf03d6a2a9e907eef4b4f0a8846b1ae1000cec5e2dfa52638be8b6dS3Bucket6160C51C:
     Type: String
     Description: S3 bucket for asset
@@ -1223,18 +1223,18 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "c24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cf"
-  AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92S3BucketF79EABC1:
+  AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62S3Bucket506CBFFD:
     Type: String
     Description: S3 bucket for asset
-      "7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92"
-  AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92S3VersionKeyEBE33688:
+      "623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62"
+  AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62S3VersionKey9279072B:
     Type: String
     Description: S3 key for asset version
-      "7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92"
-  AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92ArtifactHashAC43CB57:
+      "623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62"
+  AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62ArtifactHashA4A3AF68:
     Type: String
     Description: Artifact hash for asset
-      "7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92"
+      "623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62"
   AssetParametersdcc427ad1a9c4d2a63344256acec911f0ef035359b814054fe1485aeb59e789dS3Bucket8C070E54:
     Type: String
     Description: S3 bucket for asset

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -835,7 +835,7 @@ Resources:
           - CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536
           - Arn
       SourceBucketNames:
-        - Ref: AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62S3Bucket506CBFFD
+        - Ref: AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92S3BucketF79EABC1
       SourceObjectKeys:
         - Fn::Join:
             - ""
@@ -843,12 +843,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62S3VersionKey9279072B
+                      - Ref: AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92S3VersionKeyEBE33688
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62S3VersionKey9279072B
+                      - Ref: AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92S3VersionKeyEBE33688
       DestinationBucketName:
         Ref: ConstructHubWebAppWebsiteBucket4B2B9DB2
       Prune: true
@@ -1056,13 +1056,13 @@ Resources:
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62S3Bucket506CBFFD
+                    - Ref: AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92S3BucketF79EABC1
               - Fn::Join:
                   - ""
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62S3Bucket506CBFFD
+                    - Ref: AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92S3BucketF79EABC1
                     - /*
           - Action:
               - s3:GetObject*
@@ -1223,18 +1223,18 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "c24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cf"
-  AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62S3Bucket506CBFFD:
+  AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92S3BucketF79EABC1:
     Type: String
     Description: S3 bucket for asset
-      "623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62"
-  AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62S3VersionKey9279072B:
+      "7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92"
+  AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92S3VersionKeyEBE33688:
     Type: String
     Description: S3 key for asset version
-      "623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62"
-  AssetParameters623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62ArtifactHashA4A3AF68:
+      "7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92"
+  AssetParameters7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92ArtifactHashAC43CB57:
     Type: String
     Description: Artifact hash for asset
-      "623367f72307610c48a867e7ee3001e2bf985905286be21657e0328390024e62"
+      "7abd1fafd87a608c055d7dcbe712a30009e59267d1b423086749cb59482ceb92"
   AssetParametersdcc427ad1a9c4d2a63344256acec911f0ef035359b814054fe1485aeb59e789dS3Bucket8C070E54:
     Type: String
     Description: S3 bucket for asset

--- a/src/backend/shared/constants.lambda-shared.ts
+++ b/src/backend/shared/constants.lambda-shared.ts
@@ -17,6 +17,11 @@ export const STORAGE_KEY_PREFIX = 'data/';
 export const PACKAGE_KEY_SUFFIX = '/package.tgz';
 
 /**
+ * Key suffix for storing npm package metadata.
+ */
+export const METADATA_KEY_SUFFIX = '/metadata.json';
+
+/**
  * The key suffix for (TypeScript) assembly files
  */
 export const ASSEMBLY_KEY_SUFFIX = '/assembly.json';


### PR DESCRIPTION
Resolves https://github.com/cdklabs/construct-hub/issues/116

Note that the file we'll have will only contain the publish date of the package:

```json
{
  "date": "2021-03-03T15:44:28.263Z",
}
```

Since all other information is actually available on the assembly.

An example of how the current file looks like on `awscdk.io`:

```json
{
  "name": "aws-cdk-lib",
  "scope": "unscoped",
  "version": "2.0.0-alpha.6",
  "description": "The AWS Cloud Development Kit library",
  "keywords": [
    "aws",
    "cdk"
  ],
  "date": "2021-03-03T15:44:28.263Z",
  "links": {
    "npm": "https://www.npmjs.com/package/aws-cdk-lib",
    "homepage": "https://github.com/aws/aws-cdk",
    "repository": "https://github.com/aws/aws-cdk",
    "bugs": "https://github.com/aws/aws-cdk/issues"
  },
  "author": {
    "name": "Amazon Web Services",
    "url": "https://aws.amazon.com"
  },
  "publisher": {
    "username": "aws-cdk-team",
    "email": "aws-cdk-dev@amazon.com"
  },
  "maintainers": [
    {
      "username": "aws-cdk-team",
      "email": "aws-cdk-dev@amazon.com"
    }
  ]
}
```

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*