### PR TITLE
feat(catalog): re-build catalog if trigger has no records

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -33,18 +33,6 @@ Object {
     },
   },
   "Parameters": Object {
-    "AssetParameters34c7dcc9f578fa0ec3da11db158dce98ccaf225c19131b357f669651db3897b2ArtifactHashA7C49A78": Object {
-      "Description": "Artifact hash for asset \\"34c7dcc9f578fa0ec3da11db158dce98ccaf225c19131b357f669651db3897b2\\"",
-      "Type": "String",
-    },
-    "AssetParameters34c7dcc9f578fa0ec3da11db158dce98ccaf225c19131b357f669651db3897b2S3Bucket7ACB823F": Object {
-      "Description": "S3 bucket for asset \\"34c7dcc9f578fa0ec3da11db158dce98ccaf225c19131b357f669651db3897b2\\"",
-      "Type": "String",
-    },
-    "AssetParameters34c7dcc9f578fa0ec3da11db158dce98ccaf225c19131b357f669651db3897b2S3VersionKey1D948596": Object {
-      "Description": "S3 key for asset version \\"34c7dcc9f578fa0ec3da11db158dce98ccaf225c19131b357f669651db3897b2\\"",
-      "Type": "String",
-    },
     "AssetParameters49a9f312aed7e8d4ad343bbad95b02deb3189efcc26bd4f6ed85af1ac968cef4ArtifactHash554D06EA": Object {
       "Description": "Artifact hash for asset \\"49a9f312aed7e8d4ad343bbad95b02deb3189efcc26bd4f6ed85af1ac968cef4\\"",
       "Type": "String",
@@ -79,6 +67,18 @@ Object {
     },
     "AssetParameters6b4a338b691490f1fd6351e29140684b4cc8c932fa8610251617ca4279b42c9fS3VersionKeyD832198D": Object {
       "Description": "S3 key for asset version \\"6b4a338b691490f1fd6351e29140684b4cc8c932fa8610251617ca4279b42c9f\\"",
+      "Type": "String",
+    },
+    "AssetParameters7f7d123e91c502006a70a8f2b85e6a857aa355f73cce6713d33752d0c492e38cArtifactHashE675C176": Object {
+      "Description": "Artifact hash for asset \\"7f7d123e91c502006a70a8f2b85e6a857aa355f73cce6713d33752d0c492e38c\\"",
+      "Type": "String",
+    },
+    "AssetParameters7f7d123e91c502006a70a8f2b85e6a857aa355f73cce6713d33752d0c492e38cS3Bucket7632C9CF": Object {
+      "Description": "S3 bucket for asset \\"7f7d123e91c502006a70a8f2b85e6a857aa355f73cce6713d33752d0c492e38c\\"",
+      "Type": "String",
+    },
+    "AssetParameters7f7d123e91c502006a70a8f2b85e6a857aa355f73cce6713d33752d0c492e38cS3VersionKey5C67FF74": Object {
+      "Description": "S3 key for asset version \\"7f7d123e91c502006a70a8f2b85e6a857aa355f73cce6713d33752d0c492e38c\\"",
       "Type": "String",
     },
     "AssetParameters8625a217e0e7f0586edd183190019d9970344fa75c829365a84a47531a60a32eArtifactHashEC22613F": Object {
@@ -436,7 +436,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters34c7dcc9f578fa0ec3da11db158dce98ccaf225c19131b357f669651db3897b2S3Bucket7ACB823F",
+            "Ref": "AssetParameters7f7d123e91c502006a70a8f2b85e6a857aa355f73cce6713d33752d0c492e38cS3Bucket7632C9CF",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -449,7 +449,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters34c7dcc9f578fa0ec3da11db158dce98ccaf225c19131b357f669651db3897b2S3VersionKey1D948596",
+                          "Ref": "AssetParameters7f7d123e91c502006a70a8f2b85e6a857aa355f73cce6713d33752d0c492e38cS3VersionKey5C67FF74",
                         },
                       ],
                     },
@@ -462,7 +462,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters34c7dcc9f578fa0ec3da11db158dce98ccaf225c19131b357f669651db3897b2S3VersionKey1D948596",
+                          "Ref": "AssetParameters7f7d123e91c502006a70a8f2b85e6a857aa355f73cce6713d33752d0c492e38cS3VersionKey5C67FF74",
                         },
                       ],
                     },
@@ -4926,18 +4926,6 @@ Object {
       "Description": "S3 key for asset version \\"1ba28ce93db643201d8613eed4b49e8bfdbb812137021b400028887aa6cbfc21\\"",
       "Type": "String",
     },
-    "AssetParameters34c7dcc9f578fa0ec3da11db158dce98ccaf225c19131b357f669651db3897b2ArtifactHashA7C49A78": Object {
-      "Description": "Artifact hash for asset \\"34c7dcc9f578fa0ec3da11db158dce98ccaf225c19131b357f669651db3897b2\\"",
-      "Type": "String",
-    },
-    "AssetParameters34c7dcc9f578fa0ec3da11db158dce98ccaf225c19131b357f669651db3897b2S3Bucket7ACB823F": Object {
-      "Description": "S3 bucket for asset \\"34c7dcc9f578fa0ec3da11db158dce98ccaf225c19131b357f669651db3897b2\\"",
-      "Type": "String",
-    },
-    "AssetParameters34c7dcc9f578fa0ec3da11db158dce98ccaf225c19131b357f669651db3897b2S3VersionKey1D948596": Object {
-      "Description": "S3 key for asset version \\"34c7dcc9f578fa0ec3da11db158dce98ccaf225c19131b357f669651db3897b2\\"",
-      "Type": "String",
-    },
     "AssetParameters49a9f312aed7e8d4ad343bbad95b02deb3189efcc26bd4f6ed85af1ac968cef4ArtifactHash554D06EA": Object {
       "Description": "Artifact hash for asset \\"49a9f312aed7e8d4ad343bbad95b02deb3189efcc26bd4f6ed85af1ac968cef4\\"",
       "Type": "String",
@@ -4984,6 +4972,18 @@ Object {
     },
     "AssetParameters7af6295e521fd55af94332393ceffb3e866aac4dc4956321f7918f21e72199e4S3VersionKey326451BC": Object {
       "Description": "S3 key for asset version \\"7af6295e521fd55af94332393ceffb3e866aac4dc4956321f7918f21e72199e4\\"",
+      "Type": "String",
+    },
+    "AssetParameters7f7d123e91c502006a70a8f2b85e6a857aa355f73cce6713d33752d0c492e38cArtifactHashE675C176": Object {
+      "Description": "Artifact hash for asset \\"7f7d123e91c502006a70a8f2b85e6a857aa355f73cce6713d33752d0c492e38c\\"",
+      "Type": "String",
+    },
+    "AssetParameters7f7d123e91c502006a70a8f2b85e6a857aa355f73cce6713d33752d0c492e38cS3Bucket7632C9CF": Object {
+      "Description": "S3 bucket for asset \\"7f7d123e91c502006a70a8f2b85e6a857aa355f73cce6713d33752d0c492e38c\\"",
+      "Type": "String",
+    },
+    "AssetParameters7f7d123e91c502006a70a8f2b85e6a857aa355f73cce6713d33752d0c492e38cS3VersionKey5C67FF74": Object {
+      "Description": "S3 key for asset version \\"7f7d123e91c502006a70a8f2b85e6a857aa355f73cce6713d33752d0c492e38c\\"",
       "Type": "String",
     },
     "AssetParameters8625a217e0e7f0586edd183190019d9970344fa75c829365a84a47531a60a32eArtifactHashEC22613F": Object {
@@ -5490,7 +5490,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters34c7dcc9f578fa0ec3da11db158dce98ccaf225c19131b357f669651db3897b2S3Bucket7ACB823F",
+            "Ref": "AssetParameters7f7d123e91c502006a70a8f2b85e6a857aa355f73cce6713d33752d0c492e38cS3Bucket7632C9CF",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -5503,7 +5503,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters34c7dcc9f578fa0ec3da11db158dce98ccaf225c19131b357f669651db3897b2S3VersionKey1D948596",
+                          "Ref": "AssetParameters7f7d123e91c502006a70a8f2b85e6a857aa355f73cce6713d33752d0c492e38cS3VersionKey5C67FF74",
                         },
                       ],
                     },
@@ -5516,7 +5516,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters34c7dcc9f578fa0ec3da11db158dce98ccaf225c19131b357f669651db3897b2S3VersionKey1D948596",
+                          "Ref": "AssetParameters7f7d123e91c502006a70a8f2b85e6a857aa355f73cce6713d33752d0c492e38cS3VersionKey5C67FF74",
                         },
                       ],
                     },

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -2133,7 +2133,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters34c7dcc9f578fa0ec3da11db158dce98ccaf225c19131b357f669651db3897b2S3Bucket7ACB823F
+          Ref: AssetParameters7f7d123e91c502006a70a8f2b85e6a857aa355f73cce6713d33752d0c492e38cS3Bucket7632C9CF
         S3Key:
           Fn::Join:
             - ""
@@ -2141,12 +2141,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters34c7dcc9f578fa0ec3da11db158dce98ccaf225c19131b357f669651db3897b2S3VersionKey1D948596
+                      - Ref: AssetParameters7f7d123e91c502006a70a8f2b85e6a857aa355f73cce6713d33752d0c492e38cS3VersionKey5C67FF74
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters34c7dcc9f578fa0ec3da11db158dce98ccaf225c19131b357f669651db3897b2S3VersionKey1D948596
+                      - Ref: AssetParameters7f7d123e91c502006a70a8f2b85e6a857aa355f73cce6713d33752d0c492e38cS3VersionKey5C67FF74
       Role:
         Fn::GetAtt:
           - ConstructHubCatalogBuilderServiceRole7EB4C395
@@ -2924,18 +2924,18 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24"
-  AssetParameters34c7dcc9f578fa0ec3da11db158dce98ccaf225c19131b357f669651db3897b2S3Bucket7ACB823F:
+  AssetParameters7f7d123e91c502006a70a8f2b85e6a857aa355f73cce6713d33752d0c492e38cS3Bucket7632C9CF:
     Type: String
     Description: S3 bucket for asset
-      "34c7dcc9f578fa0ec3da11db158dce98ccaf225c19131b357f669651db3897b2"
-  AssetParameters34c7dcc9f578fa0ec3da11db158dce98ccaf225c19131b357f669651db3897b2S3VersionKey1D948596:
+      "7f7d123e91c502006a70a8f2b85e6a857aa355f73cce6713d33752d0c492e38c"
+  AssetParameters7f7d123e91c502006a70a8f2b85e6a857aa355f73cce6713d33752d0c492e38cS3VersionKey5C67FF74:
     Type: String
     Description: S3 key for asset version
-      "34c7dcc9f578fa0ec3da11db158dce98ccaf225c19131b357f669651db3897b2"
-  AssetParameters34c7dcc9f578fa0ec3da11db158dce98ccaf225c19131b357f669651db3897b2ArtifactHashA7C49A78:
+      "7f7d123e91c502006a70a8f2b85e6a857aa355f73cce6713d33752d0c492e38c"
+  AssetParameters7f7d123e91c502006a70a8f2b85e6a857aa355f73cce6713d33752d0c492e38cArtifactHashE675C176:
     Type: String
     Description: Artifact hash for asset
-      "34c7dcc9f578fa0ec3da11db158dce98ccaf225c19131b357f669651db3897b2"
+      "7f7d123e91c502006a70a8f2b85e6a857aa355f73cce6713d33752d0c492e38c"
   AssetParameters86636ae9c2e497c99bfcde8a9310daa981aaae2477613f256d5cfe22541cf103S3BucketA4207D31:
     Type: String
     Description: S3 bucket for asset


### PR DESCRIPTION
This allows to easily re-create the catalog from scratch if that is
ever needed. It might be useful to schedule this every so often, just
to ensure the catalog file stays healthy (but it is not done in the
context of this change).


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*