### PR TITLE
feat: ignore packages with name or version mismatch

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -45,6 +45,18 @@ Object {
       "Description": "S3 key for asset version \\"0dfb0b3b18599bad760f45b02537f770c6d07bfba2daa5407d82b6306d92963d\\"",
       "Type": "String",
     },
+    "AssetParameters0f40b7675b3b9a3b611a984f192c2797f0a4c0b8c475cb89da4497e9762c0614ArtifactHashD93E46BF": Object {
+      "Description": "Artifact hash for asset \\"0f40b7675b3b9a3b611a984f192c2797f0a4c0b8c475cb89da4497e9762c0614\\"",
+      "Type": "String",
+    },
+    "AssetParameters0f40b7675b3b9a3b611a984f192c2797f0a4c0b8c475cb89da4497e9762c0614S3Bucket315E87E0": Object {
+      "Description": "S3 bucket for asset \\"0f40b7675b3b9a3b611a984f192c2797f0a4c0b8c475cb89da4497e9762c0614\\"",
+      "Type": "String",
+    },
+    "AssetParameters0f40b7675b3b9a3b611a984f192c2797f0a4c0b8c475cb89da4497e9762c0614S3VersionKey4955B657": Object {
+      "Description": "S3 key for asset version \\"0f40b7675b3b9a3b611a984f192c2797f0a4c0b8c475cb89da4497e9762c0614\\"",
+      "Type": "String",
+    },
     "AssetParameters29569ad5bf9948e4744218e7f7440b327629220ab1ca1cce582477911c74780bArtifactHashD350A16C": Object {
       "Description": "Artifact hash for asset \\"29569ad5bf9948e4744218e7f7440b327629220ab1ca1cce582477911c74780b\\"",
       "Type": "String",
@@ -55,18 +67,6 @@ Object {
     },
     "AssetParameters29569ad5bf9948e4744218e7f7440b327629220ab1ca1cce582477911c74780bS3VersionKeyB69597A2": Object {
       "Description": "S3 key for asset version \\"29569ad5bf9948e4744218e7f7440b327629220ab1ca1cce582477911c74780b\\"",
-      "Type": "String",
-    },
-    "AssetParameters4f217792f9ba05f14c44a222a9fc2e677586f18493e25af99827156872bf79e1ArtifactHash6048D2E6": Object {
-      "Description": "Artifact hash for asset \\"4f217792f9ba05f14c44a222a9fc2e677586f18493e25af99827156872bf79e1\\"",
-      "Type": "String",
-    },
-    "AssetParameters4f217792f9ba05f14c44a222a9fc2e677586f18493e25af99827156872bf79e1S3Bucket3936E572": Object {
-      "Description": "S3 bucket for asset \\"4f217792f9ba05f14c44a222a9fc2e677586f18493e25af99827156872bf79e1\\"",
-      "Type": "String",
-    },
-    "AssetParameters4f217792f9ba05f14c44a222a9fc2e677586f18493e25af99827156872bf79e1S3VersionKeyDFC5B004": Object {
-      "Description": "S3 key for asset version \\"4f217792f9ba05f14c44a222a9fc2e677586f18493e25af99827156872bf79e1\\"",
       "Type": "String",
     },
     "AssetParameters59be5a60739e4f0f9b881492bce41ccffa8d47d16b0a4d640db1bb8200f48bd5ArtifactHash76FE5C86": Object {
@@ -93,6 +93,18 @@ Object {
       "Description": "S3 key for asset version \\"67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24\\"",
       "Type": "String",
     },
+    "AssetParameters763da6b59c5feaad32ef8dd7fcba1b4815d75fcab6e3fd81b24041895c86d862ArtifactHash497B15E5": Object {
+      "Description": "Artifact hash for asset \\"763da6b59c5feaad32ef8dd7fcba1b4815d75fcab6e3fd81b24041895c86d862\\"",
+      "Type": "String",
+    },
+    "AssetParameters763da6b59c5feaad32ef8dd7fcba1b4815d75fcab6e3fd81b24041895c86d862S3Bucket6CA4A500": Object {
+      "Description": "S3 bucket for asset \\"763da6b59c5feaad32ef8dd7fcba1b4815d75fcab6e3fd81b24041895c86d862\\"",
+      "Type": "String",
+    },
+    "AssetParameters763da6b59c5feaad32ef8dd7fcba1b4815d75fcab6e3fd81b24041895c86d862S3VersionKey249E8EF0": Object {
+      "Description": "S3 key for asset version \\"763da6b59c5feaad32ef8dd7fcba1b4815d75fcab6e3fd81b24041895c86d862\\"",
+      "Type": "String",
+    },
     "AssetParameters97e6563aeb743805ef5d4bbbbe29d6b3bb28c0544c9cca24a203de835bd21784ArtifactHash1A2C2611": Object {
       "Description": "Artifact hash for asset \\"97e6563aeb743805ef5d4bbbbe29d6b3bb28c0544c9cca24a203de835bd21784\\"",
       "Type": "String",
@@ -103,6 +115,18 @@ Object {
     },
     "AssetParameters97e6563aeb743805ef5d4bbbbe29d6b3bb28c0544c9cca24a203de835bd21784S3VersionKey267A8045": Object {
       "Description": "S3 key for asset version \\"97e6563aeb743805ef5d4bbbbe29d6b3bb28c0544c9cca24a203de835bd21784\\"",
+      "Type": "String",
+    },
+    "AssetParametersbe1d65ce9ad73a51bd3abc174d42e7842a37bf3fe7f6ca1751a3586850c193f1ArtifactHash25FA0091": Object {
+      "Description": "Artifact hash for asset \\"be1d65ce9ad73a51bd3abc174d42e7842a37bf3fe7f6ca1751a3586850c193f1\\"",
+      "Type": "String",
+    },
+    "AssetParametersbe1d65ce9ad73a51bd3abc174d42e7842a37bf3fe7f6ca1751a3586850c193f1S3BucketF288BC18": Object {
+      "Description": "S3 bucket for asset \\"be1d65ce9ad73a51bd3abc174d42e7842a37bf3fe7f6ca1751a3586850c193f1\\"",
+      "Type": "String",
+    },
+    "AssetParametersbe1d65ce9ad73a51bd3abc174d42e7842a37bf3fe7f6ca1751a3586850c193f1S3VersionKeyF1F97C53": Object {
+      "Description": "S3 key for asset version \\"be1d65ce9ad73a51bd3abc174d42e7842a37bf3fe7f6ca1751a3586850c193f1\\"",
       "Type": "String",
     },
     "AssetParametersc24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cfArtifactHash85F58E48": Object {
@@ -117,18 +141,6 @@ Object {
       "Description": "S3 key for asset version \\"c24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cf\\"",
       "Type": "String",
     },
-    "AssetParametersc9fda6b85a877755ac17a5e66417061d1f980faf9e1f346a6c8cecb5ae8695e9ArtifactHash98105084": Object {
-      "Description": "Artifact hash for asset \\"c9fda6b85a877755ac17a5e66417061d1f980faf9e1f346a6c8cecb5ae8695e9\\"",
-      "Type": "String",
-    },
-    "AssetParametersc9fda6b85a877755ac17a5e66417061d1f980faf9e1f346a6c8cecb5ae8695e9S3Bucket5CAE6558": Object {
-      "Description": "S3 bucket for asset \\"c9fda6b85a877755ac17a5e66417061d1f980faf9e1f346a6c8cecb5ae8695e9\\"",
-      "Type": "String",
-    },
-    "AssetParametersc9fda6b85a877755ac17a5e66417061d1f980faf9e1f346a6c8cecb5ae8695e9S3VersionKey854B18C5": Object {
-      "Description": "S3 key for asset version \\"c9fda6b85a877755ac17a5e66417061d1f980faf9e1f346a6c8cecb5ae8695e9\\"",
-      "Type": "String",
-    },
     "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68ArtifactHashD9A515C3": Object {
       "Description": "Artifact hash for asset \\"e9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68\\"",
       "Type": "String",
@@ -139,18 +151,6 @@ Object {
     },
     "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3VersionKeyE415415F": Object {
       "Description": "S3 key for asset version \\"e9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68\\"",
-      "Type": "String",
-    },
-    "AssetParametersec2edcafd50beaf4d4a0a66a3013d96bd722eb210653b17993f3c42e7e77a271ArtifactHash49E0474B": Object {
-      "Description": "Artifact hash for asset \\"ec2edcafd50beaf4d4a0a66a3013d96bd722eb210653b17993f3c42e7e77a271\\"",
-      "Type": "String",
-    },
-    "AssetParametersec2edcafd50beaf4d4a0a66a3013d96bd722eb210653b17993f3c42e7e77a271S3Bucket6BF7E20A": Object {
-      "Description": "S3 bucket for asset \\"ec2edcafd50beaf4d4a0a66a3013d96bd722eb210653b17993f3c42e7e77a271\\"",
-      "Type": "String",
-    },
-    "AssetParametersec2edcafd50beaf4d4a0a66a3013d96bd722eb210653b17993f3c42e7e77a271S3VersionKey78659F17": Object {
-      "Description": "S3 key for asset version \\"ec2edcafd50beaf4d4a0a66a3013d96bd722eb210653b17993f3c42e7e77a271\\"",
       "Type": "String",
     },
   },
@@ -794,7 +794,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters4f217792f9ba05f14c44a222a9fc2e677586f18493e25af99827156872bf79e1S3Bucket3936E572",
+            "Ref": "AssetParameters0f40b7675b3b9a3b611a984f192c2797f0a4c0b8c475cb89da4497e9762c0614S3Bucket315E87E0",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -807,7 +807,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters4f217792f9ba05f14c44a222a9fc2e677586f18493e25af99827156872bf79e1S3VersionKeyDFC5B004",
+                          "Ref": "AssetParameters0f40b7675b3b9a3b611a984f192c2797f0a4c0b8c475cb89da4497e9762c0614S3VersionKey4955B657",
                         },
                       ],
                     },
@@ -820,7 +820,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters4f217792f9ba05f14c44a222a9fc2e677586f18493e25af99827156872bf79e1S3VersionKeyDFC5B004",
+                          "Ref": "AssetParameters0f40b7675b3b9a3b611a984f192c2797f0a4c0b8c475cb89da4497e9762c0614S3VersionKey4955B657",
                         },
                       ],
                     },
@@ -2337,7 +2337,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc9fda6b85a877755ac17a5e66417061d1f980faf9e1f346a6c8cecb5ae8695e9S3Bucket5CAE6558",
+            "Ref": "AssetParameters763da6b59c5feaad32ef8dd7fcba1b4815d75fcab6e3fd81b24041895c86d862S3Bucket6CA4A500",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -2350,7 +2350,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc9fda6b85a877755ac17a5e66417061d1f980faf9e1f346a6c8cecb5ae8695e9S3VersionKey854B18C5",
+                          "Ref": "AssetParameters763da6b59c5feaad32ef8dd7fcba1b4815d75fcab6e3fd81b24041895c86d862S3VersionKey249E8EF0",
                         },
                       ],
                     },
@@ -2363,7 +2363,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc9fda6b85a877755ac17a5e66417061d1f980faf9e1f346a6c8cecb5ae8695e9S3VersionKey854B18C5",
+                          "Ref": "AssetParameters763da6b59c5feaad32ef8dd7fcba1b4815d75fcab6e3fd81b24041895c86d862S3VersionKey249E8EF0",
                         },
                       ],
                     },
@@ -2639,7 +2639,7 @@ Object {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParametersec2edcafd50beaf4d4a0a66a3013d96bd722eb210653b17993f3c42e7e77a271S3Bucket6BF7E20A",
+            "Ref": "AssetParametersbe1d65ce9ad73a51bd3abc174d42e7842a37bf3fe7f6ca1751a3586850c193f1S3BucketF288BC18",
           },
         ],
         "SourceObjectKeys": Array [
@@ -2654,7 +2654,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersec2edcafd50beaf4d4a0a66a3013d96bd722eb210653b17993f3c42e7e77a271S3VersionKey78659F17",
+                          "Ref": "AssetParametersbe1d65ce9ad73a51bd3abc174d42e7842a37bf3fe7f6ca1751a3586850c193f1S3VersionKeyF1F97C53",
                         },
                       ],
                     },
@@ -2667,7 +2667,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersec2edcafd50beaf4d4a0a66a3013d96bd722eb210653b17993f3c42e7e77a271S3VersionKey78659F17",
+                          "Ref": "AssetParametersbe1d65ce9ad73a51bd3abc174d42e7842a37bf3fe7f6ca1751a3586850c193f1S3VersionKeyF1F97C53",
                         },
                       ],
                     },
@@ -2846,7 +2846,7 @@ function handler(event) {
                 Object {
                   "Ref": "AWS::Region",
                 },
-                "TestConstrubWebAppResponseFunction1F387BCC",
+                "TestConstubWebAppResponseFunction1F387BCC",
               ],
             ],
           },
@@ -2859,7 +2859,7 @@ function handler(event) {
               Object {
                 "Ref": "AWS::Region",
               },
-              "TestConstrubWebAppResponseFunction1F387BCC",
+              "TestConstubWebAppResponseFunction1F387BCC",
             ],
           ],
         },
@@ -3032,7 +3032,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParametersec2edcafd50beaf4d4a0a66a3013d96bd722eb210653b17993f3c42e7e77a271S3Bucket6BF7E20A",
+                        "Ref": "AssetParametersbe1d65ce9ad73a51bd3abc174d42e7842a37bf3fe7f6ca1751a3586850c193f1S3BucketF288BC18",
                       },
                     ],
                   ],
@@ -3047,7 +3047,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParametersec2edcafd50beaf4d4a0a66a3013d96bd722eb210653b17993f3c42e7e77a271S3Bucket6BF7E20A",
+                        "Ref": "AssetParametersbe1d65ce9ad73a51bd3abc174d42e7842a37bf3fe7f6ca1751a3586850c193f1S3BucketF288BC18",
                       },
                       "/*",
                     ],
@@ -3277,6 +3277,18 @@ Object {
       "Description": "S3 key for asset version \\"0dfb0b3b18599bad760f45b02537f770c6d07bfba2daa5407d82b6306d92963d\\"",
       "Type": "String",
     },
+    "AssetParameters0f40b7675b3b9a3b611a984f192c2797f0a4c0b8c475cb89da4497e9762c0614ArtifactHashD93E46BF": Object {
+      "Description": "Artifact hash for asset \\"0f40b7675b3b9a3b611a984f192c2797f0a4c0b8c475cb89da4497e9762c0614\\"",
+      "Type": "String",
+    },
+    "AssetParameters0f40b7675b3b9a3b611a984f192c2797f0a4c0b8c475cb89da4497e9762c0614S3Bucket315E87E0": Object {
+      "Description": "S3 bucket for asset \\"0f40b7675b3b9a3b611a984f192c2797f0a4c0b8c475cb89da4497e9762c0614\\"",
+      "Type": "String",
+    },
+    "AssetParameters0f40b7675b3b9a3b611a984f192c2797f0a4c0b8c475cb89da4497e9762c0614S3VersionKey4955B657": Object {
+      "Description": "S3 key for asset version \\"0f40b7675b3b9a3b611a984f192c2797f0a4c0b8c475cb89da4497e9762c0614\\"",
+      "Type": "String",
+    },
     "AssetParameters1ba28ce93db643201d8613eed4b49e8bfdbb812137021b400028887aa6cbfc21ArtifactHashCD81A433": Object {
       "Description": "Artifact hash for asset \\"1ba28ce93db643201d8613eed4b49e8bfdbb812137021b400028887aa6cbfc21\\"",
       "Type": "String",
@@ -3299,18 +3311,6 @@ Object {
     },
     "AssetParameters29569ad5bf9948e4744218e7f7440b327629220ab1ca1cce582477911c74780bS3VersionKeyB69597A2": Object {
       "Description": "S3 key for asset version \\"29569ad5bf9948e4744218e7f7440b327629220ab1ca1cce582477911c74780b\\"",
-      "Type": "String",
-    },
-    "AssetParameters4f217792f9ba05f14c44a222a9fc2e677586f18493e25af99827156872bf79e1ArtifactHash6048D2E6": Object {
-      "Description": "Artifact hash for asset \\"4f217792f9ba05f14c44a222a9fc2e677586f18493e25af99827156872bf79e1\\"",
-      "Type": "String",
-    },
-    "AssetParameters4f217792f9ba05f14c44a222a9fc2e677586f18493e25af99827156872bf79e1S3Bucket3936E572": Object {
-      "Description": "S3 bucket for asset \\"4f217792f9ba05f14c44a222a9fc2e677586f18493e25af99827156872bf79e1\\"",
-      "Type": "String",
-    },
-    "AssetParameters4f217792f9ba05f14c44a222a9fc2e677586f18493e25af99827156872bf79e1S3VersionKeyDFC5B004": Object {
-      "Description": "S3 key for asset version \\"4f217792f9ba05f14c44a222a9fc2e677586f18493e25af99827156872bf79e1\\"",
       "Type": "String",
     },
     "AssetParameters59be5a60739e4f0f9b881492bce41ccffa8d47d16b0a4d640db1bb8200f48bd5ArtifactHash76FE5C86": Object {
@@ -3337,6 +3337,18 @@ Object {
       "Description": "S3 key for asset version \\"67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24\\"",
       "Type": "String",
     },
+    "AssetParameters763da6b59c5feaad32ef8dd7fcba1b4815d75fcab6e3fd81b24041895c86d862ArtifactHash497B15E5": Object {
+      "Description": "Artifact hash for asset \\"763da6b59c5feaad32ef8dd7fcba1b4815d75fcab6e3fd81b24041895c86d862\\"",
+      "Type": "String",
+    },
+    "AssetParameters763da6b59c5feaad32ef8dd7fcba1b4815d75fcab6e3fd81b24041895c86d862S3Bucket6CA4A500": Object {
+      "Description": "S3 bucket for asset \\"763da6b59c5feaad32ef8dd7fcba1b4815d75fcab6e3fd81b24041895c86d862\\"",
+      "Type": "String",
+    },
+    "AssetParameters763da6b59c5feaad32ef8dd7fcba1b4815d75fcab6e3fd81b24041895c86d862S3VersionKey249E8EF0": Object {
+      "Description": "S3 key for asset version \\"763da6b59c5feaad32ef8dd7fcba1b4815d75fcab6e3fd81b24041895c86d862\\"",
+      "Type": "String",
+    },
     "AssetParameters7af6295e521fd55af94332393ceffb3e866aac4dc4956321f7918f21e72199e4ArtifactHash5E28809B": Object {
       "Description": "Artifact hash for asset \\"7af6295e521fd55af94332393ceffb3e866aac4dc4956321f7918f21e72199e4\\"",
       "Type": "String",
@@ -3361,6 +3373,18 @@ Object {
       "Description": "S3 key for asset version \\"97e6563aeb743805ef5d4bbbbe29d6b3bb28c0544c9cca24a203de835bd21784\\"",
       "Type": "String",
     },
+    "AssetParametersbe1d65ce9ad73a51bd3abc174d42e7842a37bf3fe7f6ca1751a3586850c193f1ArtifactHash25FA0091": Object {
+      "Description": "Artifact hash for asset \\"be1d65ce9ad73a51bd3abc174d42e7842a37bf3fe7f6ca1751a3586850c193f1\\"",
+      "Type": "String",
+    },
+    "AssetParametersbe1d65ce9ad73a51bd3abc174d42e7842a37bf3fe7f6ca1751a3586850c193f1S3BucketF288BC18": Object {
+      "Description": "S3 bucket for asset \\"be1d65ce9ad73a51bd3abc174d42e7842a37bf3fe7f6ca1751a3586850c193f1\\"",
+      "Type": "String",
+    },
+    "AssetParametersbe1d65ce9ad73a51bd3abc174d42e7842a37bf3fe7f6ca1751a3586850c193f1S3VersionKeyF1F97C53": Object {
+      "Description": "S3 key for asset version \\"be1d65ce9ad73a51bd3abc174d42e7842a37bf3fe7f6ca1751a3586850c193f1\\"",
+      "Type": "String",
+    },
     "AssetParametersc24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cfArtifactHash85F58E48": Object {
       "Description": "Artifact hash for asset \\"c24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cf\\"",
       "Type": "String",
@@ -3373,18 +3397,6 @@ Object {
       "Description": "S3 key for asset version \\"c24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cf\\"",
       "Type": "String",
     },
-    "AssetParametersc9fda6b85a877755ac17a5e66417061d1f980faf9e1f346a6c8cecb5ae8695e9ArtifactHash98105084": Object {
-      "Description": "Artifact hash for asset \\"c9fda6b85a877755ac17a5e66417061d1f980faf9e1f346a6c8cecb5ae8695e9\\"",
-      "Type": "String",
-    },
-    "AssetParametersc9fda6b85a877755ac17a5e66417061d1f980faf9e1f346a6c8cecb5ae8695e9S3Bucket5CAE6558": Object {
-      "Description": "S3 bucket for asset \\"c9fda6b85a877755ac17a5e66417061d1f980faf9e1f346a6c8cecb5ae8695e9\\"",
-      "Type": "String",
-    },
-    "AssetParametersc9fda6b85a877755ac17a5e66417061d1f980faf9e1f346a6c8cecb5ae8695e9S3VersionKey854B18C5": Object {
-      "Description": "S3 key for asset version \\"c9fda6b85a877755ac17a5e66417061d1f980faf9e1f346a6c8cecb5ae8695e9\\"",
-      "Type": "String",
-    },
     "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68ArtifactHashD9A515C3": Object {
       "Description": "Artifact hash for asset \\"e9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68\\"",
       "Type": "String",
@@ -3395,18 +3407,6 @@ Object {
     },
     "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3VersionKeyE415415F": Object {
       "Description": "S3 key for asset version \\"e9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68\\"",
-      "Type": "String",
-    },
-    "AssetParametersec2edcafd50beaf4d4a0a66a3013d96bd722eb210653b17993f3c42e7e77a271ArtifactHash49E0474B": Object {
-      "Description": "Artifact hash for asset \\"ec2edcafd50beaf4d4a0a66a3013d96bd722eb210653b17993f3c42e7e77a271\\"",
-      "Type": "String",
-    },
-    "AssetParametersec2edcafd50beaf4d4a0a66a3013d96bd722eb210653b17993f3c42e7e77a271S3Bucket6BF7E20A": Object {
-      "Description": "S3 bucket for asset \\"ec2edcafd50beaf4d4a0a66a3013d96bd722eb210653b17993f3c42e7e77a271\\"",
-      "Type": "String",
-    },
-    "AssetParametersec2edcafd50beaf4d4a0a66a3013d96bd722eb210653b17993f3c42e7e77a271S3VersionKey78659F17": Object {
-      "Description": "S3 key for asset version \\"ec2edcafd50beaf4d4a0a66a3013d96bd722eb210653b17993f3c42e7e77a271\\"",
       "Type": "String",
     },
   },
@@ -4199,7 +4199,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters4f217792f9ba05f14c44a222a9fc2e677586f18493e25af99827156872bf79e1S3Bucket3936E572",
+            "Ref": "AssetParameters0f40b7675b3b9a3b611a984f192c2797f0a4c0b8c475cb89da4497e9762c0614S3Bucket315E87E0",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -4212,7 +4212,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters4f217792f9ba05f14c44a222a9fc2e677586f18493e25af99827156872bf79e1S3VersionKeyDFC5B004",
+                          "Ref": "AssetParameters0f40b7675b3b9a3b611a984f192c2797f0a4c0b8c475cb89da4497e9762c0614S3VersionKey4955B657",
                         },
                       ],
                     },
@@ -4225,7 +4225,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters4f217792f9ba05f14c44a222a9fc2e677586f18493e25af99827156872bf79e1S3VersionKeyDFC5B004",
+                          "Ref": "AssetParameters0f40b7675b3b9a3b611a984f192c2797f0a4c0b8c475cb89da4497e9762c0614S3VersionKey4955B657",
                         },
                       ],
                     },
@@ -5764,7 +5764,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc9fda6b85a877755ac17a5e66417061d1f980faf9e1f346a6c8cecb5ae8695e9S3Bucket5CAE6558",
+            "Ref": "AssetParameters763da6b59c5feaad32ef8dd7fcba1b4815d75fcab6e3fd81b24041895c86d862S3Bucket6CA4A500",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -5777,7 +5777,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc9fda6b85a877755ac17a5e66417061d1f980faf9e1f346a6c8cecb5ae8695e9S3VersionKey854B18C5",
+                          "Ref": "AssetParameters763da6b59c5feaad32ef8dd7fcba1b4815d75fcab6e3fd81b24041895c86d862S3VersionKey249E8EF0",
                         },
                       ],
                     },
@@ -5790,7 +5790,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc9fda6b85a877755ac17a5e66417061d1f980faf9e1f346a6c8cecb5ae8695e9S3VersionKey854B18C5",
+                          "Ref": "AssetParameters763da6b59c5feaad32ef8dd7fcba1b4815d75fcab6e3fd81b24041895c86d862S3VersionKey249E8EF0",
                         },
                       ],
                     },
@@ -6118,7 +6118,7 @@ Object {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParametersec2edcafd50beaf4d4a0a66a3013d96bd722eb210653b17993f3c42e7e77a271S3Bucket6BF7E20A",
+            "Ref": "AssetParametersbe1d65ce9ad73a51bd3abc174d42e7842a37bf3fe7f6ca1751a3586850c193f1S3BucketF288BC18",
           },
         ],
         "SourceObjectKeys": Array [
@@ -6133,7 +6133,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersec2edcafd50beaf4d4a0a66a3013d96bd722eb210653b17993f3c42e7e77a271S3VersionKey78659F17",
+                          "Ref": "AssetParametersbe1d65ce9ad73a51bd3abc174d42e7842a37bf3fe7f6ca1751a3586850c193f1S3VersionKeyF1F97C53",
                         },
                       ],
                     },
@@ -6146,7 +6146,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersec2edcafd50beaf4d4a0a66a3013d96bd722eb210653b17993f3c42e7e77a271S3VersionKey78659F17",
+                          "Ref": "AssetParametersbe1d65ce9ad73a51bd3abc174d42e7842a37bf3fe7f6ca1751a3586850c193f1S3VersionKeyF1F97C53",
                         },
                       ],
                     },
@@ -6551,7 +6551,7 @@ function handler(event) {
                 Object {
                   "Ref": "AWS::Region",
                 },
-                "TestConstrubWebAppResponseFunction1F387BCC",
+                "TestConstubWebAppResponseFunction1F387BCC",
               ],
             ],
           },
@@ -6564,7 +6564,7 @@ function handler(event) {
               Object {
                 "Ref": "AWS::Region",
               },
-              "TestConstrubWebAppResponseFunction1F387BCC",
+              "TestConstubWebAppResponseFunction1F387BCC",
             ],
           ],
         },
@@ -6737,7 +6737,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParametersec2edcafd50beaf4d4a0a66a3013d96bd722eb210653b17993f3c42e7e77a271S3Bucket6BF7E20A",
+                        "Ref": "AssetParametersbe1d65ce9ad73a51bd3abc174d42e7842a37bf3fe7f6ca1751a3586850c193f1S3BucketF288BC18",
                       },
                     ],
                   ],
@@ -6752,7 +6752,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParametersec2edcafd50beaf4d4a0a66a3013d96bd722eb210653b17993f3c42e7e77a271S3Bucket6BF7E20A",
+                        "Ref": "AssetParametersbe1d65ce9ad73a51bd3abc174d42e7842a37bf3fe7f6ca1751a3586850c193f1S3BucketF288BC18",
                       },
                       "/*",
                     ],

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -808,7 +808,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters4f217792f9ba05f14c44a222a9fc2e677586f18493e25af99827156872bf79e1S3Bucket3936E572
+          Ref: AssetParameters0f40b7675b3b9a3b611a984f192c2797f0a4c0b8c475cb89da4497e9762c0614S3Bucket315E87E0
         S3Key:
           Fn::Join:
             - ""
@@ -816,12 +816,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters4f217792f9ba05f14c44a222a9fc2e677586f18493e25af99827156872bf79e1S3VersionKeyDFC5B004
+                      - Ref: AssetParameters0f40b7675b3b9a3b611a984f192c2797f0a4c0b8c475cb89da4497e9762c0614S3VersionKey4955B657
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters4f217792f9ba05f14c44a222a9fc2e677586f18493e25af99827156872bf79e1S3VersionKeyDFC5B004
+                      - Ref: AssetParameters0f40b7675b3b9a3b611a984f192c2797f0a4c0b8c475cb89da4497e9762c0614S3VersionKey4955B657
       Role:
         Fn::GetAtt:
           - ConstructHubIngestionServiceRole6380BAB6
@@ -1108,7 +1108,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParametersc9fda6b85a877755ac17a5e66417061d1f980faf9e1f346a6c8cecb5ae8695e9S3Bucket5CAE6558
+          Ref: AssetParameters763da6b59c5feaad32ef8dd7fcba1b4815d75fcab6e3fd81b24041895c86d862S3Bucket6CA4A500
         S3Key:
           Fn::Join:
             - ""
@@ -1116,12 +1116,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersc9fda6b85a877755ac17a5e66417061d1f980faf9e1f346a6c8cecb5ae8695e9S3VersionKey854B18C5
+                      - Ref: AssetParameters763da6b59c5feaad32ef8dd7fcba1b4815d75fcab6e3fd81b24041895c86d862S3VersionKey249E8EF0
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersc9fda6b85a877755ac17a5e66417061d1f980faf9e1f346a6c8cecb5ae8695e9S3VersionKey854B18C5
+                      - Ref: AssetParameters763da6b59c5feaad32ef8dd7fcba1b4815d75fcab6e3fd81b24041895c86d862S3VersionKey249E8EF0
       Role:
         Fn::GetAtt:
           - ConstructHubTransliteratorServiceRole0F8A20C8
@@ -1449,7 +1449,7 @@ Resources:
         Fn::Join:
           - ""
           - - Ref: AWS::Region
-            - devConstruubWebAppResponseFunction3452125C
+            - devConstrubWebAppResponseFunction3452125C
       AutoPublish: true
       FunctionCode: >-
         "use strict";
@@ -1473,7 +1473,7 @@ Resources:
           Fn::Join:
             - ""
             - - Ref: AWS::Region
-              - devConstruubWebAppResponseFunction3452125C
+              - devConstrubWebAppResponseFunction3452125C
         Runtime: cloudfront-js-1.0
   ConstructHubWebAppDistributionOrigin1S3Origin694AF937:
     Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
@@ -1585,7 +1585,7 @@ Resources:
           - CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536
           - Arn
       SourceBucketNames:
-        - Ref: AssetParametersec2edcafd50beaf4d4a0a66a3013d96bd722eb210653b17993f3c42e7e77a271S3Bucket6BF7E20A
+        - Ref: AssetParametersbe1d65ce9ad73a51bd3abc174d42e7842a37bf3fe7f6ca1751a3586850c193f1S3BucketF288BC18
       SourceObjectKeys:
         - Fn::Join:
             - ""
@@ -1593,12 +1593,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersec2edcafd50beaf4d4a0a66a3013d96bd722eb210653b17993f3c42e7e77a271S3VersionKey78659F17
+                      - Ref: AssetParametersbe1d65ce9ad73a51bd3abc174d42e7842a37bf3fe7f6ca1751a3586850c193f1S3VersionKeyF1F97C53
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersec2edcafd50beaf4d4a0a66a3013d96bd722eb210653b17993f3c42e7e77a271S3VersionKey78659F17
+                      - Ref: AssetParametersbe1d65ce9ad73a51bd3abc174d42e7842a37bf3fe7f6ca1751a3586850c193f1S3VersionKeyF1F97C53
       DestinationBucketName:
         Ref: ConstructHubWebAppWebsiteBucket4B2B9DB2
       Prune: true
@@ -1806,13 +1806,13 @@ Resources:
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParametersec2edcafd50beaf4d4a0a66a3013d96bd722eb210653b17993f3c42e7e77a271S3Bucket6BF7E20A
+                    - Ref: AssetParametersbe1d65ce9ad73a51bd3abc174d42e7842a37bf3fe7f6ca1751a3586850c193f1S3BucketF288BC18
               - Fn::Join:
                   - ""
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParametersec2edcafd50beaf4d4a0a66a3013d96bd722eb210653b17993f3c42e7e77a271S3Bucket6BF7E20A
+                    - Ref: AssetParametersbe1d65ce9ad73a51bd3abc174d42e7842a37bf3fe7f6ca1751a3586850c193f1S3BucketF288BC18
                     - /*
           - Action:
               - s3:GetObject*
@@ -1889,18 +1889,18 @@ Outputs:
     Export:
       Name: ConstructHubDomainName
 Parameters:
-  AssetParameters4f217792f9ba05f14c44a222a9fc2e677586f18493e25af99827156872bf79e1S3Bucket3936E572:
+  AssetParameters0f40b7675b3b9a3b611a984f192c2797f0a4c0b8c475cb89da4497e9762c0614S3Bucket315E87E0:
     Type: String
     Description: S3 bucket for asset
-      "4f217792f9ba05f14c44a222a9fc2e677586f18493e25af99827156872bf79e1"
-  AssetParameters4f217792f9ba05f14c44a222a9fc2e677586f18493e25af99827156872bf79e1S3VersionKeyDFC5B004:
+      "0f40b7675b3b9a3b611a984f192c2797f0a4c0b8c475cb89da4497e9762c0614"
+  AssetParameters0f40b7675b3b9a3b611a984f192c2797f0a4c0b8c475cb89da4497e9762c0614S3VersionKey4955B657:
     Type: String
     Description: S3 key for asset version
-      "4f217792f9ba05f14c44a222a9fc2e677586f18493e25af99827156872bf79e1"
-  AssetParameters4f217792f9ba05f14c44a222a9fc2e677586f18493e25af99827156872bf79e1ArtifactHash6048D2E6:
+      "0f40b7675b3b9a3b611a984f192c2797f0a4c0b8c475cb89da4497e9762c0614"
+  AssetParameters0f40b7675b3b9a3b611a984f192c2797f0a4c0b8c475cb89da4497e9762c0614ArtifactHashD93E46BF:
     Type: String
     Description: Artifact hash for asset
-      "4f217792f9ba05f14c44a222a9fc2e677586f18493e25af99827156872bf79e1"
+      "0f40b7675b3b9a3b611a984f192c2797f0a4c0b8c475cb89da4497e9762c0614"
   AssetParameters0dfb0b3b18599bad760f45b02537f770c6d07bfba2daa5407d82b6306d92963dS3Bucket7B3413EA:
     Type: String
     Description: S3 bucket for asset
@@ -1913,18 +1913,18 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "0dfb0b3b18599bad760f45b02537f770c6d07bfba2daa5407d82b6306d92963d"
-  AssetParametersc9fda6b85a877755ac17a5e66417061d1f980faf9e1f346a6c8cecb5ae8695e9S3Bucket5CAE6558:
+  AssetParameters763da6b59c5feaad32ef8dd7fcba1b4815d75fcab6e3fd81b24041895c86d862S3Bucket6CA4A500:
     Type: String
     Description: S3 bucket for asset
-      "c9fda6b85a877755ac17a5e66417061d1f980faf9e1f346a6c8cecb5ae8695e9"
-  AssetParametersc9fda6b85a877755ac17a5e66417061d1f980faf9e1f346a6c8cecb5ae8695e9S3VersionKey854B18C5:
+      "763da6b59c5feaad32ef8dd7fcba1b4815d75fcab6e3fd81b24041895c86d862"
+  AssetParameters763da6b59c5feaad32ef8dd7fcba1b4815d75fcab6e3fd81b24041895c86d862S3VersionKey249E8EF0:
     Type: String
     Description: S3 key for asset version
-      "c9fda6b85a877755ac17a5e66417061d1f980faf9e1f346a6c8cecb5ae8695e9"
-  AssetParametersc9fda6b85a877755ac17a5e66417061d1f980faf9e1f346a6c8cecb5ae8695e9ArtifactHash98105084:
+      "763da6b59c5feaad32ef8dd7fcba1b4815d75fcab6e3fd81b24041895c86d862"
+  AssetParameters763da6b59c5feaad32ef8dd7fcba1b4815d75fcab6e3fd81b24041895c86d862ArtifactHash497B15E5:
     Type: String
     Description: Artifact hash for asset
-      "c9fda6b85a877755ac17a5e66417061d1f980faf9e1f346a6c8cecb5ae8695e9"
+      "763da6b59c5feaad32ef8dd7fcba1b4815d75fcab6e3fd81b24041895c86d862"
   AssetParameters67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24S3Bucket4D46ABB5:
     Type: String
     Description: S3 bucket for asset
@@ -1985,18 +1985,18 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "c24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cf"
-  AssetParametersec2edcafd50beaf4d4a0a66a3013d96bd722eb210653b17993f3c42e7e77a271S3Bucket6BF7E20A:
+  AssetParametersbe1d65ce9ad73a51bd3abc174d42e7842a37bf3fe7f6ca1751a3586850c193f1S3BucketF288BC18:
     Type: String
     Description: S3 bucket for asset
-      "ec2edcafd50beaf4d4a0a66a3013d96bd722eb210653b17993f3c42e7e77a271"
-  AssetParametersec2edcafd50beaf4d4a0a66a3013d96bd722eb210653b17993f3c42e7e77a271S3VersionKey78659F17:
+      "be1d65ce9ad73a51bd3abc174d42e7842a37bf3fe7f6ca1751a3586850c193f1"
+  AssetParametersbe1d65ce9ad73a51bd3abc174d42e7842a37bf3fe7f6ca1751a3586850c193f1S3VersionKeyF1F97C53:
     Type: String
     Description: S3 key for asset version
-      "ec2edcafd50beaf4d4a0a66a3013d96bd722eb210653b17993f3c42e7e77a271"
-  AssetParametersec2edcafd50beaf4d4a0a66a3013d96bd722eb210653b17993f3c42e7e77a271ArtifactHash49E0474B:
+      "be1d65ce9ad73a51bd3abc174d42e7842a37bf3fe7f6ca1751a3586850c193f1"
+  AssetParametersbe1d65ce9ad73a51bd3abc174d42e7842a37bf3fe7f6ca1751a3586850c193f1ArtifactHash25FA0091:
     Type: String
     Description: Artifact hash for asset
-      "ec2edcafd50beaf4d4a0a66a3013d96bd722eb210653b17993f3c42e7e77a271"
+      "be1d65ce9ad73a51bd3abc174d42e7842a37bf3fe7f6ca1751a3586850c193f1"
   AssetParameters59be5a60739e4f0f9b881492bce41ccffa8d47d16b0a4d640db1bb8200f48bd5S3BucketFA2341B6:
     Type: String
     Description: S3 bucket for asset

--- a/src/backend/ingestion/constants.lambda-shared.ts
+++ b/src/backend/ingestion/constants.lambda-shared.ts
@@ -1,3 +1,0 @@
-export const enum MetricName {
-  FOUND_LICENSE_FILE = 'FoundLicenseFile',
-}

--- a/src/backend/ingestion/constants.ts
+++ b/src/backend/ingestion/constants.ts
@@ -1,0 +1,7 @@
+export const METRICS_NAMESPACE = 'ConstructHub/Ingestion';
+
+export const enum MetricName {
+  FOUND_LICENSE_FILE = 'FoundLicenseFile',
+  INELIGIBLE_LICENSE = 'IneligibleLicense',
+  MISMATCHED_NAME_OR_VERSION = 'MismatchedNameOrVersion',
+}

--- a/src/backend/ingestion/index.ts
+++ b/src/backend/ingestion/index.ts
@@ -1,11 +1,11 @@
-import { ComparisonOperator, IAlarm } from '@aws-cdk/aws-cloudwatch';
+import { ComparisonOperator, IAlarm, Metric, MetricOptions, Statistic } from '@aws-cdk/aws-cloudwatch';
 import { IGrantable, IPrincipal } from '@aws-cdk/aws-iam';
 import { SqsEventSource } from '@aws-cdk/aws-lambda-event-sources';
 import { IBucket } from '@aws-cdk/aws-s3';
 import { IQueue, Queue, QueueEncryption } from '@aws-cdk/aws-sqs';
 import { Construct, Duration } from '@aws-cdk/core';
 import { Monitoring } from '../../monitoring';
-
+import { MetricName, METRICS_NAMESPACE } from './constants';
 import { Ingestion as Handler } from './ingestion';
 
 export interface IngestionProps {
@@ -75,5 +75,35 @@ export class Ingestion extends Construct implements IGrantable {
         evaluationPeriods: 1,
         threshold: 1,
       });
+  }
+
+  public metricFoundLicenseFile(opts?: MetricOptions): Metric {
+    return new Metric({
+      period: Duration.minutes(5),
+      statistic: Statistic.SUM,
+      ...opts,
+      metricName: MetricName.FOUND_LICENSE_FILE,
+      namespace: METRICS_NAMESPACE,
+    });
+  }
+
+  public metricIneligibleLicense(opts?: MetricOptions): Metric {
+    return new Metric({
+      period: Duration.minutes(5),
+      statistic: Statistic.SUM,
+      ...opts,
+      metricName: MetricName.INELIGIBLE_LICENSE,
+      namespace: METRICS_NAMESPACE,
+    });
+  }
+
+  public metricMismatchedNameOrVersion(opts?: MetricOptions): Metric {
+    return new Metric({
+      period: Duration.minutes(5),
+      statistic: Statistic.SUM,
+      ...opts,
+      metricName: MetricName.MISMATCHED_NAME_OR_VERSION,
+      namespace: METRICS_NAMESPACE,
+    });
   }
 }

--- a/src/backend/ingestion/ingestion.lambda.ts
+++ b/src/backend/ingestion/ingestion.lambda.ts
@@ -3,7 +3,8 @@ import { URL } from 'url';
 import { createGunzip } from 'zlib';
 
 import { validateAssembly } from '@jsii/spec';
-import { metricScope, Unit } from 'aws-embedded-metrics';
+import { metricScope, Configuration, Unit } from 'aws-embedded-metrics';
+import Environments from 'aws-embedded-metrics/lib/environment/Environments';
 import type { Context, SQSEvent } from 'aws-lambda';
 import { extract } from 'tar-stream';
 import * as aws from '../shared/aws.lambda-shared';
@@ -11,10 +12,16 @@ import * as constants from '../shared/constants';
 import { requireEnv } from '../shared/env.lambda-shared';
 import { IngestionInput } from '../shared/ingestion-input.lambda-shared';
 import { integrity } from '../shared/integrity.lambda-shared';
-import { MetricName } from './constants.lambda-shared';
+import { MetricName, METRICS_NAMESPACE } from './constants';
 
-export async function handler(event: SQSEvent, context: Context) {
+Configuration.environmentOverride = Environments.Lambda;
+Configuration.namespace = METRICS_NAMESPACE;
+
+export const handler = metricScope((metrics) => async (event: SQSEvent, context: Context) => {
   console.log(`Event: ${JSON.stringify(event, null, 2)}`);
+
+  // Clear out the default dimensions, we won't need them.
+  metrics.setDimensions();
 
   const BUCKET_NAME = requireEnv('BUCKET_NAME');
 
@@ -41,9 +48,10 @@ export async function handler(event: SQSEvent, context: Context) {
     }
 
     const tar = await gunzip(Buffer.from(tarball.Body!));
-    const { dotJsii, licenseText } = await new Promise<{ dotJsii: Buffer; licenseText?: Buffer }>((ok, ko) => {
+    const { dotJsii, licenseText, packageJson } = await new Promise<{ dotJsii: Buffer; licenseText?: Buffer; packageJson: Buffer }>((ok, ko) => {
       let dotJsiiBuffer: Buffer | undefined;
       let licenseTextBuffer: Buffer | undefined;
+      let packageJsonData: Buffer | undefined;
       extract()
         .on('entry', (headers, stream, next) => {
           const chunks = new Array<Buffer>();
@@ -52,6 +60,15 @@ export async function handler(event: SQSEvent, context: Context) {
               .once('error', ko)
               .once('end', () => {
                 dotJsiiBuffer = Buffer.concat(chunks);
+                // Skip on next runLoop iteration so we avoid filling the stack.
+                setImmediate(next);
+              })
+              .resume();
+          } else if (headers.name === 'package/package.json') {
+            return stream.on('data', (chunk) => chunks.push(Buffer.from(chunk)))
+              .once('error', ko)
+              .once('end', () => {
+                packageJsonData = Buffer.concat(chunks);
                 // Skip on next runLoop iteration so we avoid filling the stack.
                 setImmediate(next);
               })
@@ -73,8 +90,10 @@ export async function handler(event: SQSEvent, context: Context) {
         .once('close', () => {
           if (dotJsiiBuffer == null) {
             ko(new Error('No .jsii file found in tarball!'));
+          } else if (packageJsonData == null) {
+            ko(new Error('No package.json file found in tarball!'));
           } else {
-            ok({ dotJsii: dotJsiiBuffer, licenseText: licenseTextBuffer });
+            ok({ dotJsii: dotJsiiBuffer, licenseText: licenseTextBuffer, packageJson: packageJsonData });
           }
         })
         .write(tar, (err) => {
@@ -89,12 +108,23 @@ export async function handler(event: SQSEvent, context: Context) {
     // Re-check that the license in `.jsii` is eligible. We don't blindly expect it matches that in package.json!
     if (!constants.ELIGIBLE_LICENSES.has(license.toUpperCase())) {
       console.log(`Ignoring package with ineligible license (SPDX identifier "${license}")`);
+      metrics.putMetric(MetricName.INELIGIBLE_LICENSE, 1, Unit.Count);
+      metrics.setProperty('rejectedLicense', license);
       continue;
     }
+    metrics.putMetric(MetricName.INELIGIBLE_LICENSE, 0, Unit.Count);
 
-    await metricScope((metrics) => () => {
-      metrics.putMetric(MetricName.FOUND_LICENSE_FILE, licenseText != null ? 1 : 0, Unit.Count);
-    })();
+    // Ensure the `.jsii` name & version corresponds to those in `package.json`
+    const { name: packageJsonName, version: packageJsonVersion } = JSON.parse(packageJson.toString('utf-8'));
+    if (packageJsonName !== packageName || packageJsonVersion !== packageVersion) {
+      console.log(`Ignoring package with mismatched name and/or version (${packageJsonName}@${packageJsonVersion} !== ${packageName}@${packageVersion})`);
+      metrics.putMetric(MetricName.MISMATCHED_NAME_OR_VERSION, 1, Unit.Count);
+      continue;
+    }
+    metrics.putMetric(MetricName.MISMATCHED_NAME_OR_VERSION, 0, Unit.Count);
+
+    // Did we identify a license file or not?
+    metrics.putMetric(MetricName.FOUND_LICENSE_FILE, licenseText != null ? 1 : 0, Unit.Count);
 
     const assemblyKey = `${constants.STORAGE_KEY_PREFIX}${packageName}/v${packageVersion}${constants.ASSEMBLY_KEY_SUFFIX}`;
     console.log(`Writing assembly at ${assemblyKey}`);
@@ -165,7 +195,7 @@ export async function handler(event: SQSEvent, context: Context) {
   }
 
   return result;
-}
+});
 
 function gunzip(data: Buffer): Promise<Buffer> {
   const chunks = new Array<Buffer>();


### PR DESCRIPTION
There is one package (`@rhaws/aws-ec2`) that is a re-packaging of
another (`@aws-cdk/aws-ec2`) with a different package name, however the
`.jsii` assembly included in said package still carries the original
package name, which causes undesired confusion down the processing
pipeline.

This rejects packages if the name and version found in `package.json` do
not correspond to those found in the `.jsii` assembly.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*