### PR TITLE
chore: upgrade `jsii-docgen` to `2.x`

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,97 +1,165 @@
-# API Reference
+# API Reference <a name="API Reference"></a>
 
-**Classes**
+## Constructs <a name="Constructs"></a>
 
-Name|Description
-----|-----------
-[ConstructHub](#construct-hub-constructhub)|Construct Hub.
+### ConstructHub <a name="construct-hub.ConstructHub"></a>
 
-
-**Structs**
-
-Name|Description
-----|-----------
-[AlarmActions](#construct-hub-alarmactions)|CloudWatch alarm actions to perform.
-[ConstructHubProps](#construct-hub-constructhubprops)|Props for `ConstructHub`.
-[Domain](#construct-hub-domain)|Domain configuration for the website.
-
-
-
-## class ConstructHub 🔹 <a id="construct-hub-constructhub"></a>
+- *Implements:* [`@aws-cdk/aws-iam.IGrantable`](#@aws-cdk/aws-iam.IGrantable)
 
 Construct Hub.
 
-__Implements__: [IConstruct](#constructs-iconstruct), [IConstruct](#aws-cdk-core-iconstruct), [IConstruct](#constructs-iconstruct), [IDependable](#aws-cdk-core-idependable), [IGrantable](#aws-cdk-aws-iam-igrantable)
-__Extends__: [Construct](#aws-cdk-core-construct)
+#### Initializer <a name="construct-hub.ConstructHub.Initializer"></a>
 
-### Initializer
+```typescript
+import { ConstructHub } from 'construct-hub'
 
-
-
-
-```ts
 new ConstructHub(scope: Construct, id: string, props: ConstructHubProps)
 ```
 
-* **scope** (<code>[Construct](#constructs-construct)</code>)  *No description*
-* **id** (<code>string</code>)  *No description*
-* **props** (<code>[ConstructHubProps](#construct-hub-constructhubprops)</code>)  *No description*
-  * **alarmActions** (<code>[AlarmActions](#construct-hub-alarmactions)</code>)  Actions to perform when alarms are set. 
-  * **dashboardName** (<code>string</code>)  The name of the CloudWatch Dashboard created to observe this application. __*Default*__: "construct-hub"
-  * **domain** (<code>[Domain](#construct-hub-domain)</code>)  Connect the hub to a domain (requires a hosted zone and a certificate). __*Optional*__
+##### `scope`<sup>Required</sup> <a name="construct-hub.ConstructHub.scope"></a>
+
+- *Type:* [`constructs.Construct`](#constructs.Construct)
+
+---
+
+##### `id`<sup>Required</sup> <a name="construct-hub.ConstructHub.id"></a>
+
+- *Type:* `string`
+
+---
+
+##### `props`<sup>Required</sup> <a name="construct-hub.ConstructHub.props"></a>
+
+- *Type:* [`construct-hub.ConstructHubProps`](#construct-hub.ConstructHubProps)
+
+---
 
 
 
-### Properties
+#### Properties <a name="Properties"></a>
+
+##### `grantPrincipal`<sup>Required</sup> <a name="construct-hub.ConstructHub.grantPrincipal"></a>
+
+- *Type:* [`@aws-cdk/aws-iam.IPrincipal`](#@aws-cdk/aws-iam.IPrincipal)
+
+The principal to grant permissions to.
+
+---
+
+##### `ingestionQueue`<sup>Required</sup> <a name="construct-hub.ConstructHub.ingestionQueue"></a>
+
+- *Type:* [`@aws-cdk/aws-sqs.IQueue`](#@aws-cdk/aws-sqs.IQueue)
+
+---
 
 
-Name | Type | Description 
------|------|-------------
-**grantPrincipal**🔹 | <code>[IPrincipal](#aws-cdk-aws-iam-iprincipal)</code> | The principal to grant permissions to.
-**ingestionQueue**🔹 | <code>[IQueue](#aws-cdk-aws-sqs-iqueue)</code> | <span></span>
+## Structs <a name="Structs"></a>
 
-
-
-## struct AlarmActions 🔹 <a id="construct-hub-alarmactions"></a>
-
+### AlarmActions <a name="construct-hub.AlarmActions"></a>
 
 CloudWatch alarm actions to perform.
 
+#### Initializer <a name="[object Object].Initializer"></a>
 
+```typescript
+import { AlarmActions } from 'construct-hub'
 
-Name | Type | Description 
------|------|-------------
-**highSeverity**🔹 | <code>string</code> | The ARN of the CloudWatch alarm action to take for alarms of high-severity alarms.
-**normalSeverity**?🔹 | <code>string</code> | The ARN of the CloudWatch alarm action to take for alarms of normal severity.<br/>__*Default*__: no actions are taken in response to alarms of normal severity
+const alarmActions: AlarmActions = { ... }
+```
 
+##### `highSeverity`<sup>Required</sup> <a name="construct-hub.AlarmActions.highSeverity"></a>
 
+- *Type:* `string`
 
-## struct ConstructHubProps 🔹 <a id="construct-hub-constructhubprops"></a>
+The ARN of the CloudWatch alarm action to take for alarms of high-severity alarms.
 
+This must be an ARN that can be used with CloudWatch alarms.
+
+> https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarms-and-actions
+
+---
+
+##### `normalSeverity`<sup>Optional</sup> <a name="construct-hub.AlarmActions.normalSeverity"></a>
+
+- *Type:* `string`
+- *Default:* no actions are taken in response to alarms of normal severity
+
+The ARN of the CloudWatch alarm action to take for alarms of normal severity.
+
+This must be an ARN that can be used with CloudWatch alarms.
+
+> https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarms-and-actions
+
+---
+
+### ConstructHubProps <a name="construct-hub.ConstructHubProps"></a>
 
 Props for `ConstructHub`.
 
+#### Initializer <a name="[object Object].Initializer"></a>
 
+```typescript
+import { ConstructHubProps } from 'construct-hub'
 
-Name | Type | Description 
------|------|-------------
-**alarmActions**🔹 | <code>[AlarmActions](#construct-hub-alarmactions)</code> | Actions to perform when alarms are set.
-**dashboardName**?🔹 | <code>string</code> | The name of the CloudWatch Dashboard created to observe this application.<br/>__*Default*__: "construct-hub"
-**domain**?🔹 | <code>[Domain](#construct-hub-domain)</code> | Connect the hub to a domain (requires a hosted zone and a certificate).<br/>__*Optional*__
+const constructHubProps: ConstructHubProps = { ... }
+```
 
+##### `alarmActions`<sup>Required</sup> <a name="construct-hub.ConstructHubProps.alarmActions"></a>
 
+- *Type:* [`construct-hub.AlarmActions`](#construct-hub.AlarmActions)
 
-## struct Domain 🔹 <a id="construct-hub-domain"></a>
+Actions to perform when alarms are set.
 
+---
+
+##### `dashboardName`<sup>Optional</sup> <a name="construct-hub.ConstructHubProps.dashboardName"></a>
+
+- *Type:* `string`
+- *Default:* "construct-hub"
+
+The name of the CloudWatch Dashboard created to observe this application.
+
+Must only contain alphanumerics, dash (-) and underscore (_).
+
+---
+
+##### `domain`<sup>Optional</sup> <a name="construct-hub.ConstructHubProps.domain"></a>
+
+- *Type:* [`construct-hub.Domain`](#construct-hub.Domain)
+
+Connect the hub to a domain (requires a hosted zone and a certificate).
+
+---
+
+### Domain <a name="construct-hub.Domain"></a>
 
 Domain configuration for the website.
 
+#### Initializer <a name="[object Object].Initializer"></a>
 
+```typescript
+import { Domain } from 'construct-hub'
 
-Name | Type | Description 
------|------|-------------
-**cert**🔹 | <code>[ICertificate](#aws-cdk-aws-certificatemanager-icertificate)</code> | The certificate to use for serving the Construct Hub over a custom domain.
-**zone**🔹 | <code>[IHostedZone](#aws-cdk-aws-route53-ihostedzone)</code> | The root domain name where this instance of Construct Hub will be served.
+const domain: Domain = { ... }
+```
+
+##### `cert`<sup>Required</sup> <a name="construct-hub.Domain.cert"></a>
+
+- *Type:* [`@aws-cdk/aws-certificatemanager.ICertificate`](#@aws-cdk/aws-certificatemanager.ICertificate)
+- *Default:* a DNS-Validated certificate will be provisioned using the
+  provided `hostedZone`.
+
+The certificate to use for serving the Construct Hub over a custom domain.
+
+---
+
+##### `zone`<sup>Required</sup> <a name="construct-hub.Domain.zone"></a>
+
+- *Type:* [`@aws-cdk/aws-route53.IHostedZone`](#@aws-cdk/aws-route53.IHostedZone)
+
+The root domain name where this instance of Construct Hub will be served.
+
+---
 
 
 

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "jest-junit": "^12",
     "jsii": "^1.30.0",
     "jsii-diff": "^1.30.0",
-    "jsii-docgen": "^1.8.110",
+    "jsii-docgen": "^2.0.0",
     "jsii-pacmak": "^1.30.0",
     "jsii-rosetta": "./vendor/jsii-rosetta.tgz",
     "json-schema": "^0.3.0",

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -33,18 +33,6 @@ Object {
     },
   },
   "Parameters": Object {
-    "AssetParameters1a18dd3fb3333a9846596423c7680ec8fed402464a791d1c402bf073969b444fArtifactHashB721AA28": Object {
-      "Description": "Artifact hash for asset \\"1a18dd3fb3333a9846596423c7680ec8fed402464a791d1c402bf073969b444f\\"",
-      "Type": "String",
-    },
-    "AssetParameters1a18dd3fb3333a9846596423c7680ec8fed402464a791d1c402bf073969b444fS3Bucket1402115D": Object {
-      "Description": "S3 bucket for asset \\"1a18dd3fb3333a9846596423c7680ec8fed402464a791d1c402bf073969b444f\\"",
-      "Type": "String",
-    },
-    "AssetParameters1a18dd3fb3333a9846596423c7680ec8fed402464a791d1c402bf073969b444fS3VersionKey064226C1": Object {
-      "Description": "S3 key for asset version \\"1a18dd3fb3333a9846596423c7680ec8fed402464a791d1c402bf073969b444f\\"",
-      "Type": "String",
-    },
     "AssetParameters4a8d8c6492481fded6cf033dd1a08b28f4a4d6d8458d3afdd41e09504f0df0deArtifactHash392604A6": Object {
       "Description": "Artifact hash for asset \\"4a8d8c6492481fded6cf033dd1a08b28f4a4d6d8458d3afdd41e09504f0df0de\\"",
       "Type": "String",
@@ -103,6 +91,18 @@ Object {
     },
     "AssetParametersa3d13916fdb6321f8e433bfcbbaaf0ce37d7484a6d75635fdbaceebe8bbe46ffS3VersionKey0B0E7067": Object {
       "Description": "S3 key for asset version \\"a3d13916fdb6321f8e433bfcbbaaf0ce37d7484a6d75635fdbaceebe8bbe46ff\\"",
+      "Type": "String",
+    },
+    "AssetParametersaa2c1185d2c2d8f7301e1bca04b45b6aeb7b84e31c712735e2ba4be9ff47b635ArtifactHash866122BF": Object {
+      "Description": "Artifact hash for asset \\"aa2c1185d2c2d8f7301e1bca04b45b6aeb7b84e31c712735e2ba4be9ff47b635\\"",
+      "Type": "String",
+    },
+    "AssetParametersaa2c1185d2c2d8f7301e1bca04b45b6aeb7b84e31c712735e2ba4be9ff47b635S3Bucket740E8381": Object {
+      "Description": "S3 bucket for asset \\"aa2c1185d2c2d8f7301e1bca04b45b6aeb7b84e31c712735e2ba4be9ff47b635\\"",
+      "Type": "String",
+    },
+    "AssetParametersaa2c1185d2c2d8f7301e1bca04b45b6aeb7b84e31c712735e2ba4be9ff47b635S3VersionKey94C3D26B": Object {
+      "Description": "S3 key for asset version \\"aa2c1185d2c2d8f7301e1bca04b45b6aeb7b84e31c712735e2ba4be9ff47b635\\"",
       "Type": "String",
     },
     "AssetParametersc24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cfArtifactHash85F58E48": Object {
@@ -2317,7 +2317,7 @@ Object {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters1a18dd3fb3333a9846596423c7680ec8fed402464a791d1c402bf073969b444fS3Bucket1402115D",
+            "Ref": "AssetParametersaa2c1185d2c2d8f7301e1bca04b45b6aeb7b84e31c712735e2ba4be9ff47b635S3Bucket740E8381",
           },
         ],
         "SourceObjectKeys": Array [
@@ -2332,7 +2332,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1a18dd3fb3333a9846596423c7680ec8fed402464a791d1c402bf073969b444fS3VersionKey064226C1",
+                          "Ref": "AssetParametersaa2c1185d2c2d8f7301e1bca04b45b6aeb7b84e31c712735e2ba4be9ff47b635S3VersionKey94C3D26B",
                         },
                       ],
                     },
@@ -2345,7 +2345,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1a18dd3fb3333a9846596423c7680ec8fed402464a791d1c402bf073969b444fS3VersionKey064226C1",
+                          "Ref": "AssetParametersaa2c1185d2c2d8f7301e1bca04b45b6aeb7b84e31c712735e2ba4be9ff47b635S3VersionKey94C3D26B",
                         },
                       ],
                     },
@@ -2524,7 +2524,7 @@ function handler(event) {
                 Object {
                   "Ref": "AWS::Region",
                 },
-                "TestConstrubWebAppResponseFunction1F387BCC",
+                "TestConstubWebAppResponseFunction1F387BCC",
               ],
             ],
           },
@@ -2537,7 +2537,7 @@ function handler(event) {
               Object {
                 "Ref": "AWS::Region",
               },
-              "TestConstrubWebAppResponseFunction1F387BCC",
+              "TestConstubWebAppResponseFunction1F387BCC",
             ],
           ],
         },
@@ -2710,7 +2710,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters1a18dd3fb3333a9846596423c7680ec8fed402464a791d1c402bf073969b444fS3Bucket1402115D",
+                        "Ref": "AssetParametersaa2c1185d2c2d8f7301e1bca04b45b6aeb7b84e31c712735e2ba4be9ff47b635S3Bucket740E8381",
                       },
                     ],
                   ],
@@ -2725,7 +2725,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters1a18dd3fb3333a9846596423c7680ec8fed402464a791d1c402bf073969b444fS3Bucket1402115D",
+                        "Ref": "AssetParametersaa2c1185d2c2d8f7301e1bca04b45b6aeb7b84e31c712735e2ba4be9ff47b635S3Bucket740E8381",
                       },
                       "/*",
                     ],
@@ -2943,18 +2943,6 @@ Object {
     },
   },
   "Parameters": Object {
-    "AssetParameters1a18dd3fb3333a9846596423c7680ec8fed402464a791d1c402bf073969b444fArtifactHashB721AA28": Object {
-      "Description": "Artifact hash for asset \\"1a18dd3fb3333a9846596423c7680ec8fed402464a791d1c402bf073969b444f\\"",
-      "Type": "String",
-    },
-    "AssetParameters1a18dd3fb3333a9846596423c7680ec8fed402464a791d1c402bf073969b444fS3Bucket1402115D": Object {
-      "Description": "S3 bucket for asset \\"1a18dd3fb3333a9846596423c7680ec8fed402464a791d1c402bf073969b444f\\"",
-      "Type": "String",
-    },
-    "AssetParameters1a18dd3fb3333a9846596423c7680ec8fed402464a791d1c402bf073969b444fS3VersionKey064226C1": Object {
-      "Description": "S3 key for asset version \\"1a18dd3fb3333a9846596423c7680ec8fed402464a791d1c402bf073969b444f\\"",
-      "Type": "String",
-    },
     "AssetParameters4a8d8c6492481fded6cf033dd1a08b28f4a4d6d8458d3afdd41e09504f0df0deArtifactHash392604A6": Object {
       "Description": "Artifact hash for asset \\"4a8d8c6492481fded6cf033dd1a08b28f4a4d6d8458d3afdd41e09504f0df0de\\"",
       "Type": "String",
@@ -3025,6 +3013,18 @@ Object {
     },
     "AssetParametersa3d13916fdb6321f8e433bfcbbaaf0ce37d7484a6d75635fdbaceebe8bbe46ffS3VersionKey0B0E7067": Object {
       "Description": "S3 key for asset version \\"a3d13916fdb6321f8e433bfcbbaaf0ce37d7484a6d75635fdbaceebe8bbe46ff\\"",
+      "Type": "String",
+    },
+    "AssetParametersaa2c1185d2c2d8f7301e1bca04b45b6aeb7b84e31c712735e2ba4be9ff47b635ArtifactHash866122BF": Object {
+      "Description": "Artifact hash for asset \\"aa2c1185d2c2d8f7301e1bca04b45b6aeb7b84e31c712735e2ba4be9ff47b635\\"",
+      "Type": "String",
+    },
+    "AssetParametersaa2c1185d2c2d8f7301e1bca04b45b6aeb7b84e31c712735e2ba4be9ff47b635S3Bucket740E8381": Object {
+      "Description": "S3 bucket for asset \\"aa2c1185d2c2d8f7301e1bca04b45b6aeb7b84e31c712735e2ba4be9ff47b635\\"",
+      "Type": "String",
+    },
+    "AssetParametersaa2c1185d2c2d8f7301e1bca04b45b6aeb7b84e31c712735e2ba4be9ff47b635S3VersionKey94C3D26B": Object {
+      "Description": "S3 key for asset version \\"aa2c1185d2c2d8f7301e1bca04b45b6aeb7b84e31c712735e2ba4be9ff47b635\\"",
       "Type": "String",
     },
     "AssetParametersc24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cfArtifactHash85F58E48": Object {
@@ -5440,7 +5440,7 @@ Object {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters1a18dd3fb3333a9846596423c7680ec8fed402464a791d1c402bf073969b444fS3Bucket1402115D",
+            "Ref": "AssetParametersaa2c1185d2c2d8f7301e1bca04b45b6aeb7b84e31c712735e2ba4be9ff47b635S3Bucket740E8381",
           },
         ],
         "SourceObjectKeys": Array [
@@ -5455,7 +5455,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1a18dd3fb3333a9846596423c7680ec8fed402464a791d1c402bf073969b444fS3VersionKey064226C1",
+                          "Ref": "AssetParametersaa2c1185d2c2d8f7301e1bca04b45b6aeb7b84e31c712735e2ba4be9ff47b635S3VersionKey94C3D26B",
                         },
                       ],
                     },
@@ -5468,7 +5468,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1a18dd3fb3333a9846596423c7680ec8fed402464a791d1c402bf073969b444fS3VersionKey064226C1",
+                          "Ref": "AssetParametersaa2c1185d2c2d8f7301e1bca04b45b6aeb7b84e31c712735e2ba4be9ff47b635S3VersionKey94C3D26B",
                         },
                       ],
                     },
@@ -5660,7 +5660,7 @@ function handler(event) {
                 Object {
                   "Ref": "AWS::Region",
                 },
-                "TestConstrubWebAppResponseFunction1F387BCC",
+                "TestConstubWebAppResponseFunction1F387BCC",
               ],
             ],
           },
@@ -5673,7 +5673,7 @@ function handler(event) {
               Object {
                 "Ref": "AWS::Region",
               },
-              "TestConstrubWebAppResponseFunction1F387BCC",
+              "TestConstubWebAppResponseFunction1F387BCC",
             ],
           ],
         },
@@ -5846,7 +5846,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters1a18dd3fb3333a9846596423c7680ec8fed402464a791d1c402bf073969b444fS3Bucket1402115D",
+                        "Ref": "AssetParametersaa2c1185d2c2d8f7301e1bca04b45b6aeb7b84e31c712735e2ba4be9ff47b635S3Bucket740E8381",
                       },
                     ],
                   ],
@@ -5861,7 +5861,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters1a18dd3fb3333a9846596423c7680ec8fed402464a791d1c402bf073969b444fS3Bucket1402115D",
+                        "Ref": "AssetParametersaa2c1185d2c2d8f7301e1bca04b45b6aeb7b84e31c712735e2ba4be9ff47b635S3Bucket740E8381",
                       },
                       "/*",
                     ],

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -1255,7 +1255,7 @@ Resources:
         Fn::Join:
           - ""
           - - Ref: AWS::Region
-            - devConstruubWebAppResponseFunction3452125C
+            - devConstrubWebAppResponseFunction3452125C
       AutoPublish: true
       FunctionCode: >-
         "use strict";
@@ -1279,7 +1279,7 @@ Resources:
           Fn::Join:
             - ""
             - - Ref: AWS::Region
-              - devConstruubWebAppResponseFunction3452125C
+              - devConstrubWebAppResponseFunction3452125C
         Runtime: cloudfront-js-1.0
   ConstructHubWebAppDistributionOrigin1S3Origin694AF937:
     Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
@@ -1391,7 +1391,7 @@ Resources:
           - CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536
           - Arn
       SourceBucketNames:
-        - Ref: AssetParameters1a18dd3fb3333a9846596423c7680ec8fed402464a791d1c402bf073969b444fS3Bucket1402115D
+        - Ref: AssetParametersaa2c1185d2c2d8f7301e1bca04b45b6aeb7b84e31c712735e2ba4be9ff47b635S3Bucket740E8381
       SourceObjectKeys:
         - Fn::Join:
             - ""
@@ -1399,12 +1399,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters1a18dd3fb3333a9846596423c7680ec8fed402464a791d1c402bf073969b444fS3VersionKey064226C1
+                      - Ref: AssetParametersaa2c1185d2c2d8f7301e1bca04b45b6aeb7b84e31c712735e2ba4be9ff47b635S3VersionKey94C3D26B
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters1a18dd3fb3333a9846596423c7680ec8fed402464a791d1c402bf073969b444fS3VersionKey064226C1
+                      - Ref: AssetParametersaa2c1185d2c2d8f7301e1bca04b45b6aeb7b84e31c712735e2ba4be9ff47b635S3VersionKey94C3D26B
       DestinationBucketName:
         Ref: ConstructHubWebAppWebsiteBucket4B2B9DB2
       Prune: true
@@ -1612,13 +1612,13 @@ Resources:
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParameters1a18dd3fb3333a9846596423c7680ec8fed402464a791d1c402bf073969b444fS3Bucket1402115D
+                    - Ref: AssetParametersaa2c1185d2c2d8f7301e1bca04b45b6aeb7b84e31c712735e2ba4be9ff47b635S3Bucket740E8381
               - Fn::Join:
                   - ""
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParameters1a18dd3fb3333a9846596423c7680ec8fed402464a791d1c402bf073969b444fS3Bucket1402115D
+                    - Ref: AssetParametersaa2c1185d2c2d8f7301e1bca04b45b6aeb7b84e31c712735e2ba4be9ff47b635S3Bucket740E8381
                     - /*
           - Action:
               - s3:GetObject*
@@ -1779,18 +1779,18 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "c24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cf"
-  AssetParameters1a18dd3fb3333a9846596423c7680ec8fed402464a791d1c402bf073969b444fS3Bucket1402115D:
+  AssetParametersaa2c1185d2c2d8f7301e1bca04b45b6aeb7b84e31c712735e2ba4be9ff47b635S3Bucket740E8381:
     Type: String
     Description: S3 bucket for asset
-      "1a18dd3fb3333a9846596423c7680ec8fed402464a791d1c402bf073969b444f"
-  AssetParameters1a18dd3fb3333a9846596423c7680ec8fed402464a791d1c402bf073969b444fS3VersionKey064226C1:
+      "aa2c1185d2c2d8f7301e1bca04b45b6aeb7b84e31c712735e2ba4be9ff47b635"
+  AssetParametersaa2c1185d2c2d8f7301e1bca04b45b6aeb7b84e31c712735e2ba4be9ff47b635S3VersionKey94C3D26B:
     Type: String
     Description: S3 key for asset version
-      "1a18dd3fb3333a9846596423c7680ec8fed402464a791d1c402bf073969b444f"
-  AssetParameters1a18dd3fb3333a9846596423c7680ec8fed402464a791d1c402bf073969b444fArtifactHashB721AA28:
+      "aa2c1185d2c2d8f7301e1bca04b45b6aeb7b84e31c712735e2ba4be9ff47b635"
+  AssetParametersaa2c1185d2c2d8f7301e1bca04b45b6aeb7b84e31c712735e2ba4be9ff47b635ArtifactHash866122BF:
     Type: String
     Description: Artifact hash for asset
-      "1a18dd3fb3333a9846596423c7680ec8fed402464a791d1c402bf073969b444f"
+      "aa2c1185d2c2d8f7301e1bca04b45b6aeb7b84e31c712735e2ba4be9ff47b635"
   AssetParameters59be5a60739e4f0f9b881492bce41ccffa8d47d16b0a4d640db1bb8200f48bd5S3BucketFA2341B6:
     Type: String
     Description: S3 bucket for asset

--- a/yarn.lock
+++ b/yarn.lock
@@ -10103,13 +10103,15 @@ jsii-diff@^1.30.0:
     typescript "~3.9.9"
     yargs "^16.2.0"
 
-jsii-docgen@^1.8.110:
-  version "1.8.110"
-  resolved "https://registry.yarnpkg.com/jsii-docgen/-/jsii-docgen-1.8.110.tgz#83c829864db993a9479531b43e8dcb2288803c1f"
-  integrity sha512-xl/A8lpOfRzG7KQqHDkWf3bveR3b0hM91CG1/eHLSpBJpvsEvCS97JkOpcCp16XEiTHrHMrnILZPPGWneFUncw==
+jsii-docgen@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/jsii-docgen/-/jsii-docgen-2.0.0.tgz#a171e82d4fe17e3a88d3d7b211dbb422a23258d3"
+  integrity sha512-2CvsC3Ct0kx8l+7AEDzCJv9lRw+LYLJEtbCH76H7DCCq5HeX3W16WV8CP7d5bztiOQ+wNl8YOHh8CdwWaPrqMw==
   dependencies:
     "@jsii/spec" "^1.30.0"
+    case "^1.6.3"
     fs-extra "^9.1.0"
+    glob "^7.1.7"
     jsii-reflect "^1.30.0"
     yargs "^16.2.0"
 


### PR DESCRIPTION
Rendered API Reference: https://github.com/cdklabs/construct-hub/blob/epolon/upgrade-jsii-docgen/API.md

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*