### PR TITLE
fix: circular dependency around the deny list

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -105,16 +105,16 @@ Object {
       "Description": "S3 key for asset version \\"8265ccdf680d2fc53b19193e2b93340a27f335cc3be02b673f0742d7700fd6ac\\"",
       "Type": "String",
     },
-    "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9ArtifactHash7A6CE4F0": Object {
-      "Description": "Artifact hash for asset \\"8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9\\"",
+    "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bArtifactHashAC589578": Object {
+      "Description": "Artifact hash for asset \\"85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929b\\"",
       "Type": "String",
     },
-    "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7": Object {
-      "Description": "S3 bucket for asset \\"8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9\\"",
+    "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3Bucket465251CA": Object {
+      "Description": "S3 bucket for asset \\"85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929b\\"",
       "Type": "String",
     },
-    "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9": Object {
-      "Description": "S3 key for asset version \\"8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9\\"",
+    "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C": Object {
+      "Description": "S3 key for asset version \\"85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929b\\"",
       "Type": "String",
     },
     "AssetParameters8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064ArtifactHashEA963870": Object {
@@ -1310,8 +1310,6 @@ def submit_response(event: dict, context, response_status: str, error_message: s
     },
     "ConstructHubDenyListPrunePruneHandler30B33551": Object {
       "DependsOn": Array [
-        "ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA",
-        "ConstructHubDenyListBucketDeploymentCustomResourceF835956B",
         "ConstructHubDenyListPrunePruneHandlerServiceRoleDefaultPolicy416BC8DA",
         "ConstructHubDenyListPrunePruneHandlerServiceRole58BDE1FE",
       ],
@@ -1389,10 +1387,6 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Type": "AWS::Lambda::Function",
     },
     "ConstructHubDenyListPrunePruneHandlerServiceRole58BDE1FE": Object {
-      "DependsOn": Array [
-        "ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA",
-        "ConstructHubDenyListBucketDeploymentCustomResourceF835956B",
-      ],
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -1424,10 +1418,6 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Type": "AWS::IAM::Role",
     },
     "ConstructHubDenyListPrunePruneHandlerServiceRoleDefaultPolicy416BC8DA": Object {
-      "DependsOn": Array [
-        "ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA",
-        "ConstructHubDenyListBucketDeploymentCustomResourceF835956B",
-      ],
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -4019,8 +4009,6 @@ Direct link to function: /lambda/home#/functions/",
     },
     "ConstructHubOrchestrationCatalogBuilder7C964951": Object {
       "DependsOn": Array [
-        "ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA",
-        "ConstructHubDenyListBucketDeploymentCustomResourceF835956B",
         "ConstructHubOrchestrationCatalogBuilderServiceRoleDefaultPolicyDA5D5AA5",
         "ConstructHubOrchestrationCatalogBuilderServiceRole851C750C",
       ],
@@ -4103,10 +4091,6 @@ Direct link to function: /lambda/home#/functions/",
       "Type": "AWS::Lambda::Function",
     },
     "ConstructHubOrchestrationCatalogBuilderLogRetention04ED6996": Object {
-      "DependsOn": Array [
-        "ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA",
-        "ConstructHubDenyListBucketDeploymentCustomResourceF835956B",
-      ],
       "Properties": Object {
         "LogGroupName": Object {
           "Fn::Join": Array [
@@ -4130,10 +4114,6 @@ Direct link to function: /lambda/home#/functions/",
       "Type": "Custom::LogRetention",
     },
     "ConstructHubOrchestrationCatalogBuilderServiceRole851C750C": Object {
-      "DependsOn": Array [
-        "ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA",
-        "ConstructHubDenyListBucketDeploymentCustomResourceF835956B",
-      ],
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -4165,10 +4145,6 @@ Direct link to function: /lambda/home#/functions/",
       "Type": "AWS::IAM::Role",
     },
     "ConstructHubOrchestrationCatalogBuilderServiceRoleDefaultPolicyDA5D5AA5": Object {
-      "DependsOn": Array [
-        "ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA",
-        "ConstructHubDenyListBucketDeploymentCustomResourceF835956B",
-      ],
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -4364,7 +4340,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7",
+            "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3Bucket465251CA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -4377,7 +4353,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C",
                         },
                       ],
                     },
@@ -4390,7 +4366,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C",
                         },
                       ],
                     },
@@ -4776,7 +4752,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7",
+            "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3Bucket465251CA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -4789,7 +4765,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C",
                         },
                       ],
                     },
@@ -4802,7 +4778,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C",
                         },
                       ],
                     },
@@ -5826,8 +5802,6 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
     },
     "ConstructHubSourcesNpmJs15A77D2D": Object {
       "DependsOn": Array [
-        "ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA",
-        "ConstructHubDenyListBucketDeploymentCustomResourceF835956B",
         "ConstructHubLicenseListAwsCliLayer59592811",
         "ConstructHubLicenseListCustomResource323F0FD4",
         "ConstructHubSourcesNpmJsServiceRoleDefaultPolicy65FBFA22",
@@ -6034,8 +6008,6 @@ Direct link to Lambda function: /lambda/home#/functions/",
     },
     "ConstructHubSourcesNpmJsServiceRoleAC3F7AA6": Object {
       "DependsOn": Array [
-        "ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA",
-        "ConstructHubDenyListBucketDeploymentCustomResourceF835956B",
         "ConstructHubLicenseListAwsCliLayer59592811",
         "ConstructHubLicenseListCustomResource323F0FD4",
       ],
@@ -6071,8 +6043,6 @@ Direct link to Lambda function: /lambda/home#/functions/",
     },
     "ConstructHubSourcesNpmJsServiceRoleDefaultPolicy65FBFA22": Object {
       "DependsOn": Array [
-        "ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA",
-        "ConstructHubDenyListBucketDeploymentCustomResourceF835956B",
         "ConstructHubLicenseListAwsCliLayer59592811",
         "ConstructHubLicenseListCustomResource323F0FD4",
       ],
@@ -7356,16 +7326,16 @@ Object {
       "Description": "S3 key for asset version \\"8265ccdf680d2fc53b19193e2b93340a27f335cc3be02b673f0742d7700fd6ac\\"",
       "Type": "String",
     },
-    "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9ArtifactHash7A6CE4F0": Object {
-      "Description": "Artifact hash for asset \\"8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9\\"",
+    "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bArtifactHashAC589578": Object {
+      "Description": "Artifact hash for asset \\"85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929b\\"",
       "Type": "String",
     },
-    "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7": Object {
-      "Description": "S3 bucket for asset \\"8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9\\"",
+    "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3Bucket465251CA": Object {
+      "Description": "S3 bucket for asset \\"85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929b\\"",
       "Type": "String",
     },
-    "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9": Object {
-      "Description": "S3 key for asset version \\"8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9\\"",
+    "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C": Object {
+      "Description": "S3 key for asset version \\"85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929b\\"",
       "Type": "String",
     },
     "AssetParameters8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064ArtifactHashEA963870": Object {
@@ -8710,8 +8680,6 @@ def submit_response(event: dict, context, response_status: str, error_message: s
     },
     "ConstructHubDenyListPrunePruneHandler30B33551": Object {
       "DependsOn": Array [
-        "ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA",
-        "ConstructHubDenyListBucketDeploymentCustomResourceF835956B",
         "ConstructHubDenyListPrunePruneHandlerServiceRoleDefaultPolicy416BC8DA",
         "ConstructHubDenyListPrunePruneHandlerServiceRole58BDE1FE",
       ],
@@ -8789,10 +8757,6 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Type": "AWS::Lambda::Function",
     },
     "ConstructHubDenyListPrunePruneHandlerServiceRole58BDE1FE": Object {
-      "DependsOn": Array [
-        "ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA",
-        "ConstructHubDenyListBucketDeploymentCustomResourceF835956B",
-      ],
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -8824,10 +8788,6 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Type": "AWS::IAM::Role",
     },
     "ConstructHubDenyListPrunePruneHandlerServiceRoleDefaultPolicy416BC8DA": Object {
-      "DependsOn": Array [
-        "ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA",
-        "ConstructHubDenyListBucketDeploymentCustomResourceF835956B",
-      ],
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -11441,8 +11401,6 @@ Direct link to function: /lambda/home#/functions/",
     },
     "ConstructHubOrchestrationCatalogBuilder7C964951": Object {
       "DependsOn": Array [
-        "ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA",
-        "ConstructHubDenyListBucketDeploymentCustomResourceF835956B",
         "ConstructHubOrchestrationCatalogBuilderServiceRoleDefaultPolicyDA5D5AA5",
         "ConstructHubOrchestrationCatalogBuilderServiceRole851C750C",
       ],
@@ -11525,10 +11483,6 @@ Direct link to function: /lambda/home#/functions/",
       "Type": "AWS::Lambda::Function",
     },
     "ConstructHubOrchestrationCatalogBuilderLogRetention04ED6996": Object {
-      "DependsOn": Array [
-        "ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA",
-        "ConstructHubDenyListBucketDeploymentCustomResourceF835956B",
-      ],
       "Properties": Object {
         "LogGroupName": Object {
           "Fn::Join": Array [
@@ -11552,10 +11506,6 @@ Direct link to function: /lambda/home#/functions/",
       "Type": "Custom::LogRetention",
     },
     "ConstructHubOrchestrationCatalogBuilderServiceRole851C750C": Object {
-      "DependsOn": Array [
-        "ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA",
-        "ConstructHubDenyListBucketDeploymentCustomResourceF835956B",
-      ],
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -11587,10 +11537,6 @@ Direct link to function: /lambda/home#/functions/",
       "Type": "AWS::IAM::Role",
     },
     "ConstructHubOrchestrationCatalogBuilderServiceRoleDefaultPolicyDA5D5AA5": Object {
-      "DependsOn": Array [
-        "ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA",
-        "ConstructHubDenyListBucketDeploymentCustomResourceF835956B",
-      ],
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -11786,7 +11732,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7",
+            "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3Bucket465251CA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -11799,7 +11745,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C",
                         },
                       ],
                     },
@@ -11812,7 +11758,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C",
                         },
                       ],
                     },
@@ -12198,7 +12144,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7",
+            "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3Bucket465251CA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -12211,7 +12157,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C",
                         },
                       ],
                     },
@@ -12224,7 +12170,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C",
                         },
                       ],
                     },
@@ -13248,8 +13194,6 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
     },
     "ConstructHubSourcesNpmJs15A77D2D": Object {
       "DependsOn": Array [
-        "ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA",
-        "ConstructHubDenyListBucketDeploymentCustomResourceF835956B",
         "ConstructHubLicenseListAwsCliLayer59592811",
         "ConstructHubLicenseListCustomResource323F0FD4",
         "ConstructHubSourcesNpmJsServiceRoleDefaultPolicy65FBFA22",
@@ -13456,8 +13400,6 @@ Direct link to Lambda function: /lambda/home#/functions/",
     },
     "ConstructHubSourcesNpmJsServiceRoleAC3F7AA6": Object {
       "DependsOn": Array [
-        "ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA",
-        "ConstructHubDenyListBucketDeploymentCustomResourceF835956B",
         "ConstructHubLicenseListAwsCliLayer59592811",
         "ConstructHubLicenseListCustomResource323F0FD4",
       ],
@@ -13493,8 +13435,6 @@ Direct link to Lambda function: /lambda/home#/functions/",
     },
     "ConstructHubSourcesNpmJsServiceRoleDefaultPolicy65FBFA22": Object {
       "DependsOn": Array [
-        "ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA",
-        "ConstructHubDenyListBucketDeploymentCustomResourceF835956B",
         "ConstructHubLicenseListAwsCliLayer59592811",
         "ConstructHubLicenseListCustomResource323F0FD4",
       ],
@@ -15022,16 +14962,16 @@ Object {
       "Description": "S3 key for asset version \\"8265ccdf680d2fc53b19193e2b93340a27f335cc3be02b673f0742d7700fd6ac\\"",
       "Type": "String",
     },
-    "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9ArtifactHash7A6CE4F0": Object {
-      "Description": "Artifact hash for asset \\"8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9\\"",
+    "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bArtifactHashAC589578": Object {
+      "Description": "Artifact hash for asset \\"85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929b\\"",
       "Type": "String",
     },
-    "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7": Object {
-      "Description": "S3 bucket for asset \\"8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9\\"",
+    "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3Bucket465251CA": Object {
+      "Description": "S3 bucket for asset \\"85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929b\\"",
       "Type": "String",
     },
-    "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9": Object {
-      "Description": "S3 key for asset version \\"8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9\\"",
+    "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C": Object {
+      "Description": "S3 key for asset version \\"85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929b\\"",
       "Type": "String",
     },
     "AssetParameters8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064ArtifactHashEA963870": Object {
@@ -16162,8 +16102,6 @@ def submit_response(event: dict, context, response_status: str, error_message: s
     },
     "ConstructHubDenyListPrunePruneHandler30B33551": Object {
       "DependsOn": Array [
-        "ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA",
-        "ConstructHubDenyListBucketDeploymentCustomResourceF835956B",
         "ConstructHubDenyListPrunePruneHandlerServiceRoleDefaultPolicy416BC8DA",
         "ConstructHubDenyListPrunePruneHandlerServiceRole58BDE1FE",
       ],
@@ -16241,10 +16179,6 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Type": "AWS::Lambda::Function",
     },
     "ConstructHubDenyListPrunePruneHandlerServiceRole58BDE1FE": Object {
-      "DependsOn": Array [
-        "ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA",
-        "ConstructHubDenyListBucketDeploymentCustomResourceF835956B",
-      ],
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -16276,10 +16210,6 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Type": "AWS::IAM::Role",
     },
     "ConstructHubDenyListPrunePruneHandlerServiceRoleDefaultPolicy416BC8DA": Object {
-      "DependsOn": Array [
-        "ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA",
-        "ConstructHubDenyListBucketDeploymentCustomResourceF835956B",
-      ],
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -18050,8 +17980,6 @@ Direct link to function: /lambda/home#/functions/",
     },
     "ConstructHubOrchestrationCatalogBuilder7C964951": Object {
       "DependsOn": Array [
-        "ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA",
-        "ConstructHubDenyListBucketDeploymentCustomResourceF835956B",
         "ConstructHubOrchestrationCatalogBuilderServiceRoleDefaultPolicyDA5D5AA5",
         "ConstructHubOrchestrationCatalogBuilderServiceRole851C750C",
       ],
@@ -18134,10 +18062,6 @@ Direct link to function: /lambda/home#/functions/",
       "Type": "AWS::Lambda::Function",
     },
     "ConstructHubOrchestrationCatalogBuilderLogRetention04ED6996": Object {
-      "DependsOn": Array [
-        "ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA",
-        "ConstructHubDenyListBucketDeploymentCustomResourceF835956B",
-      ],
       "Properties": Object {
         "LogGroupName": Object {
           "Fn::Join": Array [
@@ -18161,10 +18085,6 @@ Direct link to function: /lambda/home#/functions/",
       "Type": "Custom::LogRetention",
     },
     "ConstructHubOrchestrationCatalogBuilderServiceRole851C750C": Object {
-      "DependsOn": Array [
-        "ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA",
-        "ConstructHubDenyListBucketDeploymentCustomResourceF835956B",
-      ],
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -18196,10 +18116,6 @@ Direct link to function: /lambda/home#/functions/",
       "Type": "AWS::IAM::Role",
     },
     "ConstructHubOrchestrationCatalogBuilderServiceRoleDefaultPolicyDA5D5AA5": Object {
-      "DependsOn": Array [
-        "ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA",
-        "ConstructHubDenyListBucketDeploymentCustomResourceF835956B",
-      ],
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -18395,7 +18311,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7",
+            "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3Bucket465251CA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -18408,7 +18324,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C",
                         },
                       ],
                     },
@@ -18421,7 +18337,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C",
                         },
                       ],
                     },
@@ -18740,7 +18656,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7",
+            "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3Bucket465251CA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -18753,7 +18669,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C",
                         },
                       ],
                     },
@@ -18766,7 +18682,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C",
                         },
                       ],
                     },
@@ -19717,8 +19633,6 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
     },
     "ConstructHubSourcesNpmJs15A77D2D": Object {
       "DependsOn": Array [
-        "ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA",
-        "ConstructHubDenyListBucketDeploymentCustomResourceF835956B",
         "ConstructHubLicenseListAwsCliLayer59592811",
         "ConstructHubLicenseListCustomResource323F0FD4",
         "ConstructHubSourcesNpmJsServiceRoleDefaultPolicy65FBFA22",
@@ -19925,8 +19839,6 @@ Direct link to Lambda function: /lambda/home#/functions/",
     },
     "ConstructHubSourcesNpmJsServiceRoleAC3F7AA6": Object {
       "DependsOn": Array [
-        "ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA",
-        "ConstructHubDenyListBucketDeploymentCustomResourceF835956B",
         "ConstructHubLicenseListAwsCliLayer59592811",
         "ConstructHubLicenseListCustomResource323F0FD4",
       ],
@@ -19962,8 +19874,6 @@ Direct link to Lambda function: /lambda/home#/functions/",
     },
     "ConstructHubSourcesNpmJsServiceRoleDefaultPolicy65FBFA22": Object {
       "DependsOn": Array [
-        "ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA",
-        "ConstructHubDenyListBucketDeploymentCustomResourceF835956B",
         "ConstructHubLicenseListAwsCliLayer59592811",
         "ConstructHubLicenseListCustomResource323F0FD4",
       ],

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -105,16 +105,16 @@ Object {
       "Description": "S3 key for asset version \\"8265ccdf680d2fc53b19193e2b93340a27f335cc3be02b673f0742d7700fd6ac\\"",
       "Type": "String",
     },
-    "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bArtifactHashAC589578": Object {
-      "Description": "Artifact hash for asset \\"85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929b\\"",
+    "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9ArtifactHash7A6CE4F0": Object {
+      "Description": "Artifact hash for asset \\"8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9\\"",
       "Type": "String",
     },
-    "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3Bucket465251CA": Object {
-      "Description": "S3 bucket for asset \\"85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929b\\"",
+    "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7": Object {
+      "Description": "S3 bucket for asset \\"8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9\\"",
       "Type": "String",
     },
-    "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C": Object {
-      "Description": "S3 key for asset version \\"85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929b\\"",
+    "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9": Object {
+      "Description": "S3 key for asset version \\"8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9\\"",
       "Type": "String",
     },
     "AssetParameters8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064ArtifactHashEA963870": Object {
@@ -4340,7 +4340,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3Bucket465251CA",
+            "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -4353,7 +4353,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C",
+                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
                         },
                       ],
                     },
@@ -4366,7 +4366,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C",
+                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
                         },
                       ],
                     },
@@ -4752,7 +4752,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3Bucket465251CA",
+            "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -4765,7 +4765,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C",
+                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
                         },
                       ],
                     },
@@ -4778,7 +4778,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C",
+                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
                         },
                       ],
                     },
@@ -7326,16 +7326,16 @@ Object {
       "Description": "S3 key for asset version \\"8265ccdf680d2fc53b19193e2b93340a27f335cc3be02b673f0742d7700fd6ac\\"",
       "Type": "String",
     },
-    "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bArtifactHashAC589578": Object {
-      "Description": "Artifact hash for asset \\"85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929b\\"",
+    "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9ArtifactHash7A6CE4F0": Object {
+      "Description": "Artifact hash for asset \\"8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9\\"",
       "Type": "String",
     },
-    "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3Bucket465251CA": Object {
-      "Description": "S3 bucket for asset \\"85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929b\\"",
+    "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7": Object {
+      "Description": "S3 bucket for asset \\"8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9\\"",
       "Type": "String",
     },
-    "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C": Object {
-      "Description": "S3 key for asset version \\"85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929b\\"",
+    "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9": Object {
+      "Description": "S3 key for asset version \\"8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9\\"",
       "Type": "String",
     },
     "AssetParameters8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064ArtifactHashEA963870": Object {
@@ -11732,7 +11732,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3Bucket465251CA",
+            "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -11745,7 +11745,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C",
+                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
                         },
                       ],
                     },
@@ -11758,7 +11758,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C",
+                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
                         },
                       ],
                     },
@@ -12144,7 +12144,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3Bucket465251CA",
+            "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -12157,7 +12157,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C",
+                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
                         },
                       ],
                     },
@@ -12170,7 +12170,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C",
+                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
                         },
                       ],
                     },
@@ -14962,16 +14962,16 @@ Object {
       "Description": "S3 key for asset version \\"8265ccdf680d2fc53b19193e2b93340a27f335cc3be02b673f0742d7700fd6ac\\"",
       "Type": "String",
     },
-    "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bArtifactHashAC589578": Object {
-      "Description": "Artifact hash for asset \\"85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929b\\"",
+    "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9ArtifactHash7A6CE4F0": Object {
+      "Description": "Artifact hash for asset \\"8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9\\"",
       "Type": "String",
     },
-    "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3Bucket465251CA": Object {
-      "Description": "S3 bucket for asset \\"85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929b\\"",
+    "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7": Object {
+      "Description": "S3 bucket for asset \\"8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9\\"",
       "Type": "String",
     },
-    "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C": Object {
-      "Description": "S3 key for asset version \\"85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929b\\"",
+    "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9": Object {
+      "Description": "S3 key for asset version \\"8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9\\"",
       "Type": "String",
     },
     "AssetParameters8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064ArtifactHashEA963870": Object {
@@ -18311,7 +18311,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3Bucket465251CA",
+            "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -18324,7 +18324,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C",
+                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
                         },
                       ],
                     },
@@ -18337,7 +18337,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C",
+                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
                         },
                       ],
                     },
@@ -18656,7 +18656,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3Bucket465251CA",
+            "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -18669,7 +18669,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C",
+                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
                         },
                       ],
                     },
@@ -18682,7 +18682,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C",
+                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
                         },
                       ],
                     },

--- a/src/__tests__/backend/deny-list/__snapshots__/deny-list.test.ts.snap
+++ b/src/__tests__/backend/deny-list/__snapshots__/deny-list.test.ts.snap
@@ -841,8 +841,6 @@ def submit_response(event: dict, context, response_status: str, error_message: s
     },
     "DenyListPrunePruneHandler5F946B07": Object {
       "DependsOn": Array [
-        "DenyListBucketDeploymentAwsCliLayer4F94CAE9",
-        "DenyListBucketDeploymentCustomResource68E58740",
         "DenyListPrunePruneHandlerServiceRoleDefaultPolicy7222934E",
         "DenyListPrunePruneHandlerServiceRole234C8EF9",
       ],
@@ -920,10 +918,6 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Type": "AWS::Lambda::Function",
     },
     "DenyListPrunePruneHandlerServiceRole234C8EF9": Object {
-      "DependsOn": Array [
-        "DenyListBucketDeploymentAwsCliLayer4F94CAE9",
-        "DenyListBucketDeploymentCustomResource68E58740",
-      ],
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -955,10 +949,6 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Type": "AWS::IAM::Role",
     },
     "DenyListPrunePruneHandlerServiceRoleDefaultPolicy7222934E": Object {
-      "DependsOn": Array [
-        "DenyListBucketDeploymentAwsCliLayer4F94CAE9",
-        "DenyListBucketDeploymentCustomResource68E58740",
-      ],
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [

--- a/src/__tests__/backend/deny-list/integ/deny-list.integ.cdkout/TestDenyList.template.json
+++ b/src/__tests__/backend/deny-list/integ/deny-list.integ.cdkout/TestDenyList.template.json
@@ -1165,10 +1165,6 @@
           }
         ]
       },
-      "DependsOn": [
-        "DenyListBucketDeploymentAwsCliLayer4F94CAE9",
-        "DenyListBucketDeploymentCustomResource68E58740"
-      ],
       "Metadata": {
         "aws:cdk:path": "TestDenyList/DenyList/Prune/PruneHandler/ServiceRole/Resource"
       }
@@ -1272,10 +1268,6 @@
           }
         ]
       },
-      "DependsOn": [
-        "DenyListBucketDeploymentAwsCliLayer4F94CAE9",
-        "DenyListBucketDeploymentCustomResource68E58740"
-      ],
       "Metadata": {
         "aws:cdk:path": "TestDenyList/DenyList/Prune/PruneHandler/ServiceRole/DefaultPolicy/Resource"
       }
@@ -1354,8 +1346,6 @@
         "Timeout": 900
       },
       "DependsOn": [
-        "DenyListBucketDeploymentAwsCliLayer4F94CAE9",
-        "DenyListBucketDeploymentCustomResource68E58740",
         "DenyListPrunePruneHandlerServiceRoleDefaultPolicy7222934E",
         "DenyListPrunePruneHandlerServiceRole234C8EF9"
       ],
@@ -1788,10 +1778,6 @@
           }
         ]
       },
-      "DependsOn": [
-        "DenyListBucketDeploymentAwsCliLayer4F94CAE9",
-        "DenyListBucketDeploymentCustomResource68E58740"
-      ],
       "Metadata": {
         "aws:cdk:path": "TestDenyList/ClientTest/ServiceRole/Resource"
       }
@@ -1841,10 +1827,6 @@
           }
         ]
       },
-      "DependsOn": [
-        "DenyListBucketDeploymentAwsCliLayer4F94CAE9",
-        "DenyListBucketDeploymentCustomResource68E58740"
-      ],
       "Metadata": {
         "aws:cdk:path": "TestDenyList/ClientTest/ServiceRole/DefaultPolicy/Resource"
       }
@@ -1914,9 +1896,7 @@
       },
       "DependsOn": [
         "ClientTestServiceRoleDefaultPolicy3CB30A97",
-        "ClientTestServiceRole4F7802CF",
-        "DenyListBucketDeploymentAwsCliLayer4F94CAE9",
-        "DenyListBucketDeploymentCustomResource68E58740"
+        "ClientTestServiceRole4F7802CF"
       ],
       "Metadata": {
         "aws:cdk:path": "TestDenyList/ClientTest/Resource",
@@ -1934,7 +1914,7 @@
           ]
         },
         "HandlerArn": {
-          "Ref": "ClientTestCurrentVersionAB7E7F653b61d5a851dd2736d6229988734e8991"
+          "Ref": "ClientTestCurrentVersionAB7E7F6529e01c8b11d584574078cfdc2af6fba4"
         }
       },
       "DependsOn": [
@@ -1961,17 +1941,13 @@
         "aws:cdk:path": "TestDenyList/ClientTest/Trigger/Resource/Default"
       }
     },
-    "ClientTestCurrentVersionAB7E7F653b61d5a851dd2736d6229988734e8991": {
+    "ClientTestCurrentVersionAB7E7F6529e01c8b11d584574078cfdc2af6fba4": {
       "Type": "AWS::Lambda::Version",
       "Properties": {
         "FunctionName": {
           "Ref": "ClientTestBE4CEC14"
         }
       },
-      "DependsOn": [
-        "DenyListBucketDeploymentAwsCliLayer4F94CAE9",
-        "DenyListBucketDeploymentCustomResource68E58740"
-      ],
       "Metadata": {
         "aws:cdk:path": "TestDenyList/ClientTest/CurrentVersion/Resource"
       }

--- a/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
+++ b/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
@@ -216,7 +216,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7",
+            "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3Bucket465251CA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -229,7 +229,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C",
                         },
                       ],
                     },
@@ -242,7 +242,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C",
                         },
                       ],
                     },
@@ -683,7 +683,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7",
+            "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3Bucket465251CA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -696,7 +696,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C",
                         },
                       ],
                     },
@@ -709,7 +709,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C",
                         },
                       ],
                     },
@@ -1269,7 +1269,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7",
+            "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3Bucket465251CA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -1282,7 +1282,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C",
                         },
                       ],
                     },
@@ -1295,7 +1295,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C",
                         },
                       ],
                     },
@@ -1815,7 +1815,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7",
+            "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3Bucket465251CA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -1828,7 +1828,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C",
                         },
                       ],
                     },
@@ -1841,7 +1841,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C",
                         },
                       ],
                     },

--- a/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
+++ b/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
@@ -216,7 +216,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3Bucket465251CA",
+            "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -229,7 +229,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C",
+                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
                         },
                       ],
                     },
@@ -242,7 +242,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C",
+                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
                         },
                       ],
                     },
@@ -683,7 +683,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3Bucket465251CA",
+            "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -696,7 +696,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C",
+                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
                         },
                       ],
                     },
@@ -709,7 +709,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C",
+                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
                         },
                       ],
                     },
@@ -1269,7 +1269,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3Bucket465251CA",
+            "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -1282,7 +1282,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C",
+                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
                         },
                       ],
                     },
@@ -1295,7 +1295,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C",
+                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
                         },
                       ],
                     },
@@ -1815,7 +1815,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3Bucket465251CA",
+            "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -1828,7 +1828,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C",
+                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
                         },
                       ],
                     },
@@ -1841,7 +1841,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C",
+                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
                         },
                       ],
                     },

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -1212,9 +1212,6 @@ Resources:
             - - "arn:"
               - Ref: AWS::Partition
               - :iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
-    DependsOn:
-      - ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA
-      - ConstructHubDenyListBucketDeploymentCustomResourceF835956B
   ConstructHubDenyListPrunePruneHandlerServiceRoleDefaultPolicy416BC8DA:
     Type: AWS::IAM::Policy
     Properties:
@@ -1269,9 +1266,6 @@ Resources:
       PolicyName: ConstructHubDenyListPrunePruneHandlerServiceRoleDefaultPolicy416BC8DA
       Roles:
         - Ref: ConstructHubDenyListPrunePruneHandlerServiceRole58BDE1FE
-    DependsOn:
-      - ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA
-      - ConstructHubDenyListBucketDeploymentCustomResourceF835956B
   ConstructHubDenyListPrunePruneHandler30B33551:
     Type: AWS::Lambda::Function
     Properties:
@@ -1314,8 +1308,6 @@ Resources:
       Runtime: nodejs14.x
       Timeout: 900
     DependsOn:
-      - ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA
-      - ConstructHubDenyListBucketDeploymentCustomResourceF835956B
       - ConstructHubDenyListPrunePruneHandlerServiceRoleDefaultPolicy416BC8DA
       - ConstructHubDenyListPrunePruneHandlerServiceRole58BDE1FE
   ConstructHubDenyListPrunePruneQueueHandlerServiceRoleC10AC418:
@@ -1510,9 +1502,6 @@ Resources:
             - - "arn:"
               - Ref: AWS::Partition
               - :iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
-    DependsOn:
-      - ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA
-      - ConstructHubDenyListBucketDeploymentCustomResourceF835956B
   ConstructHubOrchestrationCatalogBuilderServiceRoleDefaultPolicyDA5D5AA5:
     Type: AWS::IAM::Policy
     Properties:
@@ -1560,9 +1549,6 @@ Resources:
       PolicyName: ConstructHubOrchestrationCatalogBuilderServiceRoleDefaultPolicyDA5D5AA5
       Roles:
         - Ref: ConstructHubOrchestrationCatalogBuilderServiceRole851C750C
-    DependsOn:
-      - ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA
-      - ConstructHubDenyListBucketDeploymentCustomResourceF835956B
   ConstructHubOrchestrationCatalogBuilder7C964951:
     Type: AWS::Lambda::Function
     Properties:
@@ -1606,8 +1592,6 @@ Resources:
       TracingConfig:
         Mode: PassThrough
     DependsOn:
-      - ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA
-      - ConstructHubDenyListBucketDeploymentCustomResourceF835956B
       - ConstructHubOrchestrationCatalogBuilderServiceRoleDefaultPolicyDA5D5AA5
       - ConstructHubOrchestrationCatalogBuilderServiceRole851C750C
   ConstructHubOrchestrationCatalogBuilderLogRetention04ED6996:
@@ -1623,9 +1607,6 @@ Resources:
           - - /aws/lambda/
             - Ref: ConstructHubOrchestrationCatalogBuilder7C964951
       RetentionInDays: 3653
-    DependsOn:
-      - ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA
-      - ConstructHubDenyListBucketDeploymentCustomResourceF835956B
   ConstructHubOrchestrationDocGenpythonServiceRoleD16CBDB2:
     Type: AWS::IAM::Role
     Properties:
@@ -1770,7 +1751,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7
+          Ref: AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3Bucket465251CA
         S3Key:
           Fn::Join:
             - ""
@@ -1778,12 +1759,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9
+                      - Ref: AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9
+                      - Ref: AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C
       Role:
         Fn::GetAtt:
           - ConstructHubOrchestrationDocGenpythonServiceRoleD16CBDB2
@@ -1989,7 +1970,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7
+          Ref: AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3Bucket465251CA
         S3Key:
           Fn::Join:
             - ""
@@ -1997,12 +1978,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9
+                      - Ref: AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9
+                      - Ref: AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C
       Role:
         Fn::GetAtt:
           - ConstructHubOrchestrationDocGentypescriptServiceRoleB56C2B19
@@ -2955,8 +2936,6 @@ Resources:
               - Ref: AWS::Partition
               - :iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
     DependsOn:
-      - ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA
-      - ConstructHubDenyListBucketDeploymentCustomResourceF835956B
       - ConstructHubLicenseListAwsCliLayer59592811
       - ConstructHubLicenseListCustomResource323F0FD4
   ConstructHubSourcesNpmJsServiceRoleDefaultPolicy65FBFA22:
@@ -3031,8 +3010,6 @@ Resources:
       Roles:
         - Ref: ConstructHubSourcesNpmJsServiceRoleAC3F7AA6
     DependsOn:
-      - ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA
-      - ConstructHubDenyListBucketDeploymentCustomResourceF835956B
       - ConstructHubLicenseListAwsCliLayer59592811
       - ConstructHubLicenseListCustomResource323F0FD4
   ConstructHubSourcesNpmJs15A77D2D:
@@ -3080,8 +3057,6 @@ Resources:
       TracingConfig:
         Mode: Active
     DependsOn:
-      - ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA
-      - ConstructHubDenyListBucketDeploymentCustomResourceF835956B
       - ConstructHubLicenseListAwsCliLayer59592811
       - ConstructHubLicenseListCustomResource323F0FD4
       - ConstructHubSourcesNpmJsServiceRoleDefaultPolicy65FBFA22
@@ -4245,18 +4220,18 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24"
-  AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7:
+  AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3Bucket465251CA:
     Type: String
     Description: S3 bucket for asset
-      "8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9"
-  AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9:
+      "85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929b"
+  AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C:
     Type: String
     Description: S3 key for asset version
-      "8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9"
-  AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9ArtifactHash7A6CE4F0:
+      "85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929b"
+  AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bArtifactHashAC589578:
     Type: String
     Description: Artifact hash for asset
-      "8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9"
+      "85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929b"
   AssetParameters8265ccdf680d2fc53b19193e2b93340a27f335cc3be02b673f0742d7700fd6acS3Bucket9B1F28E2:
     Type: String
     Description: S3 bucket for asset

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -1751,7 +1751,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3Bucket465251CA
+          Ref: AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7
         S3Key:
           Fn::Join:
             - ""
@@ -1759,12 +1759,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C
+                      - Ref: AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C
+                      - Ref: AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9
       Role:
         Fn::GetAtt:
           - ConstructHubOrchestrationDocGenpythonServiceRoleD16CBDB2
@@ -1970,7 +1970,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3Bucket465251CA
+          Ref: AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7
         S3Key:
           Fn::Join:
             - ""
@@ -1978,12 +1978,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C
+                      - Ref: AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C
+                      - Ref: AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9
       Role:
         Fn::GetAtt:
           - ConstructHubOrchestrationDocGentypescriptServiceRoleB56C2B19
@@ -4220,18 +4220,18 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24"
-  AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3Bucket465251CA:
+  AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7:
     Type: String
     Description: S3 bucket for asset
-      "85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929b"
-  AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bS3VersionKey5D320B9C:
+      "8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9"
+  AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9:
     Type: String
     Description: S3 key for asset version
-      "85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929b"
-  AssetParameters85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929bArtifactHashAC589578:
+      "8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9"
+  AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9ArtifactHash7A6CE4F0:
     Type: String
     Description: Artifact hash for asset
-      "85eefa7d9d6acf4735110477b7910949a4c569ab77d089dac8d8611f3a8f929b"
+      "8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9"
   AssetParameters8265ccdf680d2fc53b19193e2b93340a27f335cc3be02b673f0742d7700fd6acS3Bucket9B1F28E2:
     Type: String
     Description: S3 bucket for asset


### PR DESCRIPTION
It is not currently possible to introduce dependencies from consumers of
the DenyList to the S3 Bucket Deployment that creates the deny list,
because this results in a circular dependency when `pruneOnChange` is
enabled on the deny list:

- S3 Bucket Deployment -> S3 Bucket Notification
- S3 Bucket Notification -> Prune Handler
- Prune Handler -> Catalog Builder
- Catalog Builder -> S3 Bucket Deployment


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*