### PR TITLE
fix: certificate expiration metrics are on a day scale

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -2524,7 +2524,7 @@ function handler(event) {
                 Object {
                   "Ref": "AWS::Region",
                 },
-                "TestConstubWebAppResponseFunction1F387BCC",
+                "TestConstrubWebAppResponseFunction1F387BCC",
               ],
             ],
           },
@@ -2537,7 +2537,7 @@ function handler(event) {
               Object {
                 "Ref": "AWS::Region",
               },
-              "TestConstubWebAppResponseFunction1F387BCC",
+              "TestConstrubWebAppResponseFunction1F387BCC",
             ],
           ],
         },
@@ -5704,7 +5704,7 @@ Object {
         "EvaluationPeriods": 1,
         "MetricName": "DaysToExpiry",
         "Namespace": "AWS/CertificateManager",
-        "Period": 3600,
+        "Period": 86400,
         "Statistic": "Minimum",
         "Threshold": 45,
         "TreatMissingData": "breaching",
@@ -5795,7 +5795,7 @@ Object {
         "EvaluationPeriods": 1,
         "MetricName": "DaysToExpiry",
         "Namespace": "Test",
-        "Period": 3600,
+        "Period": 86400,
         "Statistic": "Minimum",
         "Threshold": 45,
         "TreatMissingData": "breaching",
@@ -5907,7 +5907,7 @@ function handler(event) {
                 Object {
                   "Ref": "AWS::Region",
                 },
-                "TestConstubWebAppResponseFunction1F387BCC",
+                "TestConstrubWebAppResponseFunction1F387BCC",
               ],
             ],
           },
@@ -5920,7 +5920,7 @@ function handler(event) {
               Object {
                 "Ref": "AWS::Region",
               },
-              "TestConstubWebAppResponseFunction1F387BCC",
+              "TestConstrubWebAppResponseFunction1F387BCC",
             ],
           ],
         },

--- a/src/monitored-certificate/index.ts
+++ b/src/monitored-certificate/index.ts
@@ -109,7 +109,7 @@ export class MonitoredCertificate extends Construct {
    */
   public metricAcmCertificateDaysToExpiry(opts?: MetricOptions): Metric {
     return new Metric({
-      period: Duration.hours(1),
+      period: Duration.days(1),
       statistic: Statistic.MINIMUM,
       ...opts,
       dimensions: { CertificateArn: this.props.certificate.certificateArn },
@@ -126,7 +126,7 @@ export class MonitoredCertificate extends Construct {
    */
   public metricEndpointCertificateDaysToExpiry(opts?: MetricOptions): Metric {
     return new Metric({
-      period: Duration.hours(1),
+      period: Duration.days(1),
       statistic: Statistic.MINIMUM,
       ...opts,
       dimensions: { DomainName: this.props.domainName },


### PR DESCRIPTION
Changes the periodicity of the alarms to 1 day instead of 1 hour, as the
ACM metric is only emitted once a day.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*