### PR TITLE
fix: add no-cache to index.html

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -129,6 +129,30 @@ Object {
       "Description": "S3 key for asset version \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
     },
+    "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441ArtifactHash4025BA80": Object {
+      "Description": "Artifact hash for asset \\"90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441\\"",
+      "Type": "String",
+    },
+    "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3Bucket60632F31": Object {
+      "Description": "S3 bucket for asset \\"90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441\\"",
+      "Type": "String",
+    },
+    "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3VersionKey311393EB": Object {
+      "Description": "S3 key for asset version \\"90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441\\"",
+      "Type": "String",
+    },
+    "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8ArtifactHash94E1E495": Object {
+      "Description": "Artifact hash for asset \\"99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8\\"",
+      "Type": "String",
+    },
+    "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3Bucket02CF8954": Object {
+      "Description": "S3 bucket for asset \\"99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8\\"",
+      "Type": "String",
+    },
+    "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3VersionKeyF00B9EC5": Object {
+      "Description": "S3 key for asset version \\"99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8\\"",
+      "Type": "String",
+    },
     "AssetParametersb71e1be6a7755e2db27ab32b3b3798af645eef7a61fdace74eed9545f739fe01ArtifactHash9925BDB1": Object {
       "Description": "Artifact hash for asset \\"b71e1be6a7755e2db27ab32b3b3798af645eef7a61fdace74eed9545f739fe01\\"",
       "Type": "String",
@@ -139,18 +163,6 @@ Object {
     },
     "AssetParametersb71e1be6a7755e2db27ab32b3b3798af645eef7a61fdace74eed9545f739fe01S3VersionKeyF00BCB48": Object {
       "Description": "S3 key for asset version \\"b71e1be6a7755e2db27ab32b3b3798af645eef7a61fdace74eed9545f739fe01\\"",
-      "Type": "String",
-    },
-    "AssetParametersc0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5ArtifactHashE6CA8ED1": Object {
-      "Description": "Artifact hash for asset \\"c0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5\\"",
-      "Type": "String",
-    },
-    "AssetParametersc0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5S3Bucket3B8113EA": Object {
-      "Description": "S3 bucket for asset \\"c0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5\\"",
-      "Type": "String",
-    },
-    "AssetParametersc0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5S3VersionKey962B23F9": Object {
-      "Description": "S3 key for asset version \\"c0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5\\"",
       "Type": "String",
     },
     "AssetParametersc24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cfArtifactHash85F58E48": Object {
@@ -6031,6 +6043,107 @@ function handler(event) {
       },
       "Type": "AWS::CloudFront::Function",
     },
+    "ConstructHubWebAppBucketDeploymentAwsCliLayerED1AB8B3": Object {
+      "Properties": Object {
+        "Content": Object {
+          "S3Bucket": Object {
+            "Ref": "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3BucketAEADE8C7",
+          },
+          "S3Key": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                Object {
+                  "Fn::Select": Array [
+                    0,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3VersionKeyE415415F",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                Object {
+                  "Fn::Select": Array [
+                    1,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3VersionKeyE415415F",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            ],
+          },
+        },
+        "Description": "/opt/awscli/aws",
+      },
+      "Type": "AWS::Lambda::LayerVersion",
+    },
+    "ConstructHubWebAppBucketDeploymentCustomResourceF461CEA4": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "DestinationBucketName": Object {
+          "Ref": "ConstructHubWebAppWebsiteBucket4B2B9DB2",
+        },
+        "Prune": false,
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536",
+            "Arn",
+          ],
+        },
+        "SourceBucketNames": Array [
+          Object {
+            "Ref": "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3Bucket02CF8954",
+          },
+        ],
+        "SourceObjectKeys": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                Object {
+                  "Fn::Select": Array [
+                    0,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3VersionKeyF00B9EC5",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                Object {
+                  "Fn::Select": Array [
+                    1,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3VersionKeyF00B9EC5",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "Custom::CDKBucketDeployment",
+      "UpdateReplacePolicy": "Delete",
+    },
     "ConstructHubWebAppCacheInvalidator07CDD78B": Object {
       "DependsOn": Array [
         "ConstructHubWebAppCacheInvalidatorServiceRoleDefaultPolicy6CB0D51E",
@@ -6158,110 +6271,6 @@ function handler(event) {
         ],
       },
       "Type": "AWS::IAM::Policy",
-    },
-    "ConstructHubWebAppDeployWebsiteAwsCliLayer23CFFBC1": Object {
-      "Properties": Object {
-        "Content": Object {
-          "S3Bucket": Object {
-            "Ref": "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3BucketAEADE8C7",
-          },
-          "S3Key": Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                Object {
-                  "Fn::Select": Array [
-                    0,
-                    Object {
-                      "Fn::Split": Array [
-                        "||",
-                        Object {
-                          "Ref": "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3VersionKeyE415415F",
-                        },
-                      ],
-                    },
-                  ],
-                },
-                Object {
-                  "Fn::Select": Array [
-                    1,
-                    Object {
-                      "Fn::Split": Array [
-                        "||",
-                        Object {
-                          "Ref": "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3VersionKeyE415415F",
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            ],
-          },
-        },
-        "Description": "/opt/awscli/aws",
-      },
-      "Type": "AWS::Lambda::LayerVersion",
-    },
-    "ConstructHubWebAppDeployWebsiteCustomResourceE6DF98C9": Object {
-      "DeletionPolicy": "Delete",
-      "Properties": Object {
-        "DestinationBucketName": Object {
-          "Ref": "ConstructHubWebAppWebsiteBucket4B2B9DB2",
-        },
-        "DistributionId": Object {
-          "Ref": "ConstructHubWebAppDistribution1F181DC9",
-        },
-        "Prune": true,
-        "ServiceToken": Object {
-          "Fn::GetAtt": Array [
-            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536",
-            "Arn",
-          ],
-        },
-        "SourceBucketNames": Array [
-          Object {
-            "Ref": "AssetParametersc0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5S3Bucket3B8113EA",
-          },
-        ],
-        "SourceObjectKeys": Array [
-          Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                Object {
-                  "Fn::Select": Array [
-                    0,
-                    Object {
-                      "Fn::Split": Array [
-                        "||",
-                        Object {
-                          "Ref": "AssetParametersc0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5S3VersionKey962B23F9",
-                        },
-                      ],
-                    },
-                  ],
-                },
-                Object {
-                  "Fn::Select": Array [
-                    1,
-                    Object {
-                      "Fn::Split": Array [
-                        "||",
-                        Object {
-                          "Ref": "AssetParametersc0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5S3VersionKey962B23F9",
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            ],
-          },
-        ],
-      },
-      "Type": "Custom::CDKBucketDeployment",
-      "UpdateReplacePolicy": "Delete",
     },
     "ConstructHubWebAppDistribution1F181DC9": Object {
       "Properties": Object {
@@ -6402,6 +6411,110 @@ function handler(event) {
         },
       },
       "Type": "AWS::CloudFront::CloudFrontOriginAccessIdentity",
+    },
+    "ConstructHubWebAppHTMLBucketDeploymentAwsCliLayer44B97C39": Object {
+      "Properties": Object {
+        "Content": Object {
+          "S3Bucket": Object {
+            "Ref": "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3BucketAEADE8C7",
+          },
+          "S3Key": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                Object {
+                  "Fn::Select": Array [
+                    0,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3VersionKeyE415415F",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                Object {
+                  "Fn::Select": Array [
+                    1,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3VersionKeyE415415F",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            ],
+          },
+        },
+        "Description": "/opt/awscli/aws",
+      },
+      "Type": "AWS::Lambda::LayerVersion",
+    },
+    "ConstructHubWebAppHTMLBucketDeploymentCustomResource21291B7B": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "DestinationBucketName": Object {
+          "Ref": "ConstructHubWebAppWebsiteBucket4B2B9DB2",
+        },
+        "Prune": false,
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536",
+            "Arn",
+          ],
+        },
+        "SourceBucketNames": Array [
+          Object {
+            "Ref": "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3Bucket60632F31",
+          },
+        ],
+        "SourceObjectKeys": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                Object {
+                  "Fn::Select": Array [
+                    0,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3VersionKey311393EB",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                Object {
+                  "Fn::Select": Array [
+                    1,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3VersionKey311393EB",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+        "SystemMetadata": Object {
+          "cache-control": "no-cache",
+        },
+      },
+      "Type": "Custom::CDKBucketDeployment",
+      "UpdateReplacePolicy": "Delete",
     },
     "ConstructHubWebAppWebsiteBucket4B2B9DB2": Object {
       "DeletionPolicy": "Retain",
@@ -6677,7 +6790,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParametersc0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5S3Bucket3B8113EA",
+                        "Ref": "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3Bucket02CF8954",
                       },
                     ],
                   ],
@@ -6692,7 +6805,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParametersc0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5S3Bucket3B8113EA",
+                        "Ref": "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3Bucket02CF8954",
                       },
                       "/*",
                     ],
@@ -6735,11 +6848,44 @@ function handler(event) {
             },
             Object {
               "Action": Array [
-                "cloudfront:GetInvalidation",
-                "cloudfront:CreateInvalidation",
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
               ],
               "Effect": "Allow",
-              "Resource": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Ref": "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3Bucket60632F31",
+                      },
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Ref": "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3Bucket60632F31",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
             },
           ],
           "Version": "2012-10-17",
@@ -7030,6 +7176,30 @@ Object {
       "Description": "S3 key for asset version \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
     },
+    "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441ArtifactHash4025BA80": Object {
+      "Description": "Artifact hash for asset \\"90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441\\"",
+      "Type": "String",
+    },
+    "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3Bucket60632F31": Object {
+      "Description": "S3 bucket for asset \\"90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441\\"",
+      "Type": "String",
+    },
+    "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3VersionKey311393EB": Object {
+      "Description": "S3 key for asset version \\"90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441\\"",
+      "Type": "String",
+    },
+    "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8ArtifactHash94E1E495": Object {
+      "Description": "Artifact hash for asset \\"99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8\\"",
+      "Type": "String",
+    },
+    "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3Bucket02CF8954": Object {
+      "Description": "S3 bucket for asset \\"99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8\\"",
+      "Type": "String",
+    },
+    "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3VersionKeyF00B9EC5": Object {
+      "Description": "S3 key for asset version \\"99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8\\"",
+      "Type": "String",
+    },
     "AssetParametersb71e1be6a7755e2db27ab32b3b3798af645eef7a61fdace74eed9545f739fe01ArtifactHash9925BDB1": Object {
       "Description": "Artifact hash for asset \\"b71e1be6a7755e2db27ab32b3b3798af645eef7a61fdace74eed9545f739fe01\\"",
       "Type": "String",
@@ -7040,18 +7210,6 @@ Object {
     },
     "AssetParametersb71e1be6a7755e2db27ab32b3b3798af645eef7a61fdace74eed9545f739fe01S3VersionKeyF00BCB48": Object {
       "Description": "S3 key for asset version \\"b71e1be6a7755e2db27ab32b3b3798af645eef7a61fdace74eed9545f739fe01\\"",
-      "Type": "String",
-    },
-    "AssetParametersc0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5ArtifactHashE6CA8ED1": Object {
-      "Description": "Artifact hash for asset \\"c0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5\\"",
-      "Type": "String",
-    },
-    "AssetParametersc0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5S3Bucket3B8113EA": Object {
-      "Description": "S3 bucket for asset \\"c0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5\\"",
-      "Type": "String",
-    },
-    "AssetParametersc0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5S3VersionKey962B23F9": Object {
-      "Description": "S3 key for asset version \\"c0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5\\"",
       "Type": "String",
     },
     "AssetParametersc24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cfArtifactHash85F58E48": Object {
@@ -13155,6 +13313,107 @@ function handler(event) {
       },
       "Type": "AWS::CloudFront::Function",
     },
+    "ConstructHubWebAppBucketDeploymentAwsCliLayerED1AB8B3": Object {
+      "Properties": Object {
+        "Content": Object {
+          "S3Bucket": Object {
+            "Ref": "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3BucketAEADE8C7",
+          },
+          "S3Key": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                Object {
+                  "Fn::Select": Array [
+                    0,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3VersionKeyE415415F",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                Object {
+                  "Fn::Select": Array [
+                    1,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3VersionKeyE415415F",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            ],
+          },
+        },
+        "Description": "/opt/awscli/aws",
+      },
+      "Type": "AWS::Lambda::LayerVersion",
+    },
+    "ConstructHubWebAppBucketDeploymentCustomResourceF461CEA4": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "DestinationBucketName": Object {
+          "Ref": "ConstructHubWebAppWebsiteBucket4B2B9DB2",
+        },
+        "Prune": false,
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536",
+            "Arn",
+          ],
+        },
+        "SourceBucketNames": Array [
+          Object {
+            "Ref": "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3Bucket02CF8954",
+          },
+        ],
+        "SourceObjectKeys": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                Object {
+                  "Fn::Select": Array [
+                    0,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3VersionKeyF00B9EC5",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                Object {
+                  "Fn::Select": Array [
+                    1,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3VersionKeyF00B9EC5",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "Custom::CDKBucketDeployment",
+      "UpdateReplacePolicy": "Delete",
+    },
     "ConstructHubWebAppCacheInvalidator07CDD78B": Object {
       "DependsOn": Array [
         "ConstructHubWebAppCacheInvalidatorServiceRoleDefaultPolicy6CB0D51E",
@@ -13282,110 +13541,6 @@ function handler(event) {
         ],
       },
       "Type": "AWS::IAM::Policy",
-    },
-    "ConstructHubWebAppDeployWebsiteAwsCliLayer23CFFBC1": Object {
-      "Properties": Object {
-        "Content": Object {
-          "S3Bucket": Object {
-            "Ref": "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3BucketAEADE8C7",
-          },
-          "S3Key": Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                Object {
-                  "Fn::Select": Array [
-                    0,
-                    Object {
-                      "Fn::Split": Array [
-                        "||",
-                        Object {
-                          "Ref": "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3VersionKeyE415415F",
-                        },
-                      ],
-                    },
-                  ],
-                },
-                Object {
-                  "Fn::Select": Array [
-                    1,
-                    Object {
-                      "Fn::Split": Array [
-                        "||",
-                        Object {
-                          "Ref": "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3VersionKeyE415415F",
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            ],
-          },
-        },
-        "Description": "/opt/awscli/aws",
-      },
-      "Type": "AWS::Lambda::LayerVersion",
-    },
-    "ConstructHubWebAppDeployWebsiteCustomResourceE6DF98C9": Object {
-      "DeletionPolicy": "Delete",
-      "Properties": Object {
-        "DestinationBucketName": Object {
-          "Ref": "ConstructHubWebAppWebsiteBucket4B2B9DB2",
-        },
-        "DistributionId": Object {
-          "Ref": "ConstructHubWebAppDistribution1F181DC9",
-        },
-        "Prune": true,
-        "ServiceToken": Object {
-          "Fn::GetAtt": Array [
-            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536",
-            "Arn",
-          ],
-        },
-        "SourceBucketNames": Array [
-          Object {
-            "Ref": "AssetParametersc0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5S3Bucket3B8113EA",
-          },
-        ],
-        "SourceObjectKeys": Array [
-          Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                Object {
-                  "Fn::Select": Array [
-                    0,
-                    Object {
-                      "Fn::Split": Array [
-                        "||",
-                        Object {
-                          "Ref": "AssetParametersc0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5S3VersionKey962B23F9",
-                        },
-                      ],
-                    },
-                  ],
-                },
-                Object {
-                  "Fn::Select": Array [
-                    1,
-                    Object {
-                      "Fn::Split": Array [
-                        "||",
-                        Object {
-                          "Ref": "AssetParametersc0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5S3VersionKey962B23F9",
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            ],
-          },
-        ],
-      },
-      "Type": "Custom::CDKBucketDeployment",
-      "UpdateReplacePolicy": "Delete",
     },
     "ConstructHubWebAppDistribution1F181DC9": Object {
       "Properties": Object {
@@ -13753,6 +13908,110 @@ function handler(event) {
       },
       "Type": "AWS::IAM::Role",
     },
+    "ConstructHubWebAppHTMLBucketDeploymentAwsCliLayer44B97C39": Object {
+      "Properties": Object {
+        "Content": Object {
+          "S3Bucket": Object {
+            "Ref": "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3BucketAEADE8C7",
+          },
+          "S3Key": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                Object {
+                  "Fn::Select": Array [
+                    0,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3VersionKeyE415415F",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                Object {
+                  "Fn::Select": Array [
+                    1,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3VersionKeyE415415F",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            ],
+          },
+        },
+        "Description": "/opt/awscli/aws",
+      },
+      "Type": "AWS::Lambda::LayerVersion",
+    },
+    "ConstructHubWebAppHTMLBucketDeploymentCustomResource21291B7B": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "DestinationBucketName": Object {
+          "Ref": "ConstructHubWebAppWebsiteBucket4B2B9DB2",
+        },
+        "Prune": false,
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536",
+            "Arn",
+          ],
+        },
+        "SourceBucketNames": Array [
+          Object {
+            "Ref": "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3Bucket60632F31",
+          },
+        ],
+        "SourceObjectKeys": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                Object {
+                  "Fn::Select": Array [
+                    0,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3VersionKey311393EB",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                Object {
+                  "Fn::Select": Array [
+                    1,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3VersionKey311393EB",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+        "SystemMetadata": Object {
+          "cache-control": "no-cache",
+        },
+      },
+      "Type": "Custom::CDKBucketDeployment",
+      "UpdateReplacePolicy": "Delete",
+    },
     "ConstructHubWebAppWebsiteBucket4B2B9DB2": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
@@ -14027,7 +14286,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParametersc0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5S3Bucket3B8113EA",
+                        "Ref": "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3Bucket02CF8954",
                       },
                     ],
                   ],
@@ -14042,7 +14301,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParametersc0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5S3Bucket3B8113EA",
+                        "Ref": "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3Bucket02CF8954",
                       },
                       "/*",
                     ],
@@ -14085,11 +14344,44 @@ function handler(event) {
             },
             Object {
               "Action": Array [
-                "cloudfront:GetInvalidation",
-                "cloudfront:CreateInvalidation",
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
               ],
               "Effect": "Allow",
-              "Resource": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Ref": "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3Bucket60632F31",
+                      },
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Ref": "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3Bucket60632F31",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
             },
           ],
           "Version": "2012-10-17",
@@ -14346,6 +14638,30 @@ Object {
       "Description": "S3 key for asset version \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
     },
+    "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441ArtifactHash4025BA80": Object {
+      "Description": "Artifact hash for asset \\"90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441\\"",
+      "Type": "String",
+    },
+    "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3Bucket60632F31": Object {
+      "Description": "S3 bucket for asset \\"90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441\\"",
+      "Type": "String",
+    },
+    "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3VersionKey311393EB": Object {
+      "Description": "S3 key for asset version \\"90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441\\"",
+      "Type": "String",
+    },
+    "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8ArtifactHash94E1E495": Object {
+      "Description": "Artifact hash for asset \\"99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8\\"",
+      "Type": "String",
+    },
+    "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3Bucket02CF8954": Object {
+      "Description": "S3 bucket for asset \\"99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8\\"",
+      "Type": "String",
+    },
+    "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3VersionKeyF00B9EC5": Object {
+      "Description": "S3 key for asset version \\"99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8\\"",
+      "Type": "String",
+    },
     "AssetParametersb71e1be6a7755e2db27ab32b3b3798af645eef7a61fdace74eed9545f739fe01ArtifactHash9925BDB1": Object {
       "Description": "Artifact hash for asset \\"b71e1be6a7755e2db27ab32b3b3798af645eef7a61fdace74eed9545f739fe01\\"",
       "Type": "String",
@@ -14356,18 +14672,6 @@ Object {
     },
     "AssetParametersb71e1be6a7755e2db27ab32b3b3798af645eef7a61fdace74eed9545f739fe01S3VersionKeyF00BCB48": Object {
       "Description": "S3 key for asset version \\"b71e1be6a7755e2db27ab32b3b3798af645eef7a61fdace74eed9545f739fe01\\"",
-      "Type": "String",
-    },
-    "AssetParametersc0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5ArtifactHashE6CA8ED1": Object {
-      "Description": "Artifact hash for asset \\"c0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5\\"",
-      "Type": "String",
-    },
-    "AssetParametersc0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5S3Bucket3B8113EA": Object {
-      "Description": "S3 bucket for asset \\"c0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5\\"",
-      "Type": "String",
-    },
-    "AssetParametersc0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5S3VersionKey962B23F9": Object {
-      "Description": "S3 key for asset version \\"c0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5\\"",
       "Type": "String",
     },
     "AssetParametersc24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cfArtifactHash85F58E48": Object {
@@ -19222,6 +19526,107 @@ function handler(event) {
       },
       "Type": "AWS::CloudFront::Function",
     },
+    "ConstructHubWebAppBucketDeploymentAwsCliLayerED1AB8B3": Object {
+      "Properties": Object {
+        "Content": Object {
+          "S3Bucket": Object {
+            "Ref": "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3BucketAEADE8C7",
+          },
+          "S3Key": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                Object {
+                  "Fn::Select": Array [
+                    0,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3VersionKeyE415415F",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                Object {
+                  "Fn::Select": Array [
+                    1,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3VersionKeyE415415F",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            ],
+          },
+        },
+        "Description": "/opt/awscli/aws",
+      },
+      "Type": "AWS::Lambda::LayerVersion",
+    },
+    "ConstructHubWebAppBucketDeploymentCustomResourceF461CEA4": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "DestinationBucketName": Object {
+          "Ref": "ConstructHubWebAppWebsiteBucket4B2B9DB2",
+        },
+        "Prune": false,
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536",
+            "Arn",
+          ],
+        },
+        "SourceBucketNames": Array [
+          Object {
+            "Ref": "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3Bucket02CF8954",
+          },
+        ],
+        "SourceObjectKeys": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                Object {
+                  "Fn::Select": Array [
+                    0,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3VersionKeyF00B9EC5",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                Object {
+                  "Fn::Select": Array [
+                    1,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3VersionKeyF00B9EC5",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "Custom::CDKBucketDeployment",
+      "UpdateReplacePolicy": "Delete",
+    },
     "ConstructHubWebAppCacheInvalidator07CDD78B": Object {
       "DependsOn": Array [
         "ConstructHubWebAppCacheInvalidatorServiceRoleDefaultPolicy6CB0D51E",
@@ -19349,110 +19754,6 @@ function handler(event) {
         ],
       },
       "Type": "AWS::IAM::Policy",
-    },
-    "ConstructHubWebAppDeployWebsiteAwsCliLayer23CFFBC1": Object {
-      "Properties": Object {
-        "Content": Object {
-          "S3Bucket": Object {
-            "Ref": "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3BucketAEADE8C7",
-          },
-          "S3Key": Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                Object {
-                  "Fn::Select": Array [
-                    0,
-                    Object {
-                      "Fn::Split": Array [
-                        "||",
-                        Object {
-                          "Ref": "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3VersionKeyE415415F",
-                        },
-                      ],
-                    },
-                  ],
-                },
-                Object {
-                  "Fn::Select": Array [
-                    1,
-                    Object {
-                      "Fn::Split": Array [
-                        "||",
-                        Object {
-                          "Ref": "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3VersionKeyE415415F",
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            ],
-          },
-        },
-        "Description": "/opt/awscli/aws",
-      },
-      "Type": "AWS::Lambda::LayerVersion",
-    },
-    "ConstructHubWebAppDeployWebsiteCustomResourceE6DF98C9": Object {
-      "DeletionPolicy": "Delete",
-      "Properties": Object {
-        "DestinationBucketName": Object {
-          "Ref": "ConstructHubWebAppWebsiteBucket4B2B9DB2",
-        },
-        "DistributionId": Object {
-          "Ref": "ConstructHubWebAppDistribution1F181DC9",
-        },
-        "Prune": true,
-        "ServiceToken": Object {
-          "Fn::GetAtt": Array [
-            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536",
-            "Arn",
-          ],
-        },
-        "SourceBucketNames": Array [
-          Object {
-            "Ref": "AssetParametersc0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5S3Bucket3B8113EA",
-          },
-        ],
-        "SourceObjectKeys": Array [
-          Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                Object {
-                  "Fn::Select": Array [
-                    0,
-                    Object {
-                      "Fn::Split": Array [
-                        "||",
-                        Object {
-                          "Ref": "AssetParametersc0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5S3VersionKey962B23F9",
-                        },
-                      ],
-                    },
-                  ],
-                },
-                Object {
-                  "Fn::Select": Array [
-                    1,
-                    Object {
-                      "Fn::Split": Array [
-                        "||",
-                        Object {
-                          "Ref": "AssetParametersc0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5S3VersionKey962B23F9",
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            ],
-          },
-        ],
-      },
-      "Type": "Custom::CDKBucketDeployment",
-      "UpdateReplacePolicy": "Delete",
     },
     "ConstructHubWebAppDistribution1F181DC9": Object {
       "Properties": Object {
@@ -19593,6 +19894,110 @@ function handler(event) {
         },
       },
       "Type": "AWS::CloudFront::CloudFrontOriginAccessIdentity",
+    },
+    "ConstructHubWebAppHTMLBucketDeploymentAwsCliLayer44B97C39": Object {
+      "Properties": Object {
+        "Content": Object {
+          "S3Bucket": Object {
+            "Ref": "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3BucketAEADE8C7",
+          },
+          "S3Key": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                Object {
+                  "Fn::Select": Array [
+                    0,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3VersionKeyE415415F",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                Object {
+                  "Fn::Select": Array [
+                    1,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3VersionKeyE415415F",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            ],
+          },
+        },
+        "Description": "/opt/awscli/aws",
+      },
+      "Type": "AWS::Lambda::LayerVersion",
+    },
+    "ConstructHubWebAppHTMLBucketDeploymentCustomResource21291B7B": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "DestinationBucketName": Object {
+          "Ref": "ConstructHubWebAppWebsiteBucket4B2B9DB2",
+        },
+        "Prune": false,
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536",
+            "Arn",
+          ],
+        },
+        "SourceBucketNames": Array [
+          Object {
+            "Ref": "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3Bucket60632F31",
+          },
+        ],
+        "SourceObjectKeys": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                Object {
+                  "Fn::Select": Array [
+                    0,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3VersionKey311393EB",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                Object {
+                  "Fn::Select": Array [
+                    1,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3VersionKey311393EB",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+        "SystemMetadata": Object {
+          "cache-control": "no-cache",
+        },
+      },
+      "Type": "Custom::CDKBucketDeployment",
+      "UpdateReplacePolicy": "Delete",
     },
     "ConstructHubWebAppWebsiteBucket4B2B9DB2": Object {
       "DeletionPolicy": "Retain",
@@ -19868,7 +20273,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParametersc0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5S3Bucket3B8113EA",
+                        "Ref": "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3Bucket02CF8954",
                       },
                     ],
                   ],
@@ -19883,7 +20288,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParametersc0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5S3Bucket3B8113EA",
+                        "Ref": "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3Bucket02CF8954",
                       },
                       "/*",
                     ],
@@ -19926,11 +20331,44 @@ function handler(event) {
             },
             Object {
               "Action": Array [
-                "cloudfront:GetInvalidation",
-                "cloudfront:CreateInvalidation",
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
               ],
               "Effect": "Allow",
-              "Resource": "*",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Ref": "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3Bucket60632F31",
+                      },
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Ref": "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3Bucket60632F31",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
             },
           ],
           "Version": "2012-10-17",

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -69,6 +69,18 @@ Object {
       "Description": "S3 key for asset version \\"529e89165f0a6bb521f833515ae2371785bce4e028e7ae3c91e3732ae77e951b\\"",
       "Type": "String",
     },
+    "AssetParameters65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82ArtifactHashEE507FA1": Object {
+      "Description": "Artifact hash for asset \\"65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82\\"",
+      "Type": "String",
+    },
+    "AssetParameters65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82S3Bucket708301C0": Object {
+      "Description": "S3 bucket for asset \\"65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82\\"",
+      "Type": "String",
+    },
+    "AssetParameters65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82S3VersionKey8CB26159": Object {
+      "Description": "S3 key for asset version \\"65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82\\"",
+      "Type": "String",
+    },
     "AssetParameters67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24ArtifactHashBA91B77F": Object {
       "Description": "Artifact hash for asset \\"67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24\\"",
       "Type": "String",
@@ -117,6 +129,18 @@ Object {
       "Description": "S3 key for asset version \\"8265ccdf680d2fc53b19193e2b93340a27f335cc3be02b673f0742d7700fd6ac\\"",
       "Type": "String",
     },
+    "AssetParameters8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4ArtifactHashE05FD5E3": Object {
+      "Description": "Artifact hash for asset \\"8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4\\"",
+      "Type": "String",
+    },
+    "AssetParameters8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4S3BucketA6C8B10A": Object {
+      "Description": "S3 bucket for asset \\"8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4\\"",
+      "Type": "String",
+    },
+    "AssetParameters8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4S3VersionKey45339783": Object {
+      "Description": "S3 key for asset version \\"8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4\\"",
+      "Type": "String",
+    },
     "AssetParameters8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064ArtifactHashEA963870": Object {
       "Description": "Artifact hash for asset \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
@@ -127,30 +151,6 @@ Object {
     },
     "AssetParameters8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064S3VersionKey5B081B37": Object {
       "Description": "S3 key for asset version \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
-      "Type": "String",
-    },
-    "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441ArtifactHash4025BA80": Object {
-      "Description": "Artifact hash for asset \\"90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441\\"",
-      "Type": "String",
-    },
-    "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3Bucket60632F31": Object {
-      "Description": "S3 bucket for asset \\"90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441\\"",
-      "Type": "String",
-    },
-    "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3VersionKey311393EB": Object {
-      "Description": "S3 key for asset version \\"90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441\\"",
-      "Type": "String",
-    },
-    "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8ArtifactHash94E1E495": Object {
-      "Description": "Artifact hash for asset \\"99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8\\"",
-      "Type": "String",
-    },
-    "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3Bucket02CF8954": Object {
-      "Description": "S3 bucket for asset \\"99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8\\"",
-      "Type": "String",
-    },
-    "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3VersionKeyF00B9EC5": Object {
-      "Description": "S3 key for asset version \\"99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8\\"",
       "Type": "String",
     },
     "AssetParametersb71e1be6a7755e2db27ab32b3b3798af645eef7a61fdace74eed9545f739fe01ArtifactHash9925BDB1": Object {
@@ -6102,7 +6102,7 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3Bucket02CF8954",
+            "Ref": "AssetParameters8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4S3BucketA6C8B10A",
           },
         ],
         "SourceObjectKeys": Array [
@@ -6117,7 +6117,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3VersionKeyF00B9EC5",
+                          "Ref": "AssetParameters8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4S3VersionKey45339783",
                         },
                       ],
                     },
@@ -6130,7 +6130,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3VersionKeyF00B9EC5",
+                          "Ref": "AssetParameters8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4S3VersionKey45339783",
                         },
                       ],
                     },
@@ -6471,7 +6471,7 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3Bucket60632F31",
+            "Ref": "AssetParameters65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82S3Bucket708301C0",
           },
         ],
         "SourceObjectKeys": Array [
@@ -6486,7 +6486,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3VersionKey311393EB",
+                          "Ref": "AssetParameters65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82S3VersionKey8CB26159",
                         },
                       ],
                     },
@@ -6499,7 +6499,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3VersionKey311393EB",
+                          "Ref": "AssetParameters65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82S3VersionKey8CB26159",
                         },
                       ],
                     },
@@ -6790,7 +6790,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3Bucket02CF8954",
+                        "Ref": "AssetParameters8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4S3BucketA6C8B10A",
                       },
                     ],
                   ],
@@ -6805,7 +6805,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3Bucket02CF8954",
+                        "Ref": "AssetParameters8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4S3BucketA6C8B10A",
                       },
                       "/*",
                     ],
@@ -6864,7 +6864,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3Bucket60632F31",
+                        "Ref": "AssetParameters65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82S3Bucket708301C0",
                       },
                     ],
                   ],
@@ -6879,7 +6879,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3Bucket60632F31",
+                        "Ref": "AssetParameters65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82S3Bucket708301C0",
                       },
                       "/*",
                     ],
@@ -7092,6 +7092,18 @@ Object {
       "Description": "S3 key for asset version \\"529e89165f0a6bb521f833515ae2371785bce4e028e7ae3c91e3732ae77e951b\\"",
       "Type": "String",
     },
+    "AssetParameters65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82ArtifactHashEE507FA1": Object {
+      "Description": "Artifact hash for asset \\"65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82\\"",
+      "Type": "String",
+    },
+    "AssetParameters65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82S3Bucket708301C0": Object {
+      "Description": "S3 bucket for asset \\"65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82\\"",
+      "Type": "String",
+    },
+    "AssetParameters65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82S3VersionKey8CB26159": Object {
+      "Description": "S3 key for asset version \\"65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82\\"",
+      "Type": "String",
+    },
     "AssetParameters67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24ArtifactHashBA91B77F": Object {
       "Description": "Artifact hash for asset \\"67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24\\"",
       "Type": "String",
@@ -7164,6 +7176,18 @@ Object {
       "Description": "S3 key for asset version \\"8265ccdf680d2fc53b19193e2b93340a27f335cc3be02b673f0742d7700fd6ac\\"",
       "Type": "String",
     },
+    "AssetParameters8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4ArtifactHashE05FD5E3": Object {
+      "Description": "Artifact hash for asset \\"8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4\\"",
+      "Type": "String",
+    },
+    "AssetParameters8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4S3BucketA6C8B10A": Object {
+      "Description": "S3 bucket for asset \\"8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4\\"",
+      "Type": "String",
+    },
+    "AssetParameters8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4S3VersionKey45339783": Object {
+      "Description": "S3 key for asset version \\"8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4\\"",
+      "Type": "String",
+    },
     "AssetParameters8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064ArtifactHashEA963870": Object {
       "Description": "Artifact hash for asset \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
@@ -7174,30 +7198,6 @@ Object {
     },
     "AssetParameters8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064S3VersionKey5B081B37": Object {
       "Description": "S3 key for asset version \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
-      "Type": "String",
-    },
-    "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441ArtifactHash4025BA80": Object {
-      "Description": "Artifact hash for asset \\"90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441\\"",
-      "Type": "String",
-    },
-    "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3Bucket60632F31": Object {
-      "Description": "S3 bucket for asset \\"90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441\\"",
-      "Type": "String",
-    },
-    "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3VersionKey311393EB": Object {
-      "Description": "S3 key for asset version \\"90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441\\"",
-      "Type": "String",
-    },
-    "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8ArtifactHash94E1E495": Object {
-      "Description": "Artifact hash for asset \\"99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8\\"",
-      "Type": "String",
-    },
-    "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3Bucket02CF8954": Object {
-      "Description": "S3 bucket for asset \\"99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8\\"",
-      "Type": "String",
-    },
-    "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3VersionKeyF00B9EC5": Object {
-      "Description": "S3 key for asset version \\"99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8\\"",
       "Type": "String",
     },
     "AssetParametersb71e1be6a7755e2db27ab32b3b3798af645eef7a61fdace74eed9545f739fe01ArtifactHash9925BDB1": Object {
@@ -13372,7 +13372,7 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3Bucket02CF8954",
+            "Ref": "AssetParameters8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4S3BucketA6C8B10A",
           },
         ],
         "SourceObjectKeys": Array [
@@ -13387,7 +13387,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3VersionKeyF00B9EC5",
+                          "Ref": "AssetParameters8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4S3VersionKey45339783",
                         },
                       ],
                     },
@@ -13400,7 +13400,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3VersionKeyF00B9EC5",
+                          "Ref": "AssetParameters8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4S3VersionKey45339783",
                         },
                       ],
                     },
@@ -13967,7 +13967,7 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3Bucket60632F31",
+            "Ref": "AssetParameters65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82S3Bucket708301C0",
           },
         ],
         "SourceObjectKeys": Array [
@@ -13982,7 +13982,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3VersionKey311393EB",
+                          "Ref": "AssetParameters65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82S3VersionKey8CB26159",
                         },
                       ],
                     },
@@ -13995,7 +13995,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3VersionKey311393EB",
+                          "Ref": "AssetParameters65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82S3VersionKey8CB26159",
                         },
                       ],
                     },
@@ -14286,7 +14286,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3Bucket02CF8954",
+                        "Ref": "AssetParameters8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4S3BucketA6C8B10A",
                       },
                     ],
                   ],
@@ -14301,7 +14301,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3Bucket02CF8954",
+                        "Ref": "AssetParameters8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4S3BucketA6C8B10A",
                       },
                       "/*",
                     ],
@@ -14360,7 +14360,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3Bucket60632F31",
+                        "Ref": "AssetParameters65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82S3Bucket708301C0",
                       },
                     ],
                   ],
@@ -14375,7 +14375,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3Bucket60632F31",
+                        "Ref": "AssetParameters65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82S3Bucket708301C0",
                       },
                       "/*",
                     ],
@@ -14578,6 +14578,18 @@ Object {
       "Description": "S3 key for asset version \\"529e89165f0a6bb521f833515ae2371785bce4e028e7ae3c91e3732ae77e951b\\"",
       "Type": "String",
     },
+    "AssetParameters65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82ArtifactHashEE507FA1": Object {
+      "Description": "Artifact hash for asset \\"65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82\\"",
+      "Type": "String",
+    },
+    "AssetParameters65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82S3Bucket708301C0": Object {
+      "Description": "S3 bucket for asset \\"65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82\\"",
+      "Type": "String",
+    },
+    "AssetParameters65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82S3VersionKey8CB26159": Object {
+      "Description": "S3 key for asset version \\"65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82\\"",
+      "Type": "String",
+    },
     "AssetParameters67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24ArtifactHashBA91B77F": Object {
       "Description": "Artifact hash for asset \\"67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24\\"",
       "Type": "String",
@@ -14626,6 +14638,18 @@ Object {
       "Description": "S3 key for asset version \\"8265ccdf680d2fc53b19193e2b93340a27f335cc3be02b673f0742d7700fd6ac\\"",
       "Type": "String",
     },
+    "AssetParameters8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4ArtifactHashE05FD5E3": Object {
+      "Description": "Artifact hash for asset \\"8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4\\"",
+      "Type": "String",
+    },
+    "AssetParameters8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4S3BucketA6C8B10A": Object {
+      "Description": "S3 bucket for asset \\"8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4\\"",
+      "Type": "String",
+    },
+    "AssetParameters8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4S3VersionKey45339783": Object {
+      "Description": "S3 key for asset version \\"8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4\\"",
+      "Type": "String",
+    },
     "AssetParameters8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064ArtifactHashEA963870": Object {
       "Description": "Artifact hash for asset \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
@@ -14636,30 +14660,6 @@ Object {
     },
     "AssetParameters8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064S3VersionKey5B081B37": Object {
       "Description": "S3 key for asset version \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
-      "Type": "String",
-    },
-    "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441ArtifactHash4025BA80": Object {
-      "Description": "Artifact hash for asset \\"90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441\\"",
-      "Type": "String",
-    },
-    "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3Bucket60632F31": Object {
-      "Description": "S3 bucket for asset \\"90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441\\"",
-      "Type": "String",
-    },
-    "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3VersionKey311393EB": Object {
-      "Description": "S3 key for asset version \\"90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441\\"",
-      "Type": "String",
-    },
-    "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8ArtifactHash94E1E495": Object {
-      "Description": "Artifact hash for asset \\"99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8\\"",
-      "Type": "String",
-    },
-    "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3Bucket02CF8954": Object {
-      "Description": "S3 bucket for asset \\"99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8\\"",
-      "Type": "String",
-    },
-    "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3VersionKeyF00B9EC5": Object {
-      "Description": "S3 key for asset version \\"99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8\\"",
       "Type": "String",
     },
     "AssetParametersb71e1be6a7755e2db27ab32b3b3798af645eef7a61fdace74eed9545f739fe01ArtifactHash9925BDB1": Object {
@@ -19585,7 +19585,7 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3Bucket02CF8954",
+            "Ref": "AssetParameters8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4S3BucketA6C8B10A",
           },
         ],
         "SourceObjectKeys": Array [
@@ -19600,7 +19600,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3VersionKeyF00B9EC5",
+                          "Ref": "AssetParameters8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4S3VersionKey45339783",
                         },
                       ],
                     },
@@ -19613,7 +19613,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3VersionKeyF00B9EC5",
+                          "Ref": "AssetParameters8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4S3VersionKey45339783",
                         },
                       ],
                     },
@@ -19954,7 +19954,7 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3Bucket60632F31",
+            "Ref": "AssetParameters65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82S3Bucket708301C0",
           },
         ],
         "SourceObjectKeys": Array [
@@ -19969,7 +19969,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3VersionKey311393EB",
+                          "Ref": "AssetParameters65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82S3VersionKey8CB26159",
                         },
                       ],
                     },
@@ -19982,7 +19982,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3VersionKey311393EB",
+                          "Ref": "AssetParameters65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82S3VersionKey8CB26159",
                         },
                       ],
                     },
@@ -20273,7 +20273,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3Bucket02CF8954",
+                        "Ref": "AssetParameters8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4S3BucketA6C8B10A",
                       },
                     ],
                   ],
@@ -20288,7 +20288,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3Bucket02CF8954",
+                        "Ref": "AssetParameters8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4S3BucketA6C8B10A",
                       },
                       "/*",
                     ],
@@ -20347,7 +20347,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3Bucket60632F31",
+                        "Ref": "AssetParameters65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82S3Bucket708301C0",
                       },
                     ],
                   ],
@@ -20362,7 +20362,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3Bucket60632F31",
+                        "Ref": "AssetParameters65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82S3Bucket708301C0",
                       },
                       "/*",
                     ],

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -3534,7 +3534,7 @@ Resources:
           - CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536
           - Arn
       SourceBucketNames:
-        - Ref: AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3Bucket02CF8954
+        - Ref: AssetParameters8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4S3BucketA6C8B10A
       SourceObjectKeys:
         - Fn::Join:
             - ""
@@ -3542,12 +3542,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3VersionKeyF00B9EC5
+                      - Ref: AssetParameters8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4S3VersionKey45339783
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3VersionKeyF00B9EC5
+                      - Ref: AssetParameters8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4S3VersionKey45339783
       DestinationBucketName:
         Ref: ConstructHubWebAppWebsiteBucket4B2B9DB2
       Prune: false
@@ -3581,7 +3581,7 @@ Resources:
           - CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536
           - Arn
       SourceBucketNames:
-        - Ref: AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3Bucket60632F31
+        - Ref: AssetParameters65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82S3Bucket708301C0
       SourceObjectKeys:
         - Fn::Join:
             - ""
@@ -3589,12 +3589,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3VersionKey311393EB
+                      - Ref: AssetParameters65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82S3VersionKey8CB26159
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3VersionKey311393EB
+                      - Ref: AssetParameters65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82S3VersionKey8CB26159
       DestinationBucketName:
         Ref: ConstructHubWebAppWebsiteBucket4B2B9DB2
       Prune: false
@@ -3715,13 +3715,13 @@ Resources:
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3Bucket02CF8954
+                    - Ref: AssetParameters8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4S3BucketA6C8B10A
               - Fn::Join:
                   - ""
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3Bucket02CF8954
+                    - Ref: AssetParameters8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4S3BucketA6C8B10A
                     - /*
           - Action:
               - s3:GetObject*
@@ -3752,13 +3752,13 @@ Resources:
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3Bucket60632F31
+                    - Ref: AssetParameters65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82S3Bucket708301C0
               - Fn::Join:
                   - ""
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3Bucket60632F31
+                    - Ref: AssetParameters65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82S3Bucket708301C0
                     - /*
         Version: 2012-10-17
       PolicyName: CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF
@@ -4202,30 +4202,30 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "7ee6e37c4f89b09a6b3c50e513093daf23a858809daed5a6703095d14955c9b2"
-  AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3Bucket02CF8954:
+  AssetParameters8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4S3BucketA6C8B10A:
     Type: String
     Description: S3 bucket for asset
-      "99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8"
-  AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3VersionKeyF00B9EC5:
+      "8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4"
+  AssetParameters8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4S3VersionKey45339783:
     Type: String
     Description: S3 key for asset version
-      "99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8"
-  AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8ArtifactHash94E1E495:
+      "8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4"
+  AssetParameters8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4ArtifactHashE05FD5E3:
     Type: String
     Description: Artifact hash for asset
-      "99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8"
-  AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3Bucket60632F31:
+      "8373aaba2faec321da54c26c4f372796efa6ecefcf006160ff8a06aa784ebbb4"
+  AssetParameters65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82S3Bucket708301C0:
     Type: String
     Description: S3 bucket for asset
-      "90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441"
-  AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3VersionKey311393EB:
+      "65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82"
+  AssetParameters65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82S3VersionKey8CB26159:
     Type: String
     Description: S3 key for asset version
-      "90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441"
-  AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441ArtifactHash4025BA80:
+      "65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82"
+  AssetParameters65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82ArtifactHashEE507FA1:
     Type: String
     Description: Artifact hash for asset
-      "90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441"
+      "65d4384a8f713b419584b18261020529c4cdaed7007fd5495f9ab2cbf74e1e82"
   AssetParametersd5594c96e8d8bc8ce1cd238fb011bd3e1a5c69dada29b4366e17e735f7617fa3S3Bucket5045DB1E:
     Type: String
     Description: S3 bucket for asset

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -3506,7 +3506,7 @@ Resources:
     DependsOn:
       - ConstructHubWebAppCacheInvalidatorServiceRoleDefaultPolicy6CB0D51E
       - ConstructHubWebAppCacheInvalidatorServiceRoleAABE9AE2
-  ConstructHubWebAppDeployWebsiteAwsCliLayer23CFFBC1:
+  ConstructHubWebAppBucketDeploymentAwsCliLayerED1AB8B3:
     Type: AWS::Lambda::LayerVersion
     Properties:
       Content:
@@ -3526,7 +3526,7 @@ Resources:
                       - "||"
                       - Ref: AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3VersionKeyE415415F
       Description: /opt/awscli/aws
-  ConstructHubWebAppDeployWebsiteCustomResourceE6DF98C9:
+  ConstructHubWebAppBucketDeploymentCustomResourceF461CEA4:
     Type: Custom::CDKBucketDeployment
     Properties:
       ServiceToken:
@@ -3534,7 +3534,7 @@ Resources:
           - CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536
           - Arn
       SourceBucketNames:
-        - Ref: AssetParametersc0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5S3Bucket3B8113EA
+        - Ref: AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3Bucket02CF8954
       SourceObjectKeys:
         - Fn::Join:
             - ""
@@ -3542,17 +3542,64 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersc0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5S3VersionKey962B23F9
+                      - Ref: AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3VersionKeyF00B9EC5
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersc0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5S3VersionKey962B23F9
+                      - Ref: AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3VersionKeyF00B9EC5
       DestinationBucketName:
         Ref: ConstructHubWebAppWebsiteBucket4B2B9DB2
-      Prune: true
-      DistributionId:
-        Ref: ConstructHubWebAppDistribution1F181DC9
+      Prune: false
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
+  ConstructHubWebAppHTMLBucketDeploymentAwsCliLayer44B97C39:
+    Type: AWS::Lambda::LayerVersion
+    Properties:
+      Content:
+        S3Bucket:
+          Ref: AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3BucketAEADE8C7
+        S3Key:
+          Fn::Join:
+            - ""
+            - - Fn::Select:
+                  - 0
+                  - Fn::Split:
+                      - "||"
+                      - Ref: AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3VersionKeyE415415F
+              - Fn::Select:
+                  - 1
+                  - Fn::Split:
+                      - "||"
+                      - Ref: AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3VersionKeyE415415F
+      Description: /opt/awscli/aws
+  ConstructHubWebAppHTMLBucketDeploymentCustomResource21291B7B:
+    Type: Custom::CDKBucketDeployment
+    Properties:
+      ServiceToken:
+        Fn::GetAtt:
+          - CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536
+          - Arn
+      SourceBucketNames:
+        - Ref: AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3Bucket60632F31
+      SourceObjectKeys:
+        - Fn::Join:
+            - ""
+            - - Fn::Select:
+                  - 0
+                  - Fn::Split:
+                      - "||"
+                      - Ref: AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3VersionKey311393EB
+              - Fn::Select:
+                  - 1
+                  - Fn::Split:
+                      - "||"
+                      - Ref: AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3VersionKey311393EB
+      DestinationBucketName:
+        Ref: ConstructHubWebAppWebsiteBucket4B2B9DB2
+      Prune: false
+      SystemMetadata:
+        cache-control: no-cache
     UpdateReplacePolicy: Delete
     DeletionPolicy: Delete
   AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2:
@@ -3668,13 +3715,13 @@ Resources:
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParametersc0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5S3Bucket3B8113EA
+                    - Ref: AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3Bucket02CF8954
               - Fn::Join:
                   - ""
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParametersc0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5S3Bucket3B8113EA
+                    - Ref: AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3Bucket02CF8954
                     - /*
           - Action:
               - s3:GetObject*
@@ -3695,10 +3742,24 @@ Resources:
                         - Arn
                     - /*
           - Action:
-              - cloudfront:GetInvalidation
-              - cloudfront:CreateInvalidation
+              - s3:GetObject*
+              - s3:GetBucket*
+              - s3:List*
             Effect: Allow
-            Resource: "*"
+            Resource:
+              - Fn::Join:
+                  - ""
+                  - - "arn:"
+                    - Ref: AWS::Partition
+                    - ":s3:::"
+                    - Ref: AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3Bucket60632F31
+              - Fn::Join:
+                  - ""
+                  - - "arn:"
+                    - Ref: AWS::Partition
+                    - ":s3:::"
+                    - Ref: AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3Bucket60632F31
+                    - /*
         Version: 2012-10-17
       PolicyName: CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF
       Roles:
@@ -4141,18 +4202,30 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "7ee6e37c4f89b09a6b3c50e513093daf23a858809daed5a6703095d14955c9b2"
-  AssetParametersc0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5S3Bucket3B8113EA:
+  AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3Bucket02CF8954:
     Type: String
     Description: S3 bucket for asset
-      "c0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5"
-  AssetParametersc0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5S3VersionKey962B23F9:
+      "99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8"
+  AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8S3VersionKeyF00B9EC5:
     Type: String
     Description: S3 key for asset version
-      "c0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5"
-  AssetParametersc0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5ArtifactHashE6CA8ED1:
+      "99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8"
+  AssetParameters99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8ArtifactHash94E1E495:
     Type: String
     Description: Artifact hash for asset
-      "c0f8e2d3fd8e57a9ec03cb0341f0ef210c0dc4293ba9f9a0a75d571107cd70c5"
+      "99f21f8a358f3a3a608fdb89636ded44874f350d96eb0714ed3b414aeb4ffef8"
+  AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3Bucket60632F31:
+    Type: String
+    Description: S3 bucket for asset
+      "90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441"
+  AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441S3VersionKey311393EB:
+    Type: String
+    Description: S3 key for asset version
+      "90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441"
+  AssetParameters90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441ArtifactHash4025BA80:
+    Type: String
+    Description: Artifact hash for asset
+      "90587e1c38ef6025b420a6efbab8006252921be76dab4b6e179c5dac90ae7441"
   AssetParametersd5594c96e8d8bc8ce1cd238fb011bd3e1a5c69dada29b4366e17e735f7617fa3S3Bucket5045DB1E:
     Type: String
     Description: S3 bucket for asset

--- a/src/webapp/index.ts
+++ b/src/webapp/index.ts
@@ -106,10 +106,18 @@ export class WebApp extends Construct {
 
     // "website" contains the static react app
     const webappDir = path.join(__dirname, '..', '..', 'website');
-    new s3deploy.BucketDeployment(this, 'DeployWebsite', {
-      sources: [s3deploy.Source.asset(webappDir)],
+
+    new s3deploy.BucketDeployment(this, 'BucketDeployment', {
+      sources: [s3deploy.Source.asset(webappDir, { exclude: ['index.html'] })],
       destinationBucket: this.bucket,
-      distribution: this.distribution,
+      prune: false,
+    });
+
+    new s3deploy.BucketDeployment(this, 'HTMLBucketDeployment', {
+      sources: [s3deploy.Source.asset(webappDir, { exclude: ['*', '!index.html'] })],
+      destinationBucket: this.bucket,
+      cacheControl: [s3deploy.CacheControl.noCache()],
+      prune: false,
     });
 
     new CfnOutput(this, 'DomainName', {


### PR DESCRIPTION
Adds `cache-control: no-cache` header to index.html document to prevent
browsers from caching old versions of the site. Excludes all other
assets so that larger assets, like js and css files, can continued to be
cached locally.

Broke up the `BucketDeployment` into two separate calls as detailed in
[the package docs](https://github.com/aws/aws-cdk/tree/master/packages/%40aws-cdk/aws-s3-deployment#prune)