### PR TITLE
fix: missing permissions on cloudwatch:PutMetricData

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -6009,18 +6009,6 @@ Object {
     },
   },
   "Parameters": Object {
-    "AssetParameters1ba28ce93db643201d8613eed4b49e8bfdbb812137021b400028887aa6cbfc21ArtifactHashCD81A433": Object {
-      "Description": "Artifact hash for asset \\"1ba28ce93db643201d8613eed4b49e8bfdbb812137021b400028887aa6cbfc21\\"",
-      "Type": "String",
-    },
-    "AssetParameters1ba28ce93db643201d8613eed4b49e8bfdbb812137021b400028887aa6cbfc21S3Bucket06D21812": Object {
-      "Description": "S3 bucket for asset \\"1ba28ce93db643201d8613eed4b49e8bfdbb812137021b400028887aa6cbfc21\\"",
-      "Type": "String",
-    },
-    "AssetParameters1ba28ce93db643201d8613eed4b49e8bfdbb812137021b400028887aa6cbfc21S3VersionKey1BCE3833": Object {
-      "Description": "S3 key for asset version \\"1ba28ce93db643201d8613eed4b49e8bfdbb812137021b400028887aa6cbfc21\\"",
-      "Type": "String",
-    },
     "AssetParameters1feee2e2bb756ae6aeb10a87fe5e5b79120754f52b1528eb46d95f5b35f97591ArtifactHash4F5F19A2": Object {
       "Description": "Artifact hash for asset \\"1feee2e2bb756ae6aeb10a87fe5e5b79120754f52b1528eb46d95f5b35f97591\\"",
       "Type": "String",
@@ -6079,6 +6067,18 @@ Object {
     },
     "AssetParameters7379fd84eff0b591867de2678a7733efa22e810bf064da0c1d0ef6e0c30cc74eS3VersionKey15B55BAA": Object {
       "Description": "S3 key for asset version \\"7379fd84eff0b591867de2678a7733efa22e810bf064da0c1d0ef6e0c30cc74e\\"",
+      "Type": "String",
+    },
+    "AssetParameters79e603efe968ac49808df5587ffabdc3a5dbf21d0284a3ddac62e3eac7db12a6ArtifactHash905316EF": Object {
+      "Description": "Artifact hash for asset \\"79e603efe968ac49808df5587ffabdc3a5dbf21d0284a3ddac62e3eac7db12a6\\"",
+      "Type": "String",
+    },
+    "AssetParameters79e603efe968ac49808df5587ffabdc3a5dbf21d0284a3ddac62e3eac7db12a6S3Bucket8CA30ECC": Object {
+      "Description": "S3 bucket for asset \\"79e603efe968ac49808df5587ffabdc3a5dbf21d0284a3ddac62e3eac7db12a6\\"",
+      "Type": "String",
+    },
+    "AssetParameters79e603efe968ac49808df5587ffabdc3a5dbf21d0284a3ddac62e3eac7db12a6S3VersionKeyC57D4597": Object {
+      "Description": "S3 key for asset version \\"79e603efe968ac49808df5587ffabdc3a5dbf21d0284a3ddac62e3eac7db12a6\\"",
       "Type": "String",
     },
     "AssetParameters7af6295e521fd55af94332393ceffb3e866aac4dc4956321f7918f21e72199e4ArtifactHash5E28809B": Object {
@@ -11861,7 +11861,7 @@ function handler(event) {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters1ba28ce93db643201d8613eed4b49e8bfdbb812137021b400028887aa6cbfc21S3Bucket06D21812",
+            "Ref": "AssetParameters79e603efe968ac49808df5587ffabdc3a5dbf21d0284a3ddac62e3eac7db12a6S3Bucket8CA30ECC",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -11874,7 +11874,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1ba28ce93db643201d8613eed4b49e8bfdbb812137021b400028887aa6cbfc21S3VersionKey1BCE3833",
+                          "Ref": "AssetParameters79e603efe968ac49808df5587ffabdc3a5dbf21d0284a3ddac62e3eac7db12a6S3VersionKeyC57D4597",
                         },
                       ],
                     },
@@ -11887,7 +11887,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1ba28ce93db643201d8613eed4b49e8bfdbb812137021b400028887aa6cbfc21S3VersionKey1BCE3833",
+                          "Ref": "AssetParameters79e603efe968ac49808df5587ffabdc3a5dbf21d0284a3ddac62e3eac7db12a6S3VersionKeyC57D4597",
                         },
                       ],
                     },


### PR DESCRIPTION
The certificate expiry monitor was attempting to directly use the
CloudWatch API, but this failed as permissions were never granted.
This change swicthes to using AWS embedded metrics, so that no
special permissions are needed anymore.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*