### PR TITLE
chore: better monitoring of lag to npmjs.com

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -93,7 +93,6 @@ Object {
       "Description": "S3 key for asset version \\"8625a217e0e7f0586edd183190019d9970344fa75c829365a84a47531a60a32e\\"",
       "Type": "String",
     },
-
     "AssetParameters86636ae9c2e497c99bfcde8a9310daa981aaae2477613f256d5cfe22541cf103ArtifactHash5B391504": Object {
       "Description": "Artifact hash for asset \\"86636ae9c2e497c99bfcde8a9310daa981aaae2477613f256d5cfe22541cf103\\"",
       "Type": "String",
@@ -104,18 +103,6 @@ Object {
     },
     "AssetParameters86636ae9c2e497c99bfcde8a9310daa981aaae2477613f256d5cfe22541cf103S3VersionKeyA4D9DFC0": Object {
       "Description": "S3 key for asset version \\"86636ae9c2e497c99bfcde8a9310daa981aaae2477613f256d5cfe22541cf103\\"",
-      "Type": "String",
-    },
-    "AssetParameters91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bffArtifactHash12102562": Object {
-      "Description": "Artifact hash for asset \\"91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bff\\"",
-      "Type": "String",
-    },
-    "AssetParameters91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bffS3Bucket89C755A8": Object {
-      "Description": "S3 bucket for asset \\"91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bff\\"",
-      "Type": "String",
-    },
-    "AssetParameters91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bffS3VersionKeyB74B99C5": Object {
-      "Description": "S3 key for asset version \\"91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bff\\"",
       "Type": "String",
     },
     "AssetParametersa2a420a4715fb0cfd6bc2d00c13a5a70fa1c434d6e6936185021c8fb397fd2caArtifactHashE3F0EDDF": Object {
@@ -5021,18 +5008,6 @@ Object {
     },
     "AssetParameters86636ae9c2e497c99bfcde8a9310daa981aaae2477613f256d5cfe22541cf103S3VersionKeyA4D9DFC0": Object {
       "Description": "S3 key for asset version \\"86636ae9c2e497c99bfcde8a9310daa981aaae2477613f256d5cfe22541cf103\\"",
-      "Type": "String",
-    },
-    "AssetParameters91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bffArtifactHash12102562": Object {
-      "Description": "Artifact hash for asset \\"91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bff\\"",
-      "Type": "String",
-    },
-    "AssetParameters91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bffS3Bucket89C755A8": Object {
-      "Description": "S3 bucket for asset \\"91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bff\\"",
-      "Type": "String",
-    },
-    "AssetParameters91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bffS3VersionKeyB74B99C5": Object {
-      "Description": "S3 key for asset version \\"91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bff\\"",
       "Type": "String",
     },
     "AssetParametersa2a420a4715fb0cfd6bc2d00c13a5a70fa1c434d6e6936185021c8fb397fd2caArtifactHashE3F0EDDF": Object {

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -105,18 +105,6 @@ Object {
       "Description": "S3 key for asset version \\"8625a217e0e7f0586edd183190019d9970344fa75c829365a84a47531a60a32e\\"",
       "Type": "String",
     },
-    "AssetParameters91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bffArtifactHash12102562": Object {
-      "Description": "Artifact hash for asset \\"91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bff\\"",
-      "Type": "String",
-    },
-    "AssetParameters91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bffS3Bucket89C755A8": Object {
-      "Description": "S3 bucket for asset \\"91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bff\\"",
-      "Type": "String",
-    },
-    "AssetParameters91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bffS3VersionKeyB74B99C5": Object {
-      "Description": "S3 key for asset version \\"91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bff\\"",
-      "Type": "String",
-    },
     "AssetParametersa2a420a4715fb0cfd6bc2d00c13a5a70fa1c434d6e6936185021c8fb397fd2caArtifactHashE3F0EDDF": Object {
       "Description": "Artifact hash for asset \\"a2a420a4715fb0cfd6bc2d00c13a5a70fa1c434d6e6936185021c8fb397fd2ca\\"",
       "Type": "String",
@@ -127,6 +115,18 @@ Object {
     },
     "AssetParametersa2a420a4715fb0cfd6bc2d00c13a5a70fa1c434d6e6936185021c8fb397fd2caS3VersionKeyD47D75B1": Object {
       "Description": "S3 key for asset version \\"a2a420a4715fb0cfd6bc2d00c13a5a70fa1c434d6e6936185021c8fb397fd2ca\\"",
+      "Type": "String",
+    },
+    "AssetParametersa9b8491b2911a366c43cde5d94de41240e34839f322e57e4d080be304aa55777ArtifactHash452E23B0": Object {
+      "Description": "Artifact hash for asset \\"a9b8491b2911a366c43cde5d94de41240e34839f322e57e4d080be304aa55777\\"",
+      "Type": "String",
+    },
+    "AssetParametersa9b8491b2911a366c43cde5d94de41240e34839f322e57e4d080be304aa55777S3BucketEFBEBE7E": Object {
+      "Description": "S3 bucket for asset \\"a9b8491b2911a366c43cde5d94de41240e34839f322e57e4d080be304aa55777\\"",
+      "Type": "String",
+    },
+    "AssetParametersa9b8491b2911a366c43cde5d94de41240e34839f322e57e4d080be304aa55777S3VersionKey8F8A2DB4": Object {
+      "Description": "S3 key for asset version \\"a9b8491b2911a366c43cde5d94de41240e34839f322e57e4d080be304aa55777\\"",
       "Type": "String",
     },
     "AssetParametersc24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cfArtifactHash85F58E48": Object {
@@ -853,7 +853,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bffS3Bucket89C755A8",
+            "Ref": "AssetParametersa9b8491b2911a366c43cde5d94de41240e34839f322e57e4d080be304aa55777S3BucketEFBEBE7E",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -866,7 +866,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bffS3VersionKeyB74B99C5",
+                          "Ref": "AssetParametersa9b8491b2911a366c43cde5d94de41240e34839f322e57e4d080be304aa55777S3VersionKey8F8A2DB4",
                         },
                       ],
                     },
@@ -879,7 +879,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bffS3VersionKeyB74B99C5",
+                          "Ref": "AssetParametersa9b8491b2911a366c43cde5d94de41240e34839f322e57e4d080be304aa55777S3VersionKey8F8A2DB4",
                         },
                       ],
                     },
@@ -5010,18 +5010,6 @@ Object {
       "Description": "S3 key for asset version \\"8625a217e0e7f0586edd183190019d9970344fa75c829365a84a47531a60a32e\\"",
       "Type": "String",
     },
-    "AssetParameters91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bffArtifactHash12102562": Object {
-      "Description": "Artifact hash for asset \\"91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bff\\"",
-      "Type": "String",
-    },
-    "AssetParameters91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bffS3Bucket89C755A8": Object {
-      "Description": "S3 bucket for asset \\"91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bff\\"",
-      "Type": "String",
-    },
-    "AssetParameters91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bffS3VersionKeyB74B99C5": Object {
-      "Description": "S3 key for asset version \\"91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bff\\"",
-      "Type": "String",
-    },
     "AssetParametersa2a420a4715fb0cfd6bc2d00c13a5a70fa1c434d6e6936185021c8fb397fd2caArtifactHashE3F0EDDF": Object {
       "Description": "Artifact hash for asset \\"a2a420a4715fb0cfd6bc2d00c13a5a70fa1c434d6e6936185021c8fb397fd2ca\\"",
       "Type": "String",
@@ -5032,6 +5020,18 @@ Object {
     },
     "AssetParametersa2a420a4715fb0cfd6bc2d00c13a5a70fa1c434d6e6936185021c8fb397fd2caS3VersionKeyD47D75B1": Object {
       "Description": "S3 key for asset version \\"a2a420a4715fb0cfd6bc2d00c13a5a70fa1c434d6e6936185021c8fb397fd2ca\\"",
+      "Type": "String",
+    },
+    "AssetParametersa9b8491b2911a366c43cde5d94de41240e34839f322e57e4d080be304aa55777ArtifactHash452E23B0": Object {
+      "Description": "Artifact hash for asset \\"a9b8491b2911a366c43cde5d94de41240e34839f322e57e4d080be304aa55777\\"",
+      "Type": "String",
+    },
+    "AssetParametersa9b8491b2911a366c43cde5d94de41240e34839f322e57e4d080be304aa55777S3BucketEFBEBE7E": Object {
+      "Description": "S3 bucket for asset \\"a9b8491b2911a366c43cde5d94de41240e34839f322e57e4d080be304aa55777\\"",
+      "Type": "String",
+    },
+    "AssetParametersa9b8491b2911a366c43cde5d94de41240e34839f322e57e4d080be304aa55777S3VersionKey8F8A2DB4": Object {
+      "Description": "S3 key for asset version \\"a9b8491b2911a366c43cde5d94de41240e34839f322e57e4d080be304aa55777\\"",
       "Type": "String",
     },
     "AssetParametersc24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cfArtifactHash85F58E48": Object {
@@ -5907,7 +5907,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bffS3Bucket89C755A8",
+            "Ref": "AssetParametersa9b8491b2911a366c43cde5d94de41240e34839f322e57e4d080be304aa55777S3BucketEFBEBE7E",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -5920,7 +5920,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bffS3VersionKeyB74B99C5",
+                          "Ref": "AssetParametersa9b8491b2911a366c43cde5d94de41240e34839f322e57e4d080be304aa55777S3VersionKey8F8A2DB4",
                         },
                       ],
                     },
@@ -5933,7 +5933,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bffS3VersionKeyB74B99C5",
+                          "Ref": "AssetParametersa9b8491b2911a366c43cde5d94de41240e34839f322e57e4d080be304aa55777S3VersionKey8F8A2DB4",
                         },
                       ],
                     },

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -1455,7 +1455,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bffS3Bucket89C755A8
+          Ref: AssetParametersa9b8491b2911a366c43cde5d94de41240e34839f322e57e4d080be304aa55777S3BucketEFBEBE7E
         S3Key:
           Fn::Join:
             - ""
@@ -1463,12 +1463,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bffS3VersionKeyB74B99C5
+                      - Ref: AssetParametersa9b8491b2911a366c43cde5d94de41240e34839f322e57e4d080be304aa55777S3VersionKey8F8A2DB4
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bffS3VersionKeyB74B99C5
+                      - Ref: AssetParametersa9b8491b2911a366c43cde5d94de41240e34839f322e57e4d080be304aa55777S3VersionKey8F8A2DB4
       Role:
         Fn::GetAtt:
           - ConstructHubDiscoveryServiceRole1B3CFF96
@@ -2888,18 +2888,18 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "8625a217e0e7f0586edd183190019d9970344fa75c829365a84a47531a60a32e"
-  AssetParameters91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bffS3Bucket89C755A8:
+  AssetParametersa9b8491b2911a366c43cde5d94de41240e34839f322e57e4d080be304aa55777S3BucketEFBEBE7E:
     Type: String
     Description: S3 bucket for asset
-      "91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bff"
-  AssetParameters91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bffS3VersionKeyB74B99C5:
+      "a9b8491b2911a366c43cde5d94de41240e34839f322e57e4d080be304aa55777"
+  AssetParametersa9b8491b2911a366c43cde5d94de41240e34839f322e57e4d080be304aa55777S3VersionKey8F8A2DB4:
     Type: String
     Description: S3 key for asset version
-      "91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bff"
-  AssetParameters91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bffArtifactHash12102562:
+      "a9b8491b2911a366c43cde5d94de41240e34839f322e57e4d080be304aa55777"
+  AssetParametersa9b8491b2911a366c43cde5d94de41240e34839f322e57e4d080be304aa55777ArtifactHash452E23B0:
     Type: String
     Description: Artifact hash for asset
-      "91ab8fa94a11a569cdac879accf050ca99d3ac9249073b166f01519c23420bff"
+      "a9b8491b2911a366c43cde5d94de41240e34839f322e57e4d080be304aa55777"
   AssetParametersa2a420a4715fb0cfd6bc2d00c13a5a70fa1c434d6e6936185021c8fb397fd2caS3Bucket95E84154:
     Type: String
     Description: S3 bucket for asset

--- a/src/backend/discovery/constants.lambda-shared.ts
+++ b/src/backend/discovery/constants.lambda-shared.ts
@@ -1,9 +1,10 @@
-export const METRIC_NAMESPACE = 'ConstructHub/Discovery';
+export const METRICS_NAMESPACE = 'ConstructHub/Discovery';
 
 export const enum MetricName {
   BATCH_PROCESSING_TIME = 'BatchProcessingTime',
   CHANGE_COUNT = 'ChangeCount',
   INELIGIBLE_LICENSE = 'IneligibleLicense',
+  NPMJS_CHANGE_AGE = 'NpmJsChangeAge',
   PACKAGE_VERSION_AGE = 'PackageVersionAge',
   PACKAGE_VERSION_COUNT = 'PackageVersionCount',
   RELEVANT_PACKAGE_VERSIONS = 'RelevantPackageVersions',

--- a/src/backend/discovery/index.ts
+++ b/src/backend/discovery/index.ts
@@ -7,7 +7,7 @@ import { IQueue } from '@aws-cdk/aws-sqs';
 
 import { Construct, Duration } from '@aws-cdk/core';
 import { Monitoring } from '../../monitoring';
-import { MetricName, METRIC_NAMESPACE, S3KeyPrefix } from './constants.lambda-shared';
+import { MetricName, METRICS_NAMESPACE, S3KeyPrefix } from './constants.lambda-shared';
 import { Discovery as Handler } from './discovery';
 
 export interface DiscoveryProps {
@@ -106,11 +106,11 @@ export class Discovery extends Construct {
    */
   public metricBatchProcessingTime(opts?: MetricOptions): IMetric {
     return new Metric({
-      metricName: MetricName.BATCH_PROCESSING_TIME,
-      namespace: METRIC_NAMESPACE,
       period: this.timeout,
       statistic: Statistic.AVERAGE,
       ...opts,
+      metricName: MetricName.BATCH_PROCESSING_TIME,
+      namespace: METRICS_NAMESPACE,
     });
   }
 
@@ -119,11 +119,21 @@ export class Discovery extends Construct {
    */
   public metricChangeCount(opts?: MetricOptions): IMetric {
     return new Metric({
-      metricName: MetricName.CHANGE_COUNT,
-      namespace: METRIC_NAMESPACE,
       period: this.timeout,
       statistic: Statistic.SUM,
       ...opts,
+      metricName: MetricName.CHANGE_COUNT,
+      namespace: METRICS_NAMESPACE,
+    });
+  }
+
+  public metricNpmJsChangeAge(opts?: MetricOptions): IMetric {
+    return new Metric({
+      period: this.timeout,
+      statistic: Statistic.MINIMUM,
+      ...opts,
+      metricName: MetricName.NPMJS_CHANGE_AGE,
+      namespace: METRICS_NAMESPACE,
     });
   }
 
@@ -132,11 +142,11 @@ export class Discovery extends Construct {
    */
   public metricPackageVersionAge(opts?: MetricOptions): IMetric {
     return new Metric({
-      metricName: MetricName.PACKAGE_VERSION_AGE,
-      namespace: METRIC_NAMESPACE,
       period: this.timeout,
       statistic: Statistic.MAXIMUM,
       ...opts,
+      metricName: MetricName.PACKAGE_VERSION_AGE,
+      namespace: METRICS_NAMESPACE,
     });
   }
 
@@ -145,11 +155,11 @@ export class Discovery extends Construct {
    */
   public metricPackageVersionCount(opts?: MetricOptions): IMetric {
     return new Metric({
-      metricName: MetricName.PACKAGE_VERSION_COUNT,
-      namespace: METRIC_NAMESPACE,
       period: this.timeout,
       statistic: Statistic.SUM,
       ...opts,
+      metricName: MetricName.PACKAGE_VERSION_COUNT,
+      namespace: METRICS_NAMESPACE,
     });
   }
 
@@ -158,11 +168,11 @@ export class Discovery extends Construct {
    */
   public metricRelevantPackageVersions(opts?: MetricOptions): IMetric {
     return new Metric({
-      metricName: MetricName.RELEVANT_PACKAGE_VERSIONS,
-      namespace: METRIC_NAMESPACE,
       period: this.timeout,
       statistic: Statistic.SUM,
       ...opts,
+      metricName: MetricName.RELEVANT_PACKAGE_VERSIONS,
+      namespace: METRICS_NAMESPACE,
     });
   }
 
@@ -172,11 +182,11 @@ export class Discovery extends Construct {
    */
   public metricRemainingTime(opts?: MetricOptions): IMetric {
     return new Metric({
-      metricName: MetricName.REMAINING_TIME,
-      namespace: METRIC_NAMESPACE,
       period: this.timeout,
       statistic: Statistic.AVERAGE,
       ...opts,
+      metricName: MetricName.REMAINING_TIME,
+      namespace: METRICS_NAMESPACE,
     });
   }
 
@@ -185,11 +195,11 @@ export class Discovery extends Construct {
    */
   public metricStagingFailureCount(opts?: MetricOptions): IMetric {
     return new Metric({
-      metricName: MetricName.STAGING_FAILURE_COUNT,
-      namespace: METRIC_NAMESPACE,
       period: this.timeout,
       statistic: Statistic.SUM,
       ...opts,
+      metricName: MetricName.STAGING_FAILURE_COUNT,
+      namespace: METRICS_NAMESPACE,
     });
   }
 
@@ -198,11 +208,11 @@ export class Discovery extends Construct {
    */
   public metricStagingTime(opts?: MetricOptions): IMetric {
     return new Metric({
-      metricName: MetricName.STAGING_TIME,
-      namespace: METRIC_NAMESPACE,
       period: this.timeout,
       statistic: Statistic.AVERAGE,
       ...opts,
+      metricName: MetricName.STAGING_TIME,
+      namespace: METRICS_NAMESPACE,
     });
   }
 
@@ -212,11 +222,11 @@ export class Discovery extends Construct {
    */
   public metricUnprocessableEntity(opts?: MetricOptions): IMetric {
     return new Metric({
-      metricName: MetricName.UNPROCESSABLE_ENTITY,
-      namespace: METRIC_NAMESPACE,
       period: this.timeout,
       statistic: Statistic.SUM,
       ...opts,
+      metricName: MetricName.UNPROCESSABLE_ENTITY,
+      namespace: METRICS_NAMESPACE,
     });
   }
 


### PR DESCRIPTION
Emits a metric based on the batches of changes we observe,
not just based on changes concerning relevant packages to
the Construct Hub. This way, the metric should be emitted
almost continuously.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*