### PR TITLE
fix: do not attempt to share $HOME

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -81,18 +81,6 @@ Object {
       "Description": "S3 key for asset version \\"516cab73c91fb1a1a9ada8da3852fead6468a28305ca5c46b319b4f98cc36fe9\\"",
       "Type": "String",
     },
-    "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3ArtifactHash135508FF": Object {
-      "Description": "Artifact hash for asset \\"5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3\\"",
-      "Type": "String",
-    },
-    "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3BucketEC636295": Object {
-      "Description": "S3 bucket for asset \\"5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3\\"",
-      "Type": "String",
-    },
-    "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2": Object {
-      "Description": "S3 key for asset version \\"5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3\\"",
-      "Type": "String",
-    },
     "AssetParameters67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24ArtifactHashBA91B77F": Object {
       "Description": "Artifact hash for asset \\"67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24\\"",
       "Type": "String",
@@ -103,6 +91,18 @@ Object {
     },
     "AssetParameters67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24S3VersionKeyB0F28861": Object {
       "Description": "S3 key for asset version \\"67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24\\"",
+      "Type": "String",
+    },
+    "AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fArtifactHash0E5BE15B": Object {
+      "Description": "Artifact hash for asset \\"6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5f\\"",
+      "Type": "String",
+    },
+    "AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3Bucket46FC2A6C": Object {
+      "Description": "S3 bucket for asset \\"6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5f\\"",
+      "Type": "String",
+    },
+    "AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3VersionKey3B5FCD84": Object {
+      "Description": "S3 key for asset version \\"6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5f\\"",
       "Type": "String",
     },
     "AssetParameters6c4e3d2383b1b7f493d4a873c73f292d109a402058ec3951bd81aa400f1ec362ArtifactHash4E9B3694": Object {
@@ -4843,7 +4843,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3BucketEC636295",
+            "Ref": "AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3Bucket46FC2A6C",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -4856,7 +4856,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2",
+                          "Ref": "AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3VersionKey3B5FCD84",
                         },
                       ],
                     },
@@ -4869,7 +4869,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2",
+                          "Ref": "AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3VersionKey3B5FCD84",
                         },
                       ],
                     },
@@ -4922,7 +4922,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
               ],
             },
             "HEADER_SPAN": "true",
-            "HOME": "/mnt/efs/HOME",
+            "NPM_CACHE": "/mnt/efs/npm-cache",
             "TARGET_LANGUAGE": "python",
             "TMPDIR": "/mnt/efs",
           },
@@ -5285,7 +5285,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3BucketEC636295",
+            "Ref": "AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3Bucket46FC2A6C",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -5298,7 +5298,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2",
+                          "Ref": "AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3VersionKey3B5FCD84",
                         },
                       ],
                     },
@@ -5311,7 +5311,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2",
+                          "Ref": "AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3VersionKey3B5FCD84",
                         },
                       ],
                     },
@@ -5364,7 +5364,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
               ],
             },
             "HEADER_SPAN": "true",
-            "HOME": "/mnt/efs/HOME",
+            "NPM_CACHE": "/mnt/efs/npm-cache",
             "TARGET_LANGUAGE": "typescript",
             "TMPDIR": "/mnt/efs",
           },
@@ -5766,7 +5766,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
         "Environment": Object {
           "Variables": Object {
             "EFS_MOUNT_PATH": "/mnt/efs",
-            "IGNORE_DIRS": "/mnt/efs/HOME",
+            "IGNORE_DIRS": "/mnt/efs/npm-cache",
           },
         },
         "FileSystemConfigs": Array [
@@ -7652,18 +7652,6 @@ Object {
       "Description": "S3 key for asset version \\"516cab73c91fb1a1a9ada8da3852fead6468a28305ca5c46b319b4f98cc36fe9\\"",
       "Type": "String",
     },
-    "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3ArtifactHash135508FF": Object {
-      "Description": "Artifact hash for asset \\"5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3\\"",
-      "Type": "String",
-    },
-    "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3BucketEC636295": Object {
-      "Description": "S3 bucket for asset \\"5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3\\"",
-      "Type": "String",
-    },
-    "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2": Object {
-      "Description": "S3 key for asset version \\"5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3\\"",
-      "Type": "String",
-    },
     "AssetParameters67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24ArtifactHashBA91B77F": Object {
       "Description": "Artifact hash for asset \\"67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24\\"",
       "Type": "String",
@@ -7674,6 +7662,18 @@ Object {
     },
     "AssetParameters67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24S3VersionKeyB0F28861": Object {
       "Description": "S3 key for asset version \\"67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24\\"",
+      "Type": "String",
+    },
+    "AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fArtifactHash0E5BE15B": Object {
+      "Description": "Artifact hash for asset \\"6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5f\\"",
+      "Type": "String",
+    },
+    "AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3Bucket46FC2A6C": Object {
+      "Description": "S3 bucket for asset \\"6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5f\\"",
+      "Type": "String",
+    },
+    "AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3VersionKey3B5FCD84": Object {
+      "Description": "S3 key for asset version \\"6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5f\\"",
       "Type": "String",
     },
     "AssetParameters6c4e3d2383b1b7f493d4a873c73f292d109a402058ec3951bd81aa400f1ec362ArtifactHash4E9B3694": Object {
@@ -12609,7 +12609,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3BucketEC636295",
+            "Ref": "AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3Bucket46FC2A6C",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -12622,7 +12622,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2",
+                          "Ref": "AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3VersionKey3B5FCD84",
                         },
                       ],
                     },
@@ -12635,7 +12635,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2",
+                          "Ref": "AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3VersionKey3B5FCD84",
                         },
                       ],
                     },
@@ -12688,7 +12688,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
               ],
             },
             "HEADER_SPAN": "true",
-            "HOME": "/mnt/efs/HOME",
+            "NPM_CACHE": "/mnt/efs/npm-cache",
             "TARGET_LANGUAGE": "python",
             "TMPDIR": "/mnt/efs",
           },
@@ -13051,7 +13051,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3BucketEC636295",
+            "Ref": "AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3Bucket46FC2A6C",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -13064,7 +13064,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2",
+                          "Ref": "AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3VersionKey3B5FCD84",
                         },
                       ],
                     },
@@ -13077,7 +13077,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2",
+                          "Ref": "AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3VersionKey3B5FCD84",
                         },
                       ],
                     },
@@ -13130,7 +13130,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
               ],
             },
             "HEADER_SPAN": "true",
-            "HOME": "/mnt/efs/HOME",
+            "NPM_CACHE": "/mnt/efs/npm-cache",
             "TARGET_LANGUAGE": "typescript",
             "TMPDIR": "/mnt/efs",
           },
@@ -13532,7 +13532,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
         "Environment": Object {
           "Variables": Object {
             "EFS_MOUNT_PATH": "/mnt/efs",
-            "IGNORE_DIRS": "/mnt/efs/HOME",
+            "IGNORE_DIRS": "/mnt/efs/npm-cache",
           },
         },
         "FileSystemConfigs": Array [
@@ -15686,18 +15686,6 @@ Object {
       "Description": "S3 key for asset version \\"516cab73c91fb1a1a9ada8da3852fead6468a28305ca5c46b319b4f98cc36fe9\\"",
       "Type": "String",
     },
-    "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3ArtifactHash135508FF": Object {
-      "Description": "Artifact hash for asset \\"5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3\\"",
-      "Type": "String",
-    },
-    "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3BucketEC636295": Object {
-      "Description": "S3 bucket for asset \\"5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3\\"",
-      "Type": "String",
-    },
-    "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2": Object {
-      "Description": "S3 key for asset version \\"5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3\\"",
-      "Type": "String",
-    },
     "AssetParameters67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24ArtifactHashBA91B77F": Object {
       "Description": "Artifact hash for asset \\"67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24\\"",
       "Type": "String",
@@ -15708,6 +15696,18 @@ Object {
     },
     "AssetParameters67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24S3VersionKeyB0F28861": Object {
       "Description": "S3 key for asset version \\"67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24\\"",
+      "Type": "String",
+    },
+    "AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fArtifactHash0E5BE15B": Object {
+      "Description": "Artifact hash for asset \\"6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5f\\"",
+      "Type": "String",
+    },
+    "AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3Bucket46FC2A6C": Object {
+      "Description": "S3 bucket for asset \\"6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5f\\"",
+      "Type": "String",
+    },
+    "AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3VersionKey3B5FCD84": Object {
+      "Description": "S3 key for asset version \\"6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5f\\"",
       "Type": "String",
     },
     "AssetParameters6c4e3d2383b1b7f493d4a873c73f292d109a402058ec3951bd81aa400f1ec362ArtifactHash4E9B3694": Object {
@@ -19700,7 +19700,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3BucketEC636295",
+            "Ref": "AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3Bucket46FC2A6C",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -19713,7 +19713,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2",
+                          "Ref": "AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3VersionKey3B5FCD84",
                         },
                       ],
                     },
@@ -19726,7 +19726,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2",
+                          "Ref": "AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3VersionKey3B5FCD84",
                         },
                       ],
                     },
@@ -19758,7 +19758,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
               ],
             },
             "HEADER_SPAN": "true",
-            "HOME": "/mnt/efs/HOME",
+            "NPM_CACHE": "/mnt/efs/npm-cache",
             "TARGET_LANGUAGE": "python",
             "TMPDIR": "/mnt/efs",
           },
@@ -20121,7 +20121,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3BucketEC636295",
+            "Ref": "AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3Bucket46FC2A6C",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -20134,7 +20134,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2",
+                          "Ref": "AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3VersionKey3B5FCD84",
                         },
                       ],
                     },
@@ -20147,7 +20147,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2",
+                          "Ref": "AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3VersionKey3B5FCD84",
                         },
                       ],
                     },
@@ -20179,7 +20179,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
               ],
             },
             "HEADER_SPAN": "true",
-            "HOME": "/mnt/efs/HOME",
+            "NPM_CACHE": "/mnt/efs/npm-cache",
             "TARGET_LANGUAGE": "typescript",
             "TMPDIR": "/mnt/efs",
           },
@@ -20581,7 +20581,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
         "Environment": Object {
           "Variables": Object {
             "EFS_MOUNT_PATH": "/mnt/efs",
-            "IGNORE_DIRS": "/mnt/efs/HOME",
+            "IGNORE_DIRS": "/mnt/efs/npm-cache",
           },
         },
         "FileSystemConfigs": Array [

--- a/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
+++ b/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
@@ -222,7 +222,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3BucketEC636295",
+            "Ref": "AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3Bucket46FC2A6C",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -235,7 +235,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2",
+                          "Ref": "AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3VersionKey3B5FCD84",
                         },
                       ],
                     },
@@ -248,7 +248,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2",
+                          "Ref": "AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3VersionKey3B5FCD84",
                         },
                       ],
                     },
@@ -280,7 +280,7 @@ Object {
               ],
             },
             "HEADER_SPAN": "true",
-            "HOME": "/mnt/efs/HOME",
+            "NPM_CACHE": "/mnt/efs/npm-cache",
             "TARGET_LANGUAGE": "python",
             "TMPDIR": "/mnt/efs",
           },
@@ -889,7 +889,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3BucketEC636295",
+            "Ref": "AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3Bucket46FC2A6C",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -902,7 +902,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2",
+                          "Ref": "AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3VersionKey3B5FCD84",
                         },
                       ],
                     },
@@ -915,7 +915,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2",
+                          "Ref": "AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3VersionKey3B5FCD84",
                         },
                       ],
                     },
@@ -950,7 +950,7 @@ Object {
               ],
             },
             "HEADER_SPAN": "true",
-            "HOME": "/mnt/efs/HOME",
+            "NPM_CACHE": "/mnt/efs/npm-cache",
             "TARGET_LANGUAGE": "python",
             "TMPDIR": "/mnt/efs",
           },
@@ -1513,7 +1513,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3BucketEC636295",
+            "Ref": "AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3Bucket46FC2A6C",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -1526,7 +1526,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2",
+                          "Ref": "AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3VersionKey3B5FCD84",
                         },
                       ],
                     },
@@ -1539,7 +1539,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2",
+                          "Ref": "AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3VersionKey3B5FCD84",
                         },
                       ],
                     },
@@ -1592,7 +1592,7 @@ Object {
               ],
             },
             "HEADER_SPAN": "true",
-            "HOME": "/mnt/efs/HOME",
+            "NPM_CACHE": "/mnt/efs/npm-cache",
             "TARGET_LANGUAGE": "python",
             "TMPDIR": "/mnt/efs",
           },
@@ -2097,7 +2097,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3BucketEC636295",
+            "Ref": "AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3Bucket46FC2A6C",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -2110,7 +2110,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2",
+                          "Ref": "AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3VersionKey3B5FCD84",
                         },
                       ],
                     },
@@ -2123,7 +2123,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2",
+                          "Ref": "AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3VersionKey3B5FCD84",
                         },
                       ],
                     },
@@ -2137,7 +2137,7 @@ Object {
         "Environment": Object {
           "Variables": Object {
             "HEADER_SPAN": "true",
-            "HOME": "/mnt/efs/HOME",
+            "NPM_CACHE": "/mnt/efs/npm-cache",
             "TARGET_LANGUAGE": "python",
             "TMPDIR": "/mnt/efs",
           },

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -1910,7 +1910,7 @@ Resources:
       Environment:
         Variables:
           EFS_MOUNT_PATH: /mnt/efs
-          IGNORE_DIRS: /mnt/efs/HOME
+          IGNORE_DIRS: /mnt/efs/npm-cache
       FileSystemConfigs:
         - Arn:
             Fn::Join:
@@ -2112,7 +2112,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3BucketEC636295
+          Ref: AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3Bucket46FC2A6C
         S3Key:
           Fn::Join:
             - ""
@@ -2120,12 +2120,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2
+                      - Ref: AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3VersionKey3B5FCD84
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2
+                      - Ref: AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3VersionKey3B5FCD84
       Role:
         Fn::GetAtt:
           - ConstructHubOrchestrationDocGenpythonServiceRoleD16CBDB2
@@ -2136,7 +2136,7 @@ Resources:
           HEADER_SPAN: "true"
           TARGET_LANGUAGE: python
           TMPDIR: /mnt/efs
-          HOME: /mnt/efs/HOME
+          NPM_CACHE: /mnt/efs/npm-cache
           CODE_ARTIFACT_API_ENDPOINT:
             Fn::Select:
               - 1
@@ -2346,7 +2346,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3BucketEC636295
+          Ref: AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3Bucket46FC2A6C
         S3Key:
           Fn::Join:
             - ""
@@ -2354,12 +2354,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2
+                      - Ref: AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3VersionKey3B5FCD84
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2
+                      - Ref: AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3VersionKey3B5FCD84
       Role:
         Fn::GetAtt:
           - ConstructHubOrchestrationDocGentypescriptServiceRoleB56C2B19
@@ -2370,7 +2370,7 @@ Resources:
           HEADER_SPAN: "true"
           TARGET_LANGUAGE: typescript
           TMPDIR: /mnt/efs
-          HOME: /mnt/efs/HOME
+          NPM_CACHE: /mnt/efs/npm-cache
           CODE_ARTIFACT_API_ENDPOINT:
             Fn::Select:
               - 1
@@ -4432,18 +4432,18 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "2427515f2f4227148e0ead251eb761b6c838e97be3bf77f18cb425949b71bf98"
-  AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3BucketEC636295:
+  AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3Bucket46FC2A6C:
     Type: String
     Description: S3 bucket for asset
-      "5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3"
-  AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3S3VersionKey0B6671C2:
+      "6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5f"
+  AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fS3VersionKey3B5FCD84:
     Type: String
     Description: S3 key for asset version
-      "5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3"
-  AssetParameters5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3ArtifactHash135508FF:
+      "6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5f"
+  AssetParameters6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5fArtifactHash0E5BE15B:
     Type: String
     Description: Artifact hash for asset
-      "5abbe4d206588da10173427e018e5ecf68ce4c95f7ba2d24f57d8fd26d5c65f3"
+      "6a211f4692221a9e2673f51ed0d4cbe3eb2043136d993a62202e9644ba317f5f"
   AssetParametersaed78bc431dd6cdac01afad951cec010f57f9d972c3f748c3ceeb5ca096544fdS3Bucket2D90B8C0:
     Type: String
     Description: S3 bucket for asset

--- a/src/backend/orchestration/index.ts
+++ b/src/backend/orchestration/index.ts
@@ -253,7 +253,7 @@ export class Orchestration extends Construct {
       description: '[ConstructHub/CleanUpEFS] Cleans up leftover files from an EFS file system',
       environment: {
         EFS_MOUNT_PATH: efsMountPath,
-        IGNORE_DIRS: `${efsMountPath}/HOME`,
+        IGNORE_DIRS: `${efsMountPath}${Transliterator.SHARED_NPM_CACHE_PATH}`,
       },
       memorySize: 1_024,
       timeout: Duration.minutes(15),

--- a/src/backend/shared/code-artifact.lambda-shared.ts
+++ b/src/backend/shared/code-artifact.lambda-shared.ts
@@ -1,5 +1,5 @@
-import { spawn } from 'child_process';
 import { CodeArtifact } from 'aws-sdk';
+import { shellOut } from './shell-out.lambda-shared';
 
 export interface CodeArtifactProps {
   /**
@@ -41,20 +41,4 @@ export async function logInWithCodeArtifact({ endpoint, domain, domainOwner, api
   await shellOut('npm', 'config', 'set', `registry=${endpoint}`);
   await shellOut('npm', 'config', 'set', `${protoRelativeEndpoint}:_authToken=${authorizationToken}`);
   await shellOut('npm', 'config', 'set', `${protoRelativeEndpoint}:always-auth=true`);
-
-  function shellOut(cmd: string, ...args: readonly string[]): Promise<void> {
-    return new Promise<void>((ok, ko) => {
-      const child = spawn(cmd, args, { stdio: ['ignore', 'inherit', 'inherit'] });
-      child.once('error', ko);
-      child.once('close', (code, signal) => {
-        if (code === 0) {
-          return ok();
-        }
-        const reason = code != null
-          ? `exit code ${code}`
-          : `signal ${signal}`;
-        ko(new Error(`Command "${cmd} ${args.join(' ')}" failed with ${reason}`));
-      });
-    });
-  }
 }

--- a/src/backend/shared/shell-out.lambda-shared.ts
+++ b/src/backend/shared/shell-out.lambda-shared.ts
@@ -1,0 +1,20 @@
+import { spawn } from 'child_process';
+
+/**
+ * Executes the specified command in a sub-shell, and asserts success.
+ */
+export function shellOut(cmd: string, ...args: readonly string[]): Promise<void> {
+  return new Promise<void>((ok, ko) => {
+    const child = spawn(cmd, args, { stdio: ['ignore', 'inherit', 'inherit'] });
+    child.once('error', ko);
+    child.once('close', (code, signal) => {
+      if (code === 0) {
+        return ok();
+      }
+      const reason = code != null
+        ? `exit code ${code}`
+        : `signal ${signal}`;
+      ko(new Error(`Command "${cmd} ${args.join(' ')}" failed with ${reason}`));
+    });
+  });
+}

--- a/src/backend/transliterator/index.ts
+++ b/src/backend/transliterator/index.ts
@@ -91,6 +91,11 @@ export interface TransliteratorVpcEndpoints {
  * Transliterates jsii assemblies to various other languages.
  */
 export class Transliterator extends Construct {
+  /**
+   * The path under which the npm cache will be located, within the EFS mount.
+   */
+  public static readonly SHARED_NPM_CACHE_PATH = '/npm-cache';
+
   public readonly function: IFunction
 
   public constructor(scope: Construct, id: string, props: TransliteratorProps) {
@@ -111,8 +116,8 @@ export class Transliterator extends Construct {
       TARGET_LANGUAGE: props.language.toString(),
       // Override $TMPDIR to be on the EFS volume (so we are not limited to 512MB)
       TMPDIR: EFS_MOUNT_PATH,
-      // Override $HOME to be a fixed directory in the EFS volume (so we share npm caches)
-      HOME: `${EFS_MOUNT_PATH}/HOME`,
+      // Configure a fixed directory in the EFS volume where we share npm caches
+      NPM_CACHE: `${EFS_MOUNT_PATH}${Transliterator.SHARED_NPM_CACHE_PATH}`,
     };
     if (props.vpcEndpoints) {
       // Those are returned as an array of HOSTED_ZONE_ID:DNS_NAME... We care


### PR DESCRIPTION
If all concurrent Lambda functions share a single $HOME, they end up all
trying to update the same `.npmrc` file. This leads to stale file
descriptor errors (ERRNO -116 / Exit code 140). Instead of sharing the
whole $HOME, configure the NPM cache directory, so that the cache is
shared, but all lambdas keep "their own" home directory.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*