### PR TITLE
fix: create HOME directory in EFS if it does not exist

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -105,18 +105,6 @@ Object {
       "Description": "S3 key for asset version \\"6c4e3d2383b1b7f493d4a873c73f292d109a402058ec3951bd81aa400f1ec362\\"",
       "Type": "String",
     },
-    "AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beArtifactHash5DE94BC7": Object {
-      "Description": "Artifact hash for asset \\"75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230be\\"",
-      "Type": "String",
-    },
-    "AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3BucketD7CA7618": Object {
-      "Description": "S3 bucket for asset \\"75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230be\\"",
-      "Type": "String",
-    },
-    "AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3VersionKey7C750AD6": Object {
-      "Description": "S3 key for asset version \\"75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230be\\"",
-      "Type": "String",
-    },
     "AssetParameters7e824dff8164e87d794261ec3601f3c0b0a9d602591a0a47e75fa02ae8d1ea5eArtifactHash3101EE2F": Object {
       "Description": "Artifact hash for asset \\"7e824dff8164e87d794261ec3601f3c0b0a9d602591a0a47e75fa02ae8d1ea5e\\"",
       "Type": "String",
@@ -199,6 +187,18 @@ Object {
     },
     "AssetParametersc24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cfS3VersionKey60329B70": Object {
       "Description": "S3 key for asset version \\"c24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cf\\"",
+      "Type": "String",
+    },
+    "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4ArtifactHashB4479B1B": Object {
+      "Description": "Artifact hash for asset \\"c875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4\\"",
+      "Type": "String",
+    },
+    "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3Bucket42E3B8B0": Object {
+      "Description": "S3 bucket for asset \\"c875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4\\"",
+      "Type": "String",
+    },
+    "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3": Object {
+      "Description": "S3 key for asset version \\"c875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4\\"",
       "Type": "String",
     },
     "AssetParametersd5594c96e8d8bc8ce1cd238fb011bd3e1a5c69dada29b4366e17e735f7617fa3ArtifactHash14563C69": Object {
@@ -4843,7 +4843,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3BucketD7CA7618",
+            "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3Bucket42E3B8B0",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -4856,7 +4856,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3VersionKey7C750AD6",
+                          "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3",
                         },
                       ],
                     },
@@ -4869,7 +4869,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3VersionKey7C750AD6",
+                          "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3",
                         },
                       ],
                     },
@@ -5285,7 +5285,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3BucketD7CA7618",
+            "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3Bucket42E3B8B0",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -5298,7 +5298,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3VersionKey7C750AD6",
+                          "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3",
                         },
                       ],
                     },
@@ -5311,7 +5311,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3VersionKey7C750AD6",
+                          "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3",
                         },
                       ],
                     },
@@ -7676,18 +7676,6 @@ Object {
       "Description": "S3 key for asset version \\"6c4e3d2383b1b7f493d4a873c73f292d109a402058ec3951bd81aa400f1ec362\\"",
       "Type": "String",
     },
-    "AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beArtifactHash5DE94BC7": Object {
-      "Description": "Artifact hash for asset \\"75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230be\\"",
-      "Type": "String",
-    },
-    "AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3BucketD7CA7618": Object {
-      "Description": "S3 bucket for asset \\"75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230be\\"",
-      "Type": "String",
-    },
-    "AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3VersionKey7C750AD6": Object {
-      "Description": "S3 key for asset version \\"75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230be\\"",
-      "Type": "String",
-    },
     "AssetParameters79e603efe968ac49808df5587ffabdc3a5dbf21d0284a3ddac62e3eac7db12a6ArtifactHash905316EF": Object {
       "Description": "Artifact hash for asset \\"79e603efe968ac49808df5587ffabdc3a5dbf21d0284a3ddac62e3eac7db12a6\\"",
       "Type": "String",
@@ -7794,6 +7782,18 @@ Object {
     },
     "AssetParametersc24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cfS3VersionKey60329B70": Object {
       "Description": "S3 key for asset version \\"c24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cf\\"",
+      "Type": "String",
+    },
+    "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4ArtifactHashB4479B1B": Object {
+      "Description": "Artifact hash for asset \\"c875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4\\"",
+      "Type": "String",
+    },
+    "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3Bucket42E3B8B0": Object {
+      "Description": "S3 bucket for asset \\"c875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4\\"",
+      "Type": "String",
+    },
+    "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3": Object {
+      "Description": "S3 key for asset version \\"c875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4\\"",
       "Type": "String",
     },
     "AssetParametersd5594c96e8d8bc8ce1cd238fb011bd3e1a5c69dada29b4366e17e735f7617fa3ArtifactHash14563C69": Object {
@@ -12609,7 +12609,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3BucketD7CA7618",
+            "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3Bucket42E3B8B0",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -12622,7 +12622,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3VersionKey7C750AD6",
+                          "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3",
                         },
                       ],
                     },
@@ -12635,7 +12635,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3VersionKey7C750AD6",
+                          "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3",
                         },
                       ],
                     },
@@ -13051,7 +13051,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3BucketD7CA7618",
+            "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3Bucket42E3B8B0",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -13064,7 +13064,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3VersionKey7C750AD6",
+                          "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3",
                         },
                       ],
                     },
@@ -13077,7 +13077,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3VersionKey7C750AD6",
+                          "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3",
                         },
                       ],
                     },
@@ -15710,18 +15710,6 @@ Object {
       "Description": "S3 key for asset version \\"6c4e3d2383b1b7f493d4a873c73f292d109a402058ec3951bd81aa400f1ec362\\"",
       "Type": "String",
     },
-    "AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beArtifactHash5DE94BC7": Object {
-      "Description": "Artifact hash for asset \\"75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230be\\"",
-      "Type": "String",
-    },
-    "AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3BucketD7CA7618": Object {
-      "Description": "S3 bucket for asset \\"75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230be\\"",
-      "Type": "String",
-    },
-    "AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3VersionKey7C750AD6": Object {
-      "Description": "S3 key for asset version \\"75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230be\\"",
-      "Type": "String",
-    },
     "AssetParameters7e824dff8164e87d794261ec3601f3c0b0a9d602591a0a47e75fa02ae8d1ea5eArtifactHash3101EE2F": Object {
       "Description": "Artifact hash for asset \\"7e824dff8164e87d794261ec3601f3c0b0a9d602591a0a47e75fa02ae8d1ea5e\\"",
       "Type": "String",
@@ -15804,6 +15792,18 @@ Object {
     },
     "AssetParametersc24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cfS3VersionKey60329B70": Object {
       "Description": "S3 key for asset version \\"c24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cf\\"",
+      "Type": "String",
+    },
+    "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4ArtifactHashB4479B1B": Object {
+      "Description": "Artifact hash for asset \\"c875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4\\"",
+      "Type": "String",
+    },
+    "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3Bucket42E3B8B0": Object {
+      "Description": "S3 bucket for asset \\"c875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4\\"",
+      "Type": "String",
+    },
+    "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3": Object {
+      "Description": "S3 key for asset version \\"c875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4\\"",
       "Type": "String",
     },
     "AssetParametersd5594c96e8d8bc8ce1cd238fb011bd3e1a5c69dada29b4366e17e735f7617fa3ArtifactHash14563C69": Object {
@@ -19700,7 +19700,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3BucketD7CA7618",
+            "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3Bucket42E3B8B0",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -19713,7 +19713,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3VersionKey7C750AD6",
+                          "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3",
                         },
                       ],
                     },
@@ -19726,7 +19726,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3VersionKey7C750AD6",
+                          "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3",
                         },
                       ],
                     },
@@ -20121,7 +20121,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3BucketD7CA7618",
+            "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3Bucket42E3B8B0",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -20134,7 +20134,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3VersionKey7C750AD6",
+                          "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3",
                         },
                       ],
                     },
@@ -20147,7 +20147,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3VersionKey7C750AD6",
+                          "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3",
                         },
                       ],
                     },

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -81,6 +81,18 @@ Object {
       "Description": "S3 key for asset version \\"516cab73c91fb1a1a9ada8da3852fead6468a28305ca5c46b319b4f98cc36fe9\\"",
       "Type": "String",
     },
+    "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3ArtifactHash135508FF": Object {
+      "Description": "Artifact hash for asset \\"5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3\\"",
+      "Type": "String",
+    },
+    "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3BucketEC636295": Object {
+      "Description": "S3 bucket for asset \\"5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3\\"",
+      "Type": "String",
+    },
+    "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2": Object {
+      "Description": "S3 key for asset version \\"5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3\\"",
+      "Type": "String",
+    },
     "AssetParameters67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24ArtifactHashBA91B77F": Object {
       "Description": "Artifact hash for asset \\"67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24\\"",
       "Type": "String",
@@ -187,18 +199,6 @@ Object {
     },
     "AssetParametersc24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cfS3VersionKey60329B70": Object {
       "Description": "S3 key for asset version \\"c24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cf\\"",
-      "Type": "String",
-    },
-    "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4ArtifactHashB4479B1B": Object {
-      "Description": "Artifact hash for asset \\"c875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4\\"",
-      "Type": "String",
-    },
-    "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3Bucket42E3B8B0": Object {
-      "Description": "S3 bucket for asset \\"c875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4\\"",
-      "Type": "String",
-    },
-    "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3": Object {
-      "Description": "S3 key for asset version \\"c875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4\\"",
       "Type": "String",
     },
     "AssetParametersd5594c96e8d8bc8ce1cd238fb011bd3e1a5c69dada29b4366e17e735f7617fa3ArtifactHash14563C69": Object {
@@ -4843,7 +4843,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3Bucket42E3B8B0",
+            "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3BucketEC636295",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -4856,7 +4856,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3",
+                          "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2",
                         },
                       ],
                     },
@@ -4869,7 +4869,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3",
+                          "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2",
                         },
                       ],
                     },
@@ -5285,7 +5285,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3Bucket42E3B8B0",
+            "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3BucketEC636295",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -5298,7 +5298,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3",
+                          "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2",
                         },
                       ],
                     },
@@ -5311,7 +5311,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3",
+                          "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2",
                         },
                       ],
                     },
@@ -7652,6 +7652,18 @@ Object {
       "Description": "S3 key for asset version \\"516cab73c91fb1a1a9ada8da3852fead6468a28305ca5c46b319b4f98cc36fe9\\"",
       "Type": "String",
     },
+    "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3ArtifactHash135508FF": Object {
+      "Description": "Artifact hash for asset \\"5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3\\"",
+      "Type": "String",
+    },
+    "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3BucketEC636295": Object {
+      "Description": "S3 bucket for asset \\"5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3\\"",
+      "Type": "String",
+    },
+    "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2": Object {
+      "Description": "S3 key for asset version \\"5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3\\"",
+      "Type": "String",
+    },
     "AssetParameters67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24ArtifactHashBA91B77F": Object {
       "Description": "Artifact hash for asset \\"67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24\\"",
       "Type": "String",
@@ -7782,18 +7794,6 @@ Object {
     },
     "AssetParametersc24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cfS3VersionKey60329B70": Object {
       "Description": "S3 key for asset version \\"c24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cf\\"",
-      "Type": "String",
-    },
-    "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4ArtifactHashB4479B1B": Object {
-      "Description": "Artifact hash for asset \\"c875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4\\"",
-      "Type": "String",
-    },
-    "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3Bucket42E3B8B0": Object {
-      "Description": "S3 bucket for asset \\"c875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4\\"",
-      "Type": "String",
-    },
-    "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3": Object {
-      "Description": "S3 key for asset version \\"c875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4\\"",
       "Type": "String",
     },
     "AssetParametersd5594c96e8d8bc8ce1cd238fb011bd3e1a5c69dada29b4366e17e735f7617fa3ArtifactHash14563C69": Object {
@@ -12609,7 +12609,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3Bucket42E3B8B0",
+            "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3BucketEC636295",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -12622,7 +12622,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3",
+                          "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2",
                         },
                       ],
                     },
@@ -12635,7 +12635,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3",
+                          "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2",
                         },
                       ],
                     },
@@ -13051,7 +13051,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3Bucket42E3B8B0",
+            "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3BucketEC636295",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -13064,7 +13064,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3",
+                          "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2",
                         },
                       ],
                     },
@@ -13077,7 +13077,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3",
+                          "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2",
                         },
                       ],
                     },
@@ -15686,6 +15686,18 @@ Object {
       "Description": "S3 key for asset version \\"516cab73c91fb1a1a9ada8da3852fead6468a28305ca5c46b319b4f98cc36fe9\\"",
       "Type": "String",
     },
+    "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3ArtifactHash135508FF": Object {
+      "Description": "Artifact hash for asset \\"5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3\\"",
+      "Type": "String",
+    },
+    "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3BucketEC636295": Object {
+      "Description": "S3 bucket for asset \\"5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3\\"",
+      "Type": "String",
+    },
+    "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2": Object {
+      "Description": "S3 key for asset version \\"5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3\\"",
+      "Type": "String",
+    },
     "AssetParameters67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24ArtifactHashBA91B77F": Object {
       "Description": "Artifact hash for asset \\"67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24\\"",
       "Type": "String",
@@ -15792,18 +15804,6 @@ Object {
     },
     "AssetParametersc24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cfS3VersionKey60329B70": Object {
       "Description": "S3 key for asset version \\"c24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cf\\"",
-      "Type": "String",
-    },
-    "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4ArtifactHashB4479B1B": Object {
-      "Description": "Artifact hash for asset \\"c875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4\\"",
-      "Type": "String",
-    },
-    "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3Bucket42E3B8B0": Object {
-      "Description": "S3 bucket for asset \\"c875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4\\"",
-      "Type": "String",
-    },
-    "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3": Object {
-      "Description": "S3 key for asset version \\"c875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4\\"",
       "Type": "String",
     },
     "AssetParametersd5594c96e8d8bc8ce1cd238fb011bd3e1a5c69dada29b4366e17e735f7617fa3ArtifactHash14563C69": Object {
@@ -19700,7 +19700,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3Bucket42E3B8B0",
+            "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3BucketEC636295",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -19713,7 +19713,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3",
+                          "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2",
                         },
                       ],
                     },
@@ -19726,7 +19726,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3",
+                          "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2",
                         },
                       ],
                     },
@@ -20121,7 +20121,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3Bucket42E3B8B0",
+            "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3BucketEC636295",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -20134,7 +20134,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3",
+                          "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2",
                         },
                       ],
                     },
@@ -20147,7 +20147,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3",
+                          "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2",
                         },
                       ],
                     },

--- a/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
+++ b/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
@@ -222,7 +222,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3Bucket42E3B8B0",
+            "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3BucketEC636295",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -235,7 +235,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3",
+                          "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2",
                         },
                       ],
                     },
@@ -248,7 +248,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3",
+                          "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2",
                         },
                       ],
                     },
@@ -889,7 +889,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3Bucket42E3B8B0",
+            "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3BucketEC636295",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -902,7 +902,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3",
+                          "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2",
                         },
                       ],
                     },
@@ -915,7 +915,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3",
+                          "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2",
                         },
                       ],
                     },
@@ -1513,7 +1513,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3Bucket42E3B8B0",
+            "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3BucketEC636295",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -1526,7 +1526,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3",
+                          "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2",
                         },
                       ],
                     },
@@ -1539,7 +1539,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3",
+                          "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2",
                         },
                       ],
                     },
@@ -2097,7 +2097,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3Bucket42E3B8B0",
+            "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3BucketEC636295",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -2110,7 +2110,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3",
+                          "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2",
                         },
                       ],
                     },
@@ -2123,7 +2123,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3",
+                          "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2",
                         },
                       ],
                     },

--- a/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
+++ b/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
@@ -222,7 +222,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3BucketD7CA7618",
+            "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3Bucket42E3B8B0",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -235,7 +235,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3VersionKey7C750AD6",
+                          "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3",
                         },
                       ],
                     },
@@ -248,7 +248,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3VersionKey7C750AD6",
+                          "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3",
                         },
                       ],
                     },
@@ -889,7 +889,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3BucketD7CA7618",
+            "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3Bucket42E3B8B0",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -902,7 +902,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3VersionKey7C750AD6",
+                          "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3",
                         },
                       ],
                     },
@@ -915,7 +915,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3VersionKey7C750AD6",
+                          "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3",
                         },
                       ],
                     },
@@ -1513,7 +1513,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3BucketD7CA7618",
+            "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3Bucket42E3B8B0",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -1526,7 +1526,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3VersionKey7C750AD6",
+                          "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3",
                         },
                       ],
                     },
@@ -1539,7 +1539,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3VersionKey7C750AD6",
+                          "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3",
                         },
                       ],
                     },
@@ -2097,7 +2097,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3BucketD7CA7618",
+            "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3Bucket42E3B8B0",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -2110,7 +2110,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3VersionKey7C750AD6",
+                          "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3",
                         },
                       ],
                     },
@@ -2123,7 +2123,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3VersionKey7C750AD6",
+                          "Ref": "AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3",
                         },
                       ],
                     },

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -2112,7 +2112,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3Bucket42E3B8B0
+          Ref: AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3BucketEC636295
         S3Key:
           Fn::Join:
             - ""
@@ -2120,12 +2120,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3
+                      - Ref: AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3
+                      - Ref: AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2
       Role:
         Fn::GetAtt:
           - ConstructHubOrchestrationDocGenpythonServiceRoleD16CBDB2
@@ -2346,7 +2346,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3Bucket42E3B8B0
+          Ref: AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3BucketEC636295
         S3Key:
           Fn::Join:
             - ""
@@ -2354,12 +2354,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3
+                      - Ref: AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3
+                      - Ref: AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2
       Role:
         Fn::GetAtt:
           - ConstructHubOrchestrationDocGentypescriptServiceRoleB56C2B19
@@ -4432,18 +4432,18 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "2427515f2f4227148e0ead251eb761b6c838e97be3bf77f18cb425949b71bf98"
-  AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3Bucket42E3B8B0:
+  AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3BucketEC636295:
     Type: String
     Description: S3 bucket for asset
-      "c875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4"
-  AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3:
+      "5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3"
+  AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2:
     Type: String
     Description: S3 key for asset version
-      "c875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4"
-  AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4ArtifactHashB4479B1B:
+      "5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3"
+  AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3ArtifactHash135508FF:
     Type: String
     Description: Artifact hash for asset
-      "c875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4"
+      "5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3"
   AssetParametersaed78bc431dd6cdac01afad951cec010f57f9d972c3f748c3ceeb5ca096544fdS3Bucket2D90B8C0:
     Type: String
     Description: S3 bucket for asset

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -2112,7 +2112,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3BucketD7CA7618
+          Ref: AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3Bucket42E3B8B0
         S3Key:
           Fn::Join:
             - ""
@@ -2120,12 +2120,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3VersionKey7C750AD6
+                      - Ref: AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3VersionKey7C750AD6
+                      - Ref: AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3
       Role:
         Fn::GetAtt:
           - ConstructHubOrchestrationDocGenpythonServiceRoleD16CBDB2
@@ -2346,7 +2346,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3BucketD7CA7618
+          Ref: AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3Bucket42E3B8B0
         S3Key:
           Fn::Join:
             - ""
@@ -2354,12 +2354,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3VersionKey7C750AD6
+                      - Ref: AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3VersionKey7C750AD6
+                      - Ref: AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3
       Role:
         Fn::GetAtt:
           - ConstructHubOrchestrationDocGentypescriptServiceRoleB56C2B19
@@ -4432,18 +4432,18 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "2427515f2f4227148e0ead251eb761b6c838e97be3bf77f18cb425949b71bf98"
-  AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3BucketD7CA7618:
+  AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3Bucket42E3B8B0:
     Type: String
     Description: S3 bucket for asset
-      "75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230be"
-  AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beS3VersionKey7C750AD6:
+      "c875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4"
+  AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4S3VersionKey4DD324D3:
     Type: String
     Description: S3 key for asset version
-      "75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230be"
-  AssetParameters75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230beArtifactHash5DE94BC7:
+      "c875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4"
+  AssetParametersc875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4ArtifactHashB4479B1B:
     Type: String
     Description: Artifact hash for asset
-      "75f48e0bcdd44387d27f83caba59489a5604099e9cfdc2eb37d3b270551230be"
+      "c875527a7d4778cd62553cffa6d3525b4addb89bf34e73c0590a87cdb9e2aaf4"
   AssetParametersaed78bc431dd6cdac01afad951cec010f57f9d972c3f748c3ceeb5ca096544fdS3Bucket2D90B8C0:
     Type: String
     Description: S3 bucket for asset


### PR DESCRIPTION
The "file system writable" call is susceptible to a "ENOENT" error in
case the HOME directory has not been created yet. If the environment
variable `$HOME` points to a non-existent directory, attempt to create
it, then proceed to use it as normal if that worked.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*