### PR TITLE
feat: allow specific custom links

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -37,12 +37,6 @@
       "description": "Only compile",
       "steps": [
         {
-          "exec": "rm -rf ./website"
-        },
-        {
-          "exec": "cp -r ./node_modules/construct-hub-webapp/build ./website"
-        },
-        {
           "exec": "jsii --silence-warnings=reserved-word --no-fix-peer-dependencies"
         },
         {

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -502,8 +502,6 @@ function generateSpdxLicenseEnum() {
 // dev-dependency on the webapp instead of a normal/bundled dependency.
 project.addDevDeps('construct-hub-webapp');
 project.addDevDeps('cdk-triggers');
-project.compileTask.prependExec('cp -r ./node_modules/construct-hub-webapp/build ./website');
-project.compileTask.prependExec('rm -rf ./website');
 project.npmignore.addPatterns('!/website'); // <-- include in tarball
 project.gitignore.addPatterns('/website'); // <-- don't commit
 

--- a/API.md
+++ b/API.md
@@ -187,12 +187,56 @@ implies the creation of additonal resources, including:
 
 ---
 
+##### `packageLinks`<sup>Optional</sup> <a name="construct-hub.ConstructHubProps.property.packageLinks"></a>
+
+- *Type:* [`construct-hub.CustomLinkConfig`](#construct-hub.CustomLinkConfig)[]
+- *Default:* use standard links on package details page
+
+Custom package link config.
+
+---
+
 ##### `packageSources`<sup>Optional</sup> <a name="construct-hub.ConstructHubProps.property.packageSources"></a>
 
 - *Type:* [`construct-hub.IPackageSource`](#construct-hub.IPackageSource)[]
 - *Default:* a standard npmjs.com package source will be configured.
 
 The package sources to register with this ConstructHub instance.
+
+---
+
+### CustomLinkConfig <a name="construct-hub.CustomLinkConfig"></a>
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```typescript
+import { CustomLinkConfig } from 'construct-hub'
+
+const customLinkConfig: CustomLinkConfig = { ... }
+```
+
+##### `name`<sup>Required</sup> <a name="construct-hub.CustomLinkConfig.property.name"></a>
+
+- *Type:* `string`
+
+The name of the link, appears before the ":".
+
+---
+
+##### `value`<sup>Required</sup> <a name="construct-hub.CustomLinkConfig.property.value"></a>
+
+- *Type:* `string`
+
+The location of the value inside a module's package.json.
+
+---
+
+##### `displayText`<sup>Optional</sup> <a name="construct-hub.CustomLinkConfig.property.displayText"></a>
+
+- *Type:* `string`
+- *Default:* the url of the link
+
+optional text to display as the hyperlink text.
 
 ---
 

--- a/src/construct-hub.ts
+++ b/src/construct-hub.ts
@@ -19,7 +19,7 @@ import { Monitoring } from './monitoring';
 import { IPackageSource } from './package-source';
 import { NpmJs } from './package-sources';
 import { SpdxLicense } from './spdx-license';
-import { WebApp } from './webapp';
+import { WebApp, CustomLinkConfig } from './webapp';
 
 /**
  * Props for `ConstructHub`.
@@ -75,6 +75,13 @@ export interface ConstructHubProps {
    * @default [...SpdxLicense.apache(),...SpdxLicense.bsd(),...SpdxLicense.mit()]
    */
   readonly allowedLicenses?: SpdxLicense[];
+
+  /**
+   * Custom package link config
+   *
+   * @default use standard links on package details page
+   */
+  readonly packageLinks?: CustomLinkConfig[];
 }
 
 /**
@@ -170,7 +177,7 @@ export class ConstructHub extends CoreConstruct implements iam.IGrantable {
     // rebuild the catalog when the deny list changes.
     denyList.prune.onChangeInvoke(orchestration.catalogBuilder);
 
-    this.ingestion = new Ingestion(this, 'Ingestion', { bucket: packageData, orchestration, monitoring });
+    this.ingestion = new Ingestion(this, 'Ingestion', { bucket: packageData, orchestration, monitoring, packageLinks: props.packageLinks });
 
     const licenseList = new LicenseList(this, 'LicenseList', {
       licenses: props.allowedLicenses ?? [...SpdxLicense.apache(), ...SpdxLicense.bsd(), ...SpdxLicense.mit()],
@@ -200,6 +207,7 @@ export class ConstructHub extends CoreConstruct implements iam.IGrantable {
 
     new WebApp(this, 'WebApp', {
       domain: props.domain,
+      packageLinks: props.packageLinks,
       monitoring,
       packageData,
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,4 @@ export * from './construct-hub';
 export * from './package-source';
 export * as sources from './package-sources';
 export * from './spdx-license';
+export { CustomLinkConfig } from './webapp';

--- a/src/webapp/builder.ts
+++ b/src/webapp/builder.ts
@@ -1,0 +1,94 @@
+import * as childProcess from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+export interface CustomLinkConfig {
+  /**
+   * The name of the link, appears before the ":"
+   */
+  readonly name: string;
+
+  /**
+   * The location of the value inside a module's package.json
+   */
+  readonly value: string;
+
+  /**
+   * optional text to display as the hyperlink text
+   *
+   * @default the url of the link
+   */
+  readonly displayText?: string;
+}
+
+interface WebAppBuilderConfig {
+  /**
+   * Whether to load client side analytics script.
+   * @default false
+   */
+  readonly analytics?: boolean;
+
+  /**
+   * Whether FAQ is displayed or not
+   * @default false
+   */
+  readonly faq?: boolean;
+
+  /**
+   * Custom package link config
+   */
+  readonly packageLinks?: CustomLinkConfig[];
+}
+
+export class WebAppBuilder {
+  public readonly sourceDir: string;
+  public readonly outDir: string;
+  private readonly workingDir: string;
+  public constructor(public readonly config: WebAppBuilderConfig) {
+    const rootDir = path.join(__dirname, '..', '..');
+    this.sourceDir = path.join(rootDir, 'node_modules', 'construct-hub-webapp');
+    this.workingDir = fs.mkdtempSync(`${os.tmpdir()}${path.sep}`);
+    this.outDir = path.join(this.workingDir, 'build');
+    this.build();
+  }
+
+  private addRuntimeConfig() {
+    fs.writeFileSync(path.join(this.outDir, 'config.json'), JSON.stringify({
+      packageLinks: this.config.packageLinks ?? {},
+    }));
+  }
+
+  private build() {
+    // Install app dependencies
+    // setup working directory
+    childProcess.execSync(
+      `
+      #!/bin/bash
+      rm -rf ${this.outDir}
+      cp -r ${this.sourceDir}/* ${this.workingDir}
+      `,
+      {
+        stdio: 'inherit',
+      },
+    );
+
+    // We pass config values as build time environment variables to react-scripts
+    const { analytics, faq } = this.config;
+    const env = {
+      ...process.env,
+      REACT_APP_HAS_ANALYTICS: analytics ? 'true' : 'false',
+      REACT_APP_FAQ: faq ? 'true' : 'false',
+      DISABLE_ESLINT_PLUGIN: 'true',
+    };
+    childProcess.execSync(
+      `
+        yarn install
+        npx react-app-rewired build
+      `,
+      { stdio: 'inherit', env, cwd: this.workingDir },
+    );
+
+    this.addRuntimeConfig();
+  }
+}


### PR DESCRIPTION
Allows contruct-hub admins to specify a list of allowed links that
package authors can include in their package.json to be shown on their
package's details page. For Example:

A package author can add the following to their package.json
```json
"constructHub": {
  "links": {
    "SLA": "https://link.to.my.support.info",
    "Author": "mailto:me@you.com"
  }
}
```

Then, the administrator of construct hub can add these to an allow list
like so:
```ts
new ConstructHub(this, "ConstructHub", {
  ...myProps,
  packageLinks: [{
    name: 'Service Level Agreement',
    value: 'SLA',
  }, {
    name: 'Contact',
    value: 'Author',
    displayText: 'Email Me!',
  }]
});
```

With these links allowed, the ingestion lambda will search for these
values and place them in a package's metadata.json file. Additionally,
the configuration is put into a `config.json` file alongside the webapp
assets to be loaded by the frontend in order to determine what links to
render.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*