### PR TITLE
fix: broken type links

### DIFF
--- a/API.md
+++ b/API.md
@@ -16,19 +16,19 @@ import { ConstructHub } from 'construct-hub'
 new ConstructHub(scope: Construct, id: string, props: ConstructHubProps)
 ```
 
-##### `scope`<sup>Required</sup> <a name="construct-hub.ConstructHub.scope"></a>
+##### `scope`<sup>Required</sup> <a name="construct-hub.ConstructHub.parameter.scope"></a>
 
 - *Type:* [`constructs.Construct`](#constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="construct-hub.ConstructHub.id"></a>
+##### `id`<sup>Required</sup> <a name="construct-hub.ConstructHub.parameter.id"></a>
 
 - *Type:* `string`
 
 ---
 
-##### `props`<sup>Required</sup> <a name="construct-hub.ConstructHub.props"></a>
+##### `props`<sup>Required</sup> <a name="construct-hub.ConstructHub.parameter.props"></a>
 
 - *Type:* [`construct-hub.ConstructHubProps`](#construct-hub.ConstructHubProps)
 
@@ -38,7 +38,7 @@ new ConstructHub(scope: Construct, id: string, props: ConstructHubProps)
 
 #### Properties <a name="Properties"></a>
 
-##### `grantPrincipal`<sup>Required</sup> <a name="construct-hub.ConstructHub.grantPrincipal"></a>
+##### `grantPrincipal`<sup>Required</sup> <a name="construct-hub.ConstructHub.property.grantPrincipal"></a>
 
 - *Type:* [`@aws-cdk/aws-iam.IPrincipal`](#@aws-cdk/aws-iam.IPrincipal)
 
@@ -46,7 +46,7 @@ The principal to grant permissions to.
 
 ---
 
-##### `ingestionQueue`<sup>Required</sup> <a name="construct-hub.ConstructHub.ingestionQueue"></a>
+##### `ingestionQueue`<sup>Required</sup> <a name="construct-hub.ConstructHub.property.ingestionQueue"></a>
 
 - *Type:* [`@aws-cdk/aws-sqs.IQueue`](#@aws-cdk/aws-sqs.IQueue)
 
@@ -67,7 +67,7 @@ import { AlarmActions } from 'construct-hub'
 const alarmActions: AlarmActions = { ... }
 ```
 
-##### `highSeverity`<sup>Required</sup> <a name="construct-hub.AlarmActions.highSeverity"></a>
+##### `highSeverity`<sup>Required</sup> <a name="construct-hub.AlarmActions.property.highSeverity"></a>
 
 - *Type:* `string`
 
@@ -79,7 +79,7 @@ This must be an ARN that can be used with CloudWatch alarms.
 
 ---
 
-##### `normalSeverity`<sup>Optional</sup> <a name="construct-hub.AlarmActions.normalSeverity"></a>
+##### `normalSeverity`<sup>Optional</sup> <a name="construct-hub.AlarmActions.property.normalSeverity"></a>
 
 - *Type:* `string`
 - *Default:* no actions are taken in response to alarms of normal severity
@@ -104,7 +104,7 @@ import { ConstructHubProps } from 'construct-hub'
 const constructHubProps: ConstructHubProps = { ... }
 ```
 
-##### `alarmActions`<sup>Required</sup> <a name="construct-hub.ConstructHubProps.alarmActions"></a>
+##### `alarmActions`<sup>Required</sup> <a name="construct-hub.ConstructHubProps.property.alarmActions"></a>
 
 - *Type:* [`construct-hub.AlarmActions`](#construct-hub.AlarmActions)
 
@@ -112,7 +112,7 @@ Actions to perform when alarms are set.
 
 ---
 
-##### `dashboardName`<sup>Optional</sup> <a name="construct-hub.ConstructHubProps.dashboardName"></a>
+##### `dashboardName`<sup>Optional</sup> <a name="construct-hub.ConstructHubProps.property.dashboardName"></a>
 
 - *Type:* `string`
 - *Default:* "construct-hub"
@@ -123,7 +123,7 @@ Must only contain alphanumerics, dash (-) and underscore (_).
 
 ---
 
-##### `domain`<sup>Optional</sup> <a name="construct-hub.ConstructHubProps.domain"></a>
+##### `domain`<sup>Optional</sup> <a name="construct-hub.ConstructHubProps.property.domain"></a>
 
 - *Type:* [`construct-hub.Domain`](#construct-hub.Domain)
 
@@ -131,7 +131,7 @@ Connect the hub to a domain (requires a hosted zone and a certificate).
 
 ---
 
-##### `isolateLambdas`<sup>Optional</sup> <a name="construct-hub.ConstructHubProps.isolateLambdas"></a>
+##### `isolateLambdas`<sup>Optional</sup> <a name="construct-hub.ConstructHubProps.property.isolateLambdas"></a>
 
 - *Type:* `boolean`
 - *Default:* true
@@ -159,7 +159,7 @@ import { Domain } from 'construct-hub'
 const domain: Domain = { ... }
 ```
 
-##### `cert`<sup>Required</sup> <a name="construct-hub.Domain.cert"></a>
+##### `cert`<sup>Required</sup> <a name="construct-hub.Domain.property.cert"></a>
 
 - *Type:* [`@aws-cdk/aws-certificatemanager.ICertificate`](#@aws-cdk/aws-certificatemanager.ICertificate)
 - *Default:* a DNS-Validated certificate will be provisioned using the
@@ -169,7 +169,7 @@ The certificate to use for serving the Construct Hub over a custom domain.
 
 ---
 
-##### `zone`<sup>Required</sup> <a name="construct-hub.Domain.zone"></a>
+##### `zone`<sup>Required</sup> <a name="construct-hub.Domain.property.zone"></a>
 
 - *Type:* [`@aws-cdk/aws-route53.IHostedZone`](#@aws-cdk/aws-route53.IHostedZone)
 
@@ -177,7 +177,7 @@ The root domain name where this instance of Construct Hub will be served.
 
 ---
 
-##### `monitorCertificateExpiration`<sup>Optional</sup> <a name="construct-hub.Domain.monitorCertificateExpiration"></a>
+##### `monitorCertificateExpiration`<sup>Optional</sup> <a name="construct-hub.Domain.property.monitorCertificateExpiration"></a>
 
 - *Type:* `boolean`
 - *Default:* true

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "jest-junit": "^12",
     "jsii": "^1.31.0",
     "jsii-diff": "^1.31.0",
-    "jsii-docgen": "^3.1.0",
+    "jsii-docgen": "^3.1.1",
     "jsii-pacmak": "^1.31.0",
     "jsii-rosetta": "./vendor/jsii-rosetta.tgz",
     "json-schema": "^0.3.0",

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -69,18 +69,6 @@ Object {
       "Description": "S3 key for asset version \\"5ad81f4610659fb6cc9f7ace7b76edee05f10fa0028965c4d3165d7a055054c4\\"",
       "Type": "String",
     },
-    "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23ArtifactHashBFCAFB77": Object {
-      "Description": "Artifact hash for asset \\"5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23\\"",
-      "Type": "String",
-    },
-    "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3BucketB8035160": Object {
-      "Description": "S3 bucket for asset \\"5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23\\"",
-      "Type": "String",
-    },
-    "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3VersionKey439B87EC": Object {
-      "Description": "S3 key for asset version \\"5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23\\"",
-      "Type": "String",
-    },
     "AssetParameters67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24ArtifactHashBA91B77F": Object {
       "Description": "Artifact hash for asset \\"67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24\\"",
       "Type": "String",
@@ -127,6 +115,18 @@ Object {
     },
     "AssetParameters91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bffS3VersionKeyB74B99C5": Object {
       "Description": "S3 key for asset version \\"91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bff\\"",
+      "Type": "String",
+    },
+    "AssetParameters963a3120e406b3cc369bf38d10c1489161d15dce47efecd1971f3d8da2fd2da2ArtifactHash3B1F9D07": Object {
+      "Description": "Artifact hash for asset \\"963a3120e406b3cc369bf38d10c1489161d15dce47efecd1971f3d8da2fd2da2\\"",
+      "Type": "String",
+    },
+    "AssetParameters963a3120e406b3cc369bf38d10c1489161d15dce47efecd1971f3d8da2fd2da2S3BucketDE3E40D8": Object {
+      "Description": "S3 bucket for asset \\"963a3120e406b3cc369bf38d10c1489161d15dce47efecd1971f3d8da2fd2da2\\"",
+      "Type": "String",
+    },
+    "AssetParameters963a3120e406b3cc369bf38d10c1489161d15dce47efecd1971f3d8da2fd2da2S3VersionKey5078CF6D": Object {
+      "Description": "S3 key for asset version \\"963a3120e406b3cc369bf38d10c1489161d15dce47efecd1971f3d8da2fd2da2\\"",
       "Type": "String",
     },
     "AssetParametersc24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cfArtifactHash85F58E48": Object {
@@ -2661,7 +2661,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3BucketB8035160",
+            "Ref": "AssetParameters963a3120e406b3cc369bf38d10c1489161d15dce47efecd1971f3d8da2fd2da2S3BucketDE3E40D8",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -2674,7 +2674,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3VersionKey439B87EC",
+                          "Ref": "AssetParameters963a3120e406b3cc369bf38d10c1489161d15dce47efecd1971f3d8da2fd2da2S3VersionKey5078CF6D",
                         },
                       ],
                     },
@@ -2687,7 +2687,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3VersionKey439B87EC",
+                          "Ref": "AssetParameters963a3120e406b3cc369bf38d10c1489161d15dce47efecd1971f3d8da2fd2da2S3VersionKey5078CF6D",
                         },
                       ],
                     },
@@ -4255,18 +4255,6 @@ Object {
       "Description": "S3 key for asset version \\"5ad81f4610659fb6cc9f7ace7b76edee05f10fa0028965c4d3165d7a055054c4\\"",
       "Type": "String",
     },
-    "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23ArtifactHashBFCAFB77": Object {
-      "Description": "Artifact hash for asset \\"5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23\\"",
-      "Type": "String",
-    },
-    "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3BucketB8035160": Object {
-      "Description": "S3 bucket for asset \\"5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23\\"",
-      "Type": "String",
-    },
-    "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3VersionKey439B87EC": Object {
-      "Description": "S3 key for asset version \\"5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23\\"",
-      "Type": "String",
-    },
     "AssetParameters67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24ArtifactHashBA91B77F": Object {
       "Description": "Artifact hash for asset \\"67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24\\"",
       "Type": "String",
@@ -4325,6 +4313,18 @@ Object {
     },
     "AssetParameters91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bffS3VersionKeyB74B99C5": Object {
       "Description": "S3 key for asset version \\"91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bff\\"",
+      "Type": "String",
+    },
+    "AssetParameters963a3120e406b3cc369bf38d10c1489161d15dce47efecd1971f3d8da2fd2da2ArtifactHash3B1F9D07": Object {
+      "Description": "Artifact hash for asset \\"963a3120e406b3cc369bf38d10c1489161d15dce47efecd1971f3d8da2fd2da2\\"",
+      "Type": "String",
+    },
+    "AssetParameters963a3120e406b3cc369bf38d10c1489161d15dce47efecd1971f3d8da2fd2da2S3BucketDE3E40D8": Object {
+      "Description": "S3 bucket for asset \\"963a3120e406b3cc369bf38d10c1489161d15dce47efecd1971f3d8da2fd2da2\\"",
+      "Type": "String",
+    },
+    "AssetParameters963a3120e406b3cc369bf38d10c1489161d15dce47efecd1971f3d8da2fd2da2S3VersionKey5078CF6D": Object {
+      "Description": "S3 key for asset version \\"963a3120e406b3cc369bf38d10c1489161d15dce47efecd1971f3d8da2fd2da2\\"",
       "Type": "String",
     },
     "AssetParametersc24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cfArtifactHash85F58E48": Object {
@@ -7030,7 +7030,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3BucketB8035160",
+            "Ref": "AssetParameters963a3120e406b3cc369bf38d10c1489161d15dce47efecd1971f3d8da2fd2da2S3BucketDE3E40D8",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -7043,7 +7043,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3VersionKey439B87EC",
+                          "Ref": "AssetParameters963a3120e406b3cc369bf38d10c1489161d15dce47efecd1971f3d8da2fd2da2S3VersionKey5078CF6D",
                         },
                       ],
                     },
@@ -7056,7 +7056,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3VersionKey439B87EC",
+                          "Ref": "AssetParameters963a3120e406b3cc369bf38d10c1489161d15dce47efecd1971f3d8da2fd2da2S3VersionKey5078CF6D",
                         },
                       ],
                     },

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -33,18 +33,6 @@ Object {
     },
   },
   "Parameters": Object {
-    "AssetParameters0441d0d6fb9745b881da0dffebdd48772ec4be2e9334d02de106633f7820803eArtifactHash1A8F1AA3": Object {
-      "Description": "Artifact hash for asset \\"0441d0d6fb9745b881da0dffebdd48772ec4be2e9334d02de106633f7820803e\\"",
-      "Type": "String",
-    },
-    "AssetParameters0441d0d6fb9745b881da0dffebdd48772ec4be2e9334d02de106633f7820803eS3Bucket67ADE6AE": Object {
-      "Description": "S3 bucket for asset \\"0441d0d6fb9745b881da0dffebdd48772ec4be2e9334d02de106633f7820803e\\"",
-      "Type": "String",
-    },
-    "AssetParameters0441d0d6fb9745b881da0dffebdd48772ec4be2e9334d02de106633f7820803eS3VersionKey0FF3C63F": Object {
-      "Description": "S3 key for asset version \\"0441d0d6fb9745b881da0dffebdd48772ec4be2e9334d02de106633f7820803e\\"",
-      "Type": "String",
-    },
     "AssetParameters1a0d574e726b5616c72133deab65778bac9c37f0883511815cd5d2ec3f5535e6ArtifactHashFA66270A": Object {
       "Description": "Artifact hash for asset \\"1a0d574e726b5616c72133deab65778bac9c37f0883511815cd5d2ec3f5535e6\\"",
       "Type": "String",
@@ -79,6 +67,18 @@ Object {
     },
     "AssetParameters5ad81f4610659fb6cc9f7ace7b76edee05f10fa0028965c4d3165d7a055054c4S3VersionKey192152F3": Object {
       "Description": "S3 key for asset version \\"5ad81f4610659fb6cc9f7ace7b76edee05f10fa0028965c4d3165d7a055054c4\\"",
+      "Type": "String",
+    },
+    "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23ArtifactHashBFCAFB77": Object {
+      "Description": "Artifact hash for asset \\"5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23\\"",
+      "Type": "String",
+    },
+    "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3BucketB8035160": Object {
+      "Description": "S3 bucket for asset \\"5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23\\"",
+      "Type": "String",
+    },
+    "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3VersionKey439B87EC": Object {
+      "Description": "S3 key for asset version \\"5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23\\"",
       "Type": "String",
     },
     "AssetParameters67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24ArtifactHashBA91B77F": Object {
@@ -2661,7 +2661,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters0441d0d6fb9745b881da0dffebdd48772ec4be2e9334d02de106633f7820803eS3Bucket67ADE6AE",
+            "Ref": "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3BucketB8035160",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -2674,7 +2674,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0441d0d6fb9745b881da0dffebdd48772ec4be2e9334d02de106633f7820803eS3VersionKey0FF3C63F",
+                          "Ref": "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3VersionKey439B87EC",
                         },
                       ],
                     },
@@ -2687,7 +2687,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0441d0d6fb9745b881da0dffebdd48772ec4be2e9334d02de106633f7820803eS3VersionKey0FF3C63F",
+                          "Ref": "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3VersionKey439B87EC",
                         },
                       ],
                     },
@@ -4207,18 +4207,6 @@ Object {
     },
   },
   "Parameters": Object {
-    "AssetParameters0441d0d6fb9745b881da0dffebdd48772ec4be2e9334d02de106633f7820803eArtifactHash1A8F1AA3": Object {
-      "Description": "Artifact hash for asset \\"0441d0d6fb9745b881da0dffebdd48772ec4be2e9334d02de106633f7820803e\\"",
-      "Type": "String",
-    },
-    "AssetParameters0441d0d6fb9745b881da0dffebdd48772ec4be2e9334d02de106633f7820803eS3Bucket67ADE6AE": Object {
-      "Description": "S3 bucket for asset \\"0441d0d6fb9745b881da0dffebdd48772ec4be2e9334d02de106633f7820803e\\"",
-      "Type": "String",
-    },
-    "AssetParameters0441d0d6fb9745b881da0dffebdd48772ec4be2e9334d02de106633f7820803eS3VersionKey0FF3C63F": Object {
-      "Description": "S3 key for asset version \\"0441d0d6fb9745b881da0dffebdd48772ec4be2e9334d02de106633f7820803e\\"",
-      "Type": "String",
-    },
     "AssetParameters1a0d574e726b5616c72133deab65778bac9c37f0883511815cd5d2ec3f5535e6ArtifactHashFA66270A": Object {
       "Description": "Artifact hash for asset \\"1a0d574e726b5616c72133deab65778bac9c37f0883511815cd5d2ec3f5535e6\\"",
       "Type": "String",
@@ -4265,6 +4253,18 @@ Object {
     },
     "AssetParameters5ad81f4610659fb6cc9f7ace7b76edee05f10fa0028965c4d3165d7a055054c4S3VersionKey192152F3": Object {
       "Description": "S3 key for asset version \\"5ad81f4610659fb6cc9f7ace7b76edee05f10fa0028965c4d3165d7a055054c4\\"",
+      "Type": "String",
+    },
+    "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23ArtifactHashBFCAFB77": Object {
+      "Description": "Artifact hash for asset \\"5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23\\"",
+      "Type": "String",
+    },
+    "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3BucketB8035160": Object {
+      "Description": "S3 bucket for asset \\"5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23\\"",
+      "Type": "String",
+    },
+    "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3VersionKey439B87EC": Object {
+      "Description": "S3 key for asset version \\"5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23\\"",
       "Type": "String",
     },
     "AssetParameters67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24ArtifactHashBA91B77F": Object {
@@ -7030,7 +7030,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters0441d0d6fb9745b881da0dffebdd48772ec4be2e9334d02de106633f7820803eS3Bucket67ADE6AE",
+            "Ref": "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3BucketB8035160",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -7043,7 +7043,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0441d0d6fb9745b881da0dffebdd48772ec4be2e9334d02de106633f7820803eS3VersionKey0FF3C63F",
+                          "Ref": "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3VersionKey439B87EC",
                         },
                       ],
                     },
@@ -7056,7 +7056,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0441d0d6fb9745b881da0dffebdd48772ec4be2e9334d02de106633f7820803eS3VersionKey0FF3C63F",
+                          "Ref": "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3VersionKey439B87EC",
                         },
                       ],
                     },

--- a/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
+++ b/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
@@ -396,7 +396,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3BucketB8035160",
+            "Ref": "AssetParameters963a3120e406b3cc369bf38d10c1489161d15dce47efecd1971f3d8da2fd2da2S3BucketDE3E40D8",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -409,7 +409,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3VersionKey439B87EC",
+                          "Ref": "AssetParameters963a3120e406b3cc369bf38d10c1489161d15dce47efecd1971f3d8da2fd2da2S3VersionKey5078CF6D",
                         },
                       ],
                     },
@@ -422,7 +422,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3VersionKey439B87EC",
+                          "Ref": "AssetParameters963a3120e406b3cc369bf38d10c1489161d15dce47efecd1971f3d8da2fd2da2S3VersionKey5078CF6D",
                         },
                       ],
                     },
@@ -1001,7 +1001,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3BucketB8035160",
+            "Ref": "AssetParameters963a3120e406b3cc369bf38d10c1489161d15dce47efecd1971f3d8da2fd2da2S3BucketDE3E40D8",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -1014,7 +1014,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3VersionKey439B87EC",
+                          "Ref": "AssetParameters963a3120e406b3cc369bf38d10c1489161d15dce47efecd1971f3d8da2fd2da2S3VersionKey5078CF6D",
                         },
                       ],
                     },
@@ -1027,7 +1027,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3VersionKey439B87EC",
+                          "Ref": "AssetParameters963a3120e406b3cc369bf38d10c1489161d15dce47efecd1971f3d8da2fd2da2S3VersionKey5078CF6D",
                         },
                       ],
                     },
@@ -1725,7 +1725,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3BucketB8035160",
+            "Ref": "AssetParameters963a3120e406b3cc369bf38d10c1489161d15dce47efecd1971f3d8da2fd2da2S3BucketDE3E40D8",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -1738,7 +1738,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3VersionKey439B87EC",
+                          "Ref": "AssetParameters963a3120e406b3cc369bf38d10c1489161d15dce47efecd1971f3d8da2fd2da2S3VersionKey5078CF6D",
                         },
                       ],
                     },
@@ -1751,7 +1751,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3VersionKey439B87EC",
+                          "Ref": "AssetParameters963a3120e406b3cc369bf38d10c1489161d15dce47efecd1971f3d8da2fd2da2S3VersionKey5078CF6D",
                         },
                       ],
                     },
@@ -2409,7 +2409,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3BucketB8035160",
+            "Ref": "AssetParameters963a3120e406b3cc369bf38d10c1489161d15dce47efecd1971f3d8da2fd2da2S3BucketDE3E40D8",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -2422,7 +2422,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3VersionKey439B87EC",
+                          "Ref": "AssetParameters963a3120e406b3cc369bf38d10c1489161d15dce47efecd1971f3d8da2fd2da2S3VersionKey5078CF6D",
                         },
                       ],
                     },
@@ -2435,7 +2435,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3VersionKey439B87EC",
+                          "Ref": "AssetParameters963a3120e406b3cc369bf38d10c1489161d15dce47efecd1971f3d8da2fd2da2S3VersionKey5078CF6D",
                         },
                       ],
                     },

--- a/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
+++ b/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
@@ -396,7 +396,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters0441d0d6fb9745b881da0dffebdd48772ec4be2e9334d02de106633f7820803eS3Bucket67ADE6AE",
+            "Ref": "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3BucketB8035160",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -409,7 +409,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0441d0d6fb9745b881da0dffebdd48772ec4be2e9334d02de106633f7820803eS3VersionKey0FF3C63F",
+                          "Ref": "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3VersionKey439B87EC",
                         },
                       ],
                     },
@@ -422,7 +422,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0441d0d6fb9745b881da0dffebdd48772ec4be2e9334d02de106633f7820803eS3VersionKey0FF3C63F",
+                          "Ref": "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3VersionKey439B87EC",
                         },
                       ],
                     },
@@ -1001,7 +1001,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters0441d0d6fb9745b881da0dffebdd48772ec4be2e9334d02de106633f7820803eS3Bucket67ADE6AE",
+            "Ref": "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3BucketB8035160",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -1014,7 +1014,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0441d0d6fb9745b881da0dffebdd48772ec4be2e9334d02de106633f7820803eS3VersionKey0FF3C63F",
+                          "Ref": "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3VersionKey439B87EC",
                         },
                       ],
                     },
@@ -1027,7 +1027,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0441d0d6fb9745b881da0dffebdd48772ec4be2e9334d02de106633f7820803eS3VersionKey0FF3C63F",
+                          "Ref": "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3VersionKey439B87EC",
                         },
                       ],
                     },
@@ -1725,7 +1725,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters0441d0d6fb9745b881da0dffebdd48772ec4be2e9334d02de106633f7820803eS3Bucket67ADE6AE",
+            "Ref": "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3BucketB8035160",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -1738,7 +1738,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0441d0d6fb9745b881da0dffebdd48772ec4be2e9334d02de106633f7820803eS3VersionKey0FF3C63F",
+                          "Ref": "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3VersionKey439B87EC",
                         },
                       ],
                     },
@@ -1751,7 +1751,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0441d0d6fb9745b881da0dffebdd48772ec4be2e9334d02de106633f7820803eS3VersionKey0FF3C63F",
+                          "Ref": "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3VersionKey439B87EC",
                         },
                       ],
                     },
@@ -2409,7 +2409,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters0441d0d6fb9745b881da0dffebdd48772ec4be2e9334d02de106633f7820803eS3Bucket67ADE6AE",
+            "Ref": "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3BucketB8035160",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -2422,7 +2422,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0441d0d6fb9745b881da0dffebdd48772ec4be2e9334d02de106633f7820803eS3VersionKey0FF3C63F",
+                          "Ref": "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3VersionKey439B87EC",
                         },
                       ],
                     },
@@ -2435,7 +2435,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0441d0d6fb9745b881da0dffebdd48772ec4be2e9334d02de106633f7820803eS3VersionKey0FF3C63F",
+                          "Ref": "AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3VersionKey439B87EC",
                         },
                       ],
                     },

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -1535,7 +1535,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters0441d0d6fb9745b881da0dffebdd48772ec4be2e9334d02de106633f7820803eS3Bucket67ADE6AE
+          Ref: AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3BucketB8035160
         S3Key:
           Fn::Join:
             - ""
@@ -1543,12 +1543,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters0441d0d6fb9745b881da0dffebdd48772ec4be2e9334d02de106633f7820803eS3VersionKey0FF3C63F
+                      - Ref: AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3VersionKey439B87EC
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters0441d0d6fb9745b881da0dffebdd48772ec4be2e9334d02de106633f7820803eS3VersionKey0FF3C63F
+                      - Ref: AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3VersionKey439B87EC
       Role:
         Fn::GetAtt:
           - ConstructHubTransliteratorServiceRole0F8A20C8
@@ -2471,18 +2471,18 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bff"
-  AssetParameters0441d0d6fb9745b881da0dffebdd48772ec4be2e9334d02de106633f7820803eS3Bucket67ADE6AE:
+  AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3BucketB8035160:
     Type: String
     Description: S3 bucket for asset
-      "0441d0d6fb9745b881da0dffebdd48772ec4be2e9334d02de106633f7820803e"
-  AssetParameters0441d0d6fb9745b881da0dffebdd48772ec4be2e9334d02de106633f7820803eS3VersionKey0FF3C63F:
+      "5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23"
+  AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3VersionKey439B87EC:
     Type: String
     Description: S3 key for asset version
-      "0441d0d6fb9745b881da0dffebdd48772ec4be2e9334d02de106633f7820803e"
-  AssetParameters0441d0d6fb9745b881da0dffebdd48772ec4be2e9334d02de106633f7820803eArtifactHash1A8F1AA3:
+      "5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23"
+  AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23ArtifactHashBFCAFB77:
     Type: String
     Description: Artifact hash for asset
-      "0441d0d6fb9745b881da0dffebdd48772ec4be2e9334d02de106633f7820803e"
+      "5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23"
   AssetParameters67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24S3Bucket4D46ABB5:
     Type: String
     Description: S3 bucket for asset

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -1535,7 +1535,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3BucketB8035160
+          Ref: AssetParameters963a3120e406b3cc369bf38d10c1489161d15dce47efecd1971f3d8da2fd2da2S3BucketDE3E40D8
         S3Key:
           Fn::Join:
             - ""
@@ -1543,12 +1543,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3VersionKey439B87EC
+                      - Ref: AssetParameters963a3120e406b3cc369bf38d10c1489161d15dce47efecd1971f3d8da2fd2da2S3VersionKey5078CF6D
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3VersionKey439B87EC
+                      - Ref: AssetParameters963a3120e406b3cc369bf38d10c1489161d15dce47efecd1971f3d8da2fd2da2S3VersionKey5078CF6D
       Role:
         Fn::GetAtt:
           - ConstructHubTransliteratorServiceRole0F8A20C8
@@ -2471,18 +2471,18 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bff"
-  AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3BucketB8035160:
+  AssetParameters963a3120e406b3cc369bf38d10c1489161d15dce47efecd1971f3d8da2fd2da2S3BucketDE3E40D8:
     Type: String
     Description: S3 bucket for asset
-      "5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23"
-  AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23S3VersionKey439B87EC:
+      "963a3120e406b3cc369bf38d10c1489161d15dce47efecd1971f3d8da2fd2da2"
+  AssetParameters963a3120e406b3cc369bf38d10c1489161d15dce47efecd1971f3d8da2fd2da2S3VersionKey5078CF6D:
     Type: String
     Description: S3 key for asset version
-      "5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23"
-  AssetParameters5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23ArtifactHashBFCAFB77:
+      "963a3120e406b3cc369bf38d10c1489161d15dce47efecd1971f3d8da2fd2da2"
+  AssetParameters963a3120e406b3cc369bf38d10c1489161d15dce47efecd1971f3d8da2fd2da2ArtifactHash3B1F9D07:
     Type: String
     Description: Artifact hash for asset
-      "5d959d605a489a3a945b686182fc7436ae5fa10515c2bc15d5b04ad2c1469d23"
+      "963a3120e406b3cc369bf38d10c1489161d15dce47efecd1971f3d8da2fd2da2"
   AssetParameters67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24S3Bucket4D46ABB5:
     Type: String
     Description: S3 bucket for asset

--- a/yarn.lock
+++ b/yarn.lock
@@ -10078,10 +10078,10 @@ jsii-diff@^1.31.0:
     typescript "~3.9.9"
     yargs "^16.2.0"
 
-jsii-docgen@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/jsii-docgen/-/jsii-docgen-3.1.0.tgz#d601d6826e0ba418108959f8c9139c8fbc0d1135"
-  integrity sha512-u89voK59kPy/7MT7cKwD4fKREfAW/8G7DT1TA9781U6CihbUcHDoNNqm6SeF1HDEOMGSNT1aQEVw7rGe3rCQjQ==
+jsii-docgen@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/jsii-docgen/-/jsii-docgen-3.1.1.tgz#f145e0c35c8f64340428be09a887dd2a182f6643"
+  integrity sha512-1gu5ikjxXaYVoqYmMOfoVGP0SRxqLD/7cafillhla2y0B4o3HgqR01TLmg9PEL7h35Fmwit+qn2IK249f1WibQ==
   dependencies:
     "@jsii/spec" "^1.31.0"
     case "^1.6.3"


### PR DESCRIPTION
Type links are currently broken because of:

1. Links to types in the same package do not sanitize the fqn as the webapp expects it to.
2. Links to types in other packages dont prepend the correct package path (i.e `/packages/...`).

Fixes https://github.com/cdklabs/construct-hub-webapp/issues/128 

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*