### PR TITLE
feat: Java API reference

### DIFF
--- a/API.md
+++ b/API.md
@@ -8,7 +8,7 @@
 
 Construct Hub.
 
-#### Initializer <a name="construct-hub.ConstructHub.Initializer"></a>
+#### Initializers <a name="construct-hub.ConstructHub.Initializer"></a>
 
 ```typescript
 import { ConstructHub } from 'construct-hub'

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "jest-junit": "^12",
     "jsii": "^1.33.0",
     "jsii-diff": "^1.33.0",
-    "jsii-docgen": "^3.3.2",
+    "jsii-docgen": "^3.4.5",
     "jsii-pacmak": "^1.33.0",
     "json-schema": "^0.3.0",
     "nano": "^9.0.3",

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -33,6 +33,18 @@ Object {
     },
   },
   "Parameters": Object {
+    "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15ArtifactHash2AA5202D": Object {
+      "Description": "Artifact hash for asset \\"1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15\\"",
+      "Type": "String",
+    },
+    "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3Bucket38537BD6": Object {
+      "Description": "S3 bucket for asset \\"1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15\\"",
+      "Type": "String",
+    },
+    "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35": Object {
+      "Description": "S3 key for asset version \\"1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15\\"",
+      "Type": "String",
+    },
     "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49ArtifactHashA1145632": Object {
       "Description": "Artifact hash for asset \\"1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49\\"",
       "Type": "String",
@@ -81,6 +93,18 @@ Object {
       "Description": "S3 key for asset version \\"67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24\\"",
       "Type": "String",
     },
+    "AssetParameters68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513ArtifactHash02422EA3": Object {
+      "Description": "Artifact hash for asset \\"68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513\\"",
+      "Type": "String",
+    },
+    "AssetParameters68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513S3Bucket942ED5A2": Object {
+      "Description": "S3 bucket for asset \\"68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513\\"",
+      "Type": "String",
+    },
+    "AssetParameters68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513S3VersionKeyF5E68355": Object {
+      "Description": "S3 key for asset version \\"68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513\\"",
+      "Type": "String",
+    },
     "AssetParameters7ee6e37c4f89b09a6b3c50e513093daf23a858809daed5a6703095d14955c9b2ArtifactHash65BC41FC": Object {
       "Description": "Artifact hash for asset \\"7ee6e37c4f89b09a6b3c50e513093daf23a858809daed5a6703095d14955c9b2\\"",
       "Type": "String",
@@ -105,18 +129,6 @@ Object {
       "Description": "S3 key for asset version \\"8265ccdf680d2fc53b19193e2b93340a27f335cc3be02b673f0742d7700fd6ac\\"",
       "Type": "String",
     },
-    "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9ArtifactHash7A6CE4F0": Object {
-      "Description": "Artifact hash for asset \\"8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9\\"",
-      "Type": "String",
-    },
-    "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7": Object {
-      "Description": "S3 bucket for asset \\"8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9\\"",
-      "Type": "String",
-    },
-    "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9": Object {
-      "Description": "S3 key for asset version \\"8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9\\"",
-      "Type": "String",
-    },
     "AssetParameters8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064ArtifactHashEA963870": Object {
       "Description": "Artifact hash for asset \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
@@ -129,40 +141,16 @@ Object {
       "Description": "S3 key for asset version \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
     },
-    "AssetParametersa7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100ArtifactHashB98D2EC5": Object {
-      "Description": "Artifact hash for asset \\"a7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100\\"",
+    "AssetParameters9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4bArtifactHash9C520604": Object {
+      "Description": "Artifact hash for asset \\"9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4b\\"",
       "Type": "String",
     },
-    "AssetParametersa7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100S3BucketA07EA20C": Object {
-      "Description": "S3 bucket for asset \\"a7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100\\"",
+    "AssetParameters9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4bS3BucketF0A4F598": Object {
+      "Description": "S3 bucket for asset \\"9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4b\\"",
       "Type": "String",
     },
-    "AssetParametersa7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100S3VersionKeyBF4D0B81": Object {
-      "Description": "S3 key for asset version \\"a7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100\\"",
-      "Type": "String",
-    },
-    "AssetParametersb191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17ArtifactHash65E20850": Object {
-      "Description": "Artifact hash for asset \\"b191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17\\"",
-      "Type": "String",
-    },
-    "AssetParametersb191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17S3Bucket60674A76": Object {
-      "Description": "S3 bucket for asset \\"b191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17\\"",
-      "Type": "String",
-    },
-    "AssetParametersb191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17S3VersionKey724F7AFD": Object {
-      "Description": "S3 key for asset version \\"b191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17\\"",
-      "Type": "String",
-    },
-    "AssetParametersbec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ecArtifactHash04B28626": Object {
-      "Description": "Artifact hash for asset \\"bec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ec\\"",
-      "Type": "String",
-    },
-    "AssetParametersbec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ecS3BucketE3CFE68F": Object {
-      "Description": "S3 bucket for asset \\"bec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ec\\"",
-      "Type": "String",
-    },
-    "AssetParametersbec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ecS3VersionKey6D99058D": Object {
-      "Description": "S3 key for asset version \\"bec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ec\\"",
+    "AssetParameters9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4bS3VersionKey5E4628BC": Object {
+      "Description": "S3 key for asset version \\"9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4b\\"",
       "Type": "String",
     },
     "AssetParametersc24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cfArtifactHash85F58E48": Object {
@@ -201,16 +189,16 @@ Object {
       "Description": "S3 key for asset version \\"d5ce621914a7c3f15cf5d46823956ea431a98db7cf8d22b7af369eb6d01413c7\\"",
       "Type": "String",
     },
-    "AssetParametersdef5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9ArtifactHashB9B2536A": Object {
-      "Description": "Artifact hash for asset \\"def5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9\\"",
+    "AssetParameterse0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813ArtifactHashAC8102A5": Object {
+      "Description": "Artifact hash for asset \\"e0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813\\"",
       "Type": "String",
     },
-    "AssetParametersdef5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9S3Bucket693007CE": Object {
-      "Description": "S3 bucket for asset \\"def5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9\\"",
+    "AssetParameterse0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813S3Bucket55321DF2": Object {
+      "Description": "S3 bucket for asset \\"e0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813\\"",
       "Type": "String",
     },
-    "AssetParametersdef5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9S3VersionKeyA7862DEC": Object {
-      "Description": "S3 key for asset version \\"def5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9\\"",
+    "AssetParameterse0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813S3VersionKey325A408D": Object {
+      "Description": "S3 key for asset version \\"e0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813\\"",
       "Type": "String",
     },
     "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68ArtifactHashD9A515C3": Object {
@@ -247,6 +235,18 @@ Object {
     },
     "AssetParametersfab52dab596e8f8b4fc5a26e9882c7509290ba057320ed7864232c0f290b5750S3VersionKey79B2C284": Object {
       "Description": "S3 key for asset version \\"fab52dab596e8f8b4fc5a26e9882c7509290ba057320ed7864232c0f290b5750\\"",
+      "Type": "String",
+    },
+    "AssetParametersff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2ArtifactHash58196055": Object {
+      "Description": "Artifact hash for asset \\"ff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2\\"",
+      "Type": "String",
+    },
+    "AssetParametersff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2S3BucketBC914BA2": Object {
+      "Description": "S3 bucket for asset \\"ff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2\\"",
+      "Type": "String",
+    },
+    "AssetParametersff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2S3VersionKey1681742D": Object {
+      "Description": "S3 key for asset version \\"ff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2\\"",
       "Type": "String",
     },
   },
@@ -574,7 +574,23 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"stacked\\":true,\\"metrics\\":[[\\"ConstructHub/Inventory\\",\\"SupportedSubmoduleCount\\",\\"Language\\",\\"python\\",{\\"color\\":\\"#2ca02c\\",\\"label\\":\\"Available\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"UnsupportedSubmoduleCount\\",\\"Language\\",\\"python\\",{\\"color\\":\\"#9467bd\\",\\"label\\":\\"Unsupported\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"MissingSubmoduleCount\\",\\"Language\\",\\"python\\",{\\"color\\":\\"#d62728\\",\\"label\\":\\"Missing\\",\\"stat\\":\\"Maximum\\"}]],\\"yAxis\\":{\\"left\\":{\\"showUnits\\":false}}}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":24,\\"properties\\":{\\"markdown\\":\\"# Test/ConstructHub/Sources/NpmJs\\\\n\\\\n[button:primary:NpmJs Follower](/lambda/home#/functions/",
+              "\\",\\"stacked\\":true,\\"metrics\\":[[\\"ConstructHub/Inventory\\",\\"SupportedSubmoduleCount\\",\\"Language\\",\\"python\\",{\\"color\\":\\"#2ca02c\\",\\"label\\":\\"Available\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"UnsupportedSubmoduleCount\\",\\"Language\\",\\"python\\",{\\"color\\":\\"#9467bd\\",\\"label\\":\\"Unsupported\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"MissingSubmoduleCount\\",\\"Language\\",\\"python\\",{\\"color\\":\\"#d62728\\",\\"label\\":\\"Missing\\",\\"stat\\":\\"Maximum\\"}]],\\"yAxis\\":{\\"left\\":{\\"showUnits\\":false}}}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":24,\\"properties\\":{\\"markdown\\":\\"## Language: java\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":6,\\"x\\":0,\\"y\\":25,\\"properties\\":{\\"view\\":\\"pie\\",\\"title\\":\\"Package Versions\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"ConstructHub/Inventory\\",\\"SupportedPackageVersionCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#2ca02c\\",\\"label\\":\\"Available\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"UnsupportedPackageVersionCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#9467bd\\",\\"label\\":\\"Unsupported\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"MissingPackageVersionCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#d62728\\",\\"label\\":\\"Missing\\",\\"stat\\":\\"Maximum\\"}]],\\"yAxis\\":{\\"left\\":{\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":6,\\"x\\":6,\\"y\\":25,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Package Versions\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"stacked\\":true,\\"metrics\\":[[\\"ConstructHub/Inventory\\",\\"SupportedPackageVersionCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#2ca02c\\",\\"label\\":\\"Available\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"UnsupportedPackageVersionCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#9467bd\\",\\"label\\":\\"Unsupported\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"MissingPackageVersionCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#d62728\\",\\"label\\":\\"Missing\\",\\"stat\\":\\"Maximum\\"}]],\\"yAxis\\":{\\"left\\":{\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":6,\\"x\\":12,\\"y\\":25,\\"properties\\":{\\"view\\":\\"pie\\",\\"title\\":\\"Package Version Submodules\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"ConstructHub/Inventory\\",\\"SupportedSubmoduleCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#2ca02c\\",\\"label\\":\\"Available\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"UnsupportedSubmoduleCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#9467bd\\",\\"label\\":\\"Unsupported\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"MissingSubmoduleCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#d62728\\",\\"label\\":\\"Missing\\",\\"stat\\":\\"Maximum\\"}]],\\"yAxis\\":{\\"left\\":{\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":6,\\"x\\":18,\\"y\\":25,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Package Version Submodules\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"stacked\\":true,\\"metrics\\":[[\\"ConstructHub/Inventory\\",\\"SupportedSubmoduleCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#2ca02c\\",\\"label\\":\\"Available\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"UnsupportedSubmoduleCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#9467bd\\",\\"label\\":\\"Unsupported\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"MissingSubmoduleCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#d62728\\",\\"label\\":\\"Missing\\",\\"stat\\":\\"Maximum\\"}]],\\"yAxis\\":{\\"left\\":{\\"showUnits\\":false}}}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":31,\\"properties\\":{\\"markdown\\":\\"# Test/ConstructHub/Sources/NpmJs\\\\n\\\\n[button:primary:NpmJs Follower](/lambda/home#/functions/",
               Object {
                 "Ref": "ConstructHubSourcesNpmJs15A77D2D",
               },
@@ -582,7 +598,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubSourcesNpmJsStagingBucketB286F0E6",
               },
-              "?prefix=couchdb-last-transaction-id.2)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":26,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Function Health\\",\\"region\\":\\"",
+              "?prefix=couchdb-last-transaction-id.2)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":33,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Function Health\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -594,11 +610,11 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubSourcesNpmJs15A77D2D",
               },
-              "\\",{\\"label\\":\\"Errors\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55\\"}],[\\"ConstructHub/PackageSource/NpmJs/Follower\\",\\"RemainingTime\\",{\\"label\\":\\"Remaining Time\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":900}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":26,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"CouchDB Follower\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Errors\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55\\"}],[\\"ConstructHub/PackageSource/NpmJs/Follower\\",\\"RemainingTime\\",{\\"label\\":\\"Remaining Time\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":900}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":33,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"CouchDB Follower\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[\\"ConstructHub/PackageSource/NpmJs/Follower\\",\\"ChangeCount\\",{\\"label\\":\\"Change Count\\",\\"stat\\":\\"Sum\\"}],[\\"ConstructHub/PackageSource/NpmJs/Follower\\",\\"UnprocessableEntity\\",{\\"label\\":\\"Unprocessable\\",\\"stat\\":\\"Sum\\"}],[{\\"label\\":\\"Lag to npmjs.com\\",\\"expression\\":\\"FILL(m4d6c513faac55be4bca785e8587a9a145b65f5fe675318c9c5c52f3ada197b7b, REPEAT)\\",\\"yAxis\\":\\"right\\"}],[\\"ConstructHub/PackageSource/NpmJs/Follower\\",\\"NpmJsChangeAge\\",{\\"label\\":\\"Lag to npmjs.com\\",\\"stat\\":\\"Minimum\\",\\"visible\\":false,\\"id\\":\\"m4d6c513faac55be4bca785e8587a9a145b65f5fe675318c9c5c52f3ada197b7b\\"}],[{\\"label\\":\\"Package Version Age\\",\\"expression\\":\\"FILL(mec485aa83505431ed7a356970082cd4815c310504ff176dd3eeb241ae7bbf0c4, REPEAT)\\",\\"yAxis\\":\\"right\\"}],[\\"ConstructHub/PackageSource/NpmJs/Follower\\",\\"PackageVersionAge\\",{\\"label\\":\\"Package Version Age\\",\\"stat\\":\\"Maximum\\",\\"visible\\":false,\\"id\\":\\"mec485aa83505431ed7a356970082cd4815c310504ff176dd3eeb241ae7bbf0c4\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"label\\":\\"Milliseconds\\",\\"min\\":0,\\"showUnits\\":false}},\\"period\\":900}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":32,\\"properties\\":{\\"markdown\\":\\"# Ingestion Function\\\\n\\\\n[button:Ingestion Function](/lambda/home#/functions/",
+              "\\",\\"metrics\\":[[\\"ConstructHub/PackageSource/NpmJs/Follower\\",\\"ChangeCount\\",{\\"label\\":\\"Change Count\\",\\"stat\\":\\"Sum\\"}],[\\"ConstructHub/PackageSource/NpmJs/Follower\\",\\"UnprocessableEntity\\",{\\"label\\":\\"Unprocessable\\",\\"stat\\":\\"Sum\\"}],[{\\"label\\":\\"Lag to npmjs.com\\",\\"expression\\":\\"FILL(m4d6c513faac55be4bca785e8587a9a145b65f5fe675318c9c5c52f3ada197b7b, REPEAT)\\",\\"yAxis\\":\\"right\\"}],[\\"ConstructHub/PackageSource/NpmJs/Follower\\",\\"NpmJsChangeAge\\",{\\"label\\":\\"Lag to npmjs.com\\",\\"stat\\":\\"Minimum\\",\\"visible\\":false,\\"id\\":\\"m4d6c513faac55be4bca785e8587a9a145b65f5fe675318c9c5c52f3ada197b7b\\"}],[{\\"label\\":\\"Package Version Age\\",\\"expression\\":\\"FILL(mec485aa83505431ed7a356970082cd4815c310504ff176dd3eeb241ae7bbf0c4, REPEAT)\\",\\"yAxis\\":\\"right\\"}],[\\"ConstructHub/PackageSource/NpmJs/Follower\\",\\"PackageVersionAge\\",{\\"label\\":\\"Package Version Age\\",\\"stat\\":\\"Maximum\\",\\"visible\\":false,\\"id\\":\\"mec485aa83505431ed7a356970082cd4815c310504ff176dd3eeb241ae7bbf0c4\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"label\\":\\"Milliseconds\\",\\"min\\":0,\\"showUnits\\":false}},\\"period\\":900}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":39,\\"properties\\":{\\"markdown\\":\\"# Ingestion Function\\\\n\\\\n[button:Ingestion Function](/lambda/home#/functions/",
               Object {
                 "Ref": "ConstructHubIngestion407909CE",
               },
@@ -621,7 +637,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              ")\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":34,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Function Health\\",\\"region\\":\\"",
+              ")\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":41,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Function Health\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -633,7 +649,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubIngestion407909CE",
               },
-              "\\",{\\"label\\":\\"Errors\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":34,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Input Queue\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Errors\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":41,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Input Queue\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -658,11 +674,11 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"period\\":60,\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ffa500\\",\\"label\\":\\"10 Minutes\\",\\"value\\":600,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":40,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Input Quality\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"period\\":60,\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ffa500\\",\\"label\\":\\"10 Minutes\\",\\"value\\":600,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":47,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Input Quality\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"stacked\\":true,\\"metrics\\":[[{\\"label\\":\\"Invalid Assemblies\\",\\"expression\\":\\"FILL(m0c5f10aa73687a21aa44b8985d19311246bca6c2cd1b2256b9f3e78c71e94fa3, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"InvalidAssembly\\",{\\"label\\":\\"Invalid Assemblies\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m0c5f10aa73687a21aa44b8985d19311246bca6c2cd1b2256b9f3e78c71e94fa3\\"}],[{\\"label\\":\\"Invalid Tarball\\",\\"expression\\":\\"FILL(m3a39d9b0bf974255f27dc95e44c8574bdfce2b97e49a7504346a77c5c9f6a3e1, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"InvalidTarball\\",{\\"label\\":\\"Invalid Tarball\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3a39d9b0bf974255f27dc95e44c8574bdfce2b97e49a7504346a77c5c9f6a3e1\\"}],[{\\"label\\":\\"Ineligible License\\",\\"expression\\":\\"FILL(me19ae9c3f20ae715e3462f9402684a3817282218f36e69494a60bc251e3435a6, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"IneligibleLicense\\",{\\"label\\":\\"Ineligible License\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"me19ae9c3f20ae715e3462f9402684a3817282218f36e69494a60bc251e3435a6\\"}],[{\\"label\\":\\"Mismatched Identity\\",\\"expression\\":\\"FILL(m7c1d407f17f8d2452a0bf87ac06fdd032de385a2758254f4192d6e17ed40d44b, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"MismatchedIdentityRejections\\",{\\"label\\":\\"Mismatched Identity\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m7c1d407f17f8d2452a0bf87ac06fdd032de385a2758254f4192d6e17ed40d44b\\"}],[{\\"label\\":\\"Found License file\\",\\"expression\\":\\"FILL(m7084dfec3c5bab86694d7ae438460f471c174a94bc67c9c9738e3ab60246b661, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"FoundLicenseFile\\",{\\"label\\":\\"Found License file\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m7084dfec3c5bab86694d7ae438460f471c174a94bc67c9c9738e3ab60246b661\\"}]],\\"yAxis\\":{\\"left\\":{\\"label\\":\\"Count\\",\\"min\\":0,\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":40,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Dead Letters\\",\\"region\\":\\"",
+              "\\",\\"stacked\\":true,\\"metrics\\":[[{\\"label\\":\\"Invalid Assemblies\\",\\"expression\\":\\"FILL(m0c5f10aa73687a21aa44b8985d19311246bca6c2cd1b2256b9f3e78c71e94fa3, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"InvalidAssembly\\",{\\"label\\":\\"Invalid Assemblies\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m0c5f10aa73687a21aa44b8985d19311246bca6c2cd1b2256b9f3e78c71e94fa3\\"}],[{\\"label\\":\\"Invalid Tarball\\",\\"expression\\":\\"FILL(m3a39d9b0bf974255f27dc95e44c8574bdfce2b97e49a7504346a77c5c9f6a3e1, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"InvalidTarball\\",{\\"label\\":\\"Invalid Tarball\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3a39d9b0bf974255f27dc95e44c8574bdfce2b97e49a7504346a77c5c9f6a3e1\\"}],[{\\"label\\":\\"Ineligible License\\",\\"expression\\":\\"FILL(me19ae9c3f20ae715e3462f9402684a3817282218f36e69494a60bc251e3435a6, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"IneligibleLicense\\",{\\"label\\":\\"Ineligible License\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"me19ae9c3f20ae715e3462f9402684a3817282218f36e69494a60bc251e3435a6\\"}],[{\\"label\\":\\"Mismatched Identity\\",\\"expression\\":\\"FILL(m7c1d407f17f8d2452a0bf87ac06fdd032de385a2758254f4192d6e17ed40d44b, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"MismatchedIdentityRejections\\",{\\"label\\":\\"Mismatched Identity\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m7c1d407f17f8d2452a0bf87ac06fdd032de385a2758254f4192d6e17ed40d44b\\"}],[{\\"label\\":\\"Found License file\\",\\"expression\\":\\"FILL(m7084dfec3c5bab86694d7ae438460f471c174a94bc67c9c9738e3ab60246b661, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"FoundLicenseFile\\",{\\"label\\":\\"Found License file\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m7084dfec3c5bab86694d7ae438460f471c174a94bc67c9c9738e3ab60246b661\\"}]],\\"yAxis\\":{\\"left\\":{\\"label\\":\\"Count\\",\\"min\\":0,\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":47,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Dead Letters\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -687,7 +703,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":46,\\"properties\\":{\\"markdown\\":\\"# Orchestration\\\\n\\\\n[button:State Machine](/states/home#/statemachines/view/",
+              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":53,\\"properties\\":{\\"markdown\\":\\"# Orchestration\\\\n\\\\n[button:State Machine](/states/home#/statemachines/view/",
               Object {
                 "Ref": "ConstructHubOrchestration39161A46",
               },
@@ -714,7 +730,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubOrchestrationReprocessAllFF2F2455",
               },
-              ")\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":48,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"State Machine Executions\\",\\"region\\":\\"",
+              ")\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":55,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"State Machine Executions\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -746,7 +762,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubOrchestration39161A46",
               },
-              "\\",{\\"label\\":\\"Duration\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":48,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Dead Letter Queue\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Duration\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":55,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Dead Letter Queue\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -771,7 +787,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":54,\\"properties\\":{\\"markdown\\":\\"# Deny List\\\\n\\\\n[button:Deny List Object](/s3/object/",
+              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":61,\\"properties\\":{\\"markdown\\":\\"# Deny List\\\\n\\\\n[button:Deny List Object](/s3/object/",
               Object {
                 "Ref": "ConstructHubDenyListBucket1B3C2C2E",
               },
@@ -802,7 +818,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubDenyListPrunePruneQueueHandlerF7EB599B",
               },
-              "/log-events)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":56,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Deny List\\",\\"region\\":\\"",
+              "/log-events)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":63,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Deny List\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -813,7 +829,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              "\\",{\\"label\\":\\"Deleted Files\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":300}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":56,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Prune Function Health\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Deleted Files\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":300}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":63,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Prune Function Health\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -1696,7 +1712,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersbec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ecS3BucketE3CFE68F",
+            "Ref": "AssetParametersff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2S3BucketBC914BA2",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -1709,7 +1725,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersbec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ecS3VersionKey6D99058D",
+                          "Ref": "AssetParametersff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2S3VersionKey1681742D",
                         },
                       ],
                     },
@@ -1722,7 +1738,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersbec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ecS3VersionKey6D99058D",
+                          "Ref": "AssetParametersff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2S3VersionKey1681742D",
                         },
                       ],
                     },
@@ -2117,7 +2133,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersa7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100S3BucketA07EA20C",
+            "Ref": "AssetParameters9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4bS3BucketF0A4F598",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -2130,7 +2146,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersa7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100S3VersionKeyBF4D0B81",
+                          "Ref": "AssetParameters9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4bS3VersionKey5E4628BC",
                         },
                       ],
                     },
@@ -2143,7 +2159,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersa7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100S3VersionKeyBF4D0B81",
+                          "Ref": "AssetParameters9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4bS3VersionKey5E4628BC",
                         },
                       ],
                     },
@@ -2470,6 +2486,53 @@ Direct link to function: /lambda/home#/functions/",
                 },
               ],
             },
+            Object {
+              "Action": "sts:GetServiceBearerToken",
+              "Condition": Object {
+                "StringEquals": Object {
+                  "sts:AWSServiceName": "codeartifact.amazonaws.com",
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubOrchestrationDocGenjavaServiceRoleA6039136",
+                    "Arn",
+                  ],
+                },
+              },
+              "Resource": "*",
+            },
+            Object {
+              "Action": Array [
+                "codeartifact:GetAuthorizationToken",
+                "codeartifact:GetRepositoryEndpoint",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubOrchestrationDocGenjavaServiceRoleA6039136",
+                    "Arn",
+                  ],
+                },
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubCodeArtifactDomainFC30B796",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubCodeArtifact1188409E",
+                    "Arn",
+                  ],
+                },
+              ],
+            },
           ],
           "Version": "2012-10-17",
         },
@@ -2588,6 +2651,24 @@ Direct link to function: /lambda/home#/functions/",
                 "AWS": Object {
                   "Fn::GetAtt": Array [
                     "ConstructHubOrchestrationDocGentypescriptServiceRoleB56C2B19",
+                    "Arn",
+                  ],
+                },
+              },
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "ConstructHubCodeArtifact1188409E",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": "codeartifact:ReadFromRepository",
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubOrchestrationDocGenjavaServiceRoleA6039136",
                     "Arn",
                   ],
                 },
@@ -3146,6 +3227,138 @@ Direct link to function: /lambda/home#/functions/",
                         ],
                       },
                       "/data/*/docs-*-typescript.md.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:Abort*",
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-java.md",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:Abort*",
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-java.md",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:Abort*",
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-java.md.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:Abort*",
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-java.md.not-supported",
                     ],
                   ],
                 },
@@ -3993,7 +4206,18 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              "\\",\\"Payload.$\\":\\"$\\"}},\\"\\\\\\"Generate typescript docs\\\\\\" throttled\\":{\\"Type\\":\\"Pass\\",\\"Parameters\\":{\\"error.$\\":\\"$.Cause\\",\\"language\\":{\\"lang\\":\\"typescript\\"}},\\"End\\":true},\\"\\\\\\"Generate typescript docs\\\\\\" failure\\":{\\"Type\\":\\"Pass\\",\\"Parameters\\":{\\"error.$\\":\\"States.StringToJson($.Cause)\\",\\"language\\":{\\"lang\\":\\"typescript\\"}},\\"End\\":true},\\"\\\\\\"Generate typescript docs\\\\\\" fault\\":{\\"Type\\":\\"Pass\\",\\"Parameters\\":{\\"error.$\\":\\"$.Cause\\",\\"language\\":{\\"lang\\":\\"typescript\\"}},\\"End\\":true}}}]},\\"Any Success?\\":{\\"Type\\":\\"Choice\\",\\"Choices\\":[{\\"Or\\":[{\\"Variable\\":\\"$.DocGen[0].error\\",\\"IsPresent\\":false},{\\"Variable\\":\\"$.DocGen[1].error\\",\\"IsPresent\\":false}],\\"Next\\":\\"Add to catalog.json\\"}],\\"Default\\":\\"Any Failure?\\"},\\"Any Failure?\\":{\\"Type\\":\\"Choice\\",\\"Choices\\":[{\\"Or\\":[{\\"Variable\\":\\"$.DocGen[0].error\\",\\"IsPresent\\":true},{\\"Variable\\":\\"$.DocGen[1].error\\",\\"IsPresent\\":true}],\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Default\\":\\"Success\\"},\\"Add to catalog.json\\":{\\"Next\\":\\"Any Failure?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"Lambda.ServiceException\\",\\"Lambda.AWSLambdaException\\",\\"Lambda.SdkClientException\\"],\\"IntervalSeconds\\":2,\\"MaxAttempts\\":6,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":5}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"Next\\":\\"\\\\\\"Add to catalog.json\\\\\\" throttled\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"Next\\":\\"\\\\\\"Add to catalog.json\\\\\\" failure\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"Next\\":\\"\\\\\\"Add to catalog.json\\\\\\" fault\\"}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.catalogBuilderOutput\\",\\"ResultSelector\\":{\\"ETag.$\\":\\"$.Payload.ETag\\",\\"VersionId.$\\":\\"$.Payload.VersionId\\"},\\"Resource\\":\\"arn:",
+              "\\",\\"Payload.$\\":\\"$\\"}},\\"\\\\\\"Generate typescript docs\\\\\\" throttled\\":{\\"Type\\":\\"Pass\\",\\"Parameters\\":{\\"error.$\\":\\"$.Cause\\",\\"language\\":{\\"lang\\":\\"typescript\\"}},\\"End\\":true},\\"\\\\\\"Generate typescript docs\\\\\\" failure\\":{\\"Type\\":\\"Pass\\",\\"Parameters\\":{\\"error.$\\":\\"States.StringToJson($.Cause)\\",\\"language\\":{\\"lang\\":\\"typescript\\"}},\\"End\\":true},\\"\\\\\\"Generate typescript docs\\\\\\" fault\\":{\\"Type\\":\\"Pass\\",\\"Parameters\\":{\\"error.$\\":\\"$.Cause\\",\\"language\\":{\\"lang\\":\\"typescript\\"}},\\"End\\":true}}},{\\"StartAt\\":\\"Generate java docs\\",\\"States\\":{\\"Generate java docs\\":{\\"End\\":true,\\"Retry\\":[{\\"ErrorEquals\\":[\\"Lambda.ServiceException\\",\\"Lambda.AWSLambdaException\\",\\"Lambda.SdkClientException\\"],\\"IntervalSeconds\\":2,\\"MaxAttempts\\":6,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"IntervalSeconds\\":30}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"Next\\":\\"\\\\\\"Generate java docs\\\\\\" throttled\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"Next\\":\\"\\\\\\"Generate java docs\\\\\\" failure\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"Next\\":\\"\\\\\\"Generate java docs\\\\\\" fault\\"}],\\"Type\\":\\"Task\\",\\"OutputPath\\":\\"$.result\\",\\"ResultSelector\\":{\\"result\\":{\\"language\\":{\\"lang\\":\\"java\\"},\\"success.$\\":\\"$.Payload\\"}},\\"Resource\\":\\"arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":states:::lambda:invoke\\",\\"Parameters\\":{\\"FunctionName\\":\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ConstructHubOrchestrationDocGenjava0F6D30AF",
+                  "Arn",
+                ],
+              },
+              "\\",\\"Payload.$\\":\\"$\\"}},\\"\\\\\\"Generate java docs\\\\\\" throttled\\":{\\"Type\\":\\"Pass\\",\\"Parameters\\":{\\"error.$\\":\\"$.Cause\\",\\"language\\":{\\"lang\\":\\"java\\"}},\\"End\\":true},\\"\\\\\\"Generate java docs\\\\\\" failure\\":{\\"Type\\":\\"Pass\\",\\"Parameters\\":{\\"error.$\\":\\"States.StringToJson($.Cause)\\",\\"language\\":{\\"lang\\":\\"java\\"}},\\"End\\":true},\\"\\\\\\"Generate java docs\\\\\\" fault\\":{\\"Type\\":\\"Pass\\",\\"Parameters\\":{\\"error.$\\":\\"$.Cause\\",\\"language\\":{\\"lang\\":\\"java\\"}},\\"End\\":true}}}]},\\"Any Success?\\":{\\"Type\\":\\"Choice\\",\\"Choices\\":[{\\"Or\\":[{\\"Variable\\":\\"$.DocGen[0].error\\",\\"IsPresent\\":false},{\\"Variable\\":\\"$.DocGen[1].error\\",\\"IsPresent\\":false},{\\"Variable\\":\\"$.DocGen[2].error\\",\\"IsPresent\\":false}],\\"Next\\":\\"Add to catalog.json\\"}],\\"Default\\":\\"Any Failure?\\"},\\"Any Failure?\\":{\\"Type\\":\\"Choice\\",\\"Choices\\":[{\\"Or\\":[{\\"Variable\\":\\"$.DocGen[0].error\\",\\"IsPresent\\":true},{\\"Variable\\":\\"$.DocGen[1].error\\",\\"IsPresent\\":true},{\\"Variable\\":\\"$.DocGen[2].error\\",\\"IsPresent\\":true}],\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Default\\":\\"Success\\"},\\"Add to catalog.json\\":{\\"Next\\":\\"Any Failure?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"Lambda.ServiceException\\",\\"Lambda.AWSLambdaException\\",\\"Lambda.SdkClientException\\"],\\"IntervalSeconds\\":2,\\"MaxAttempts\\":6,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":5}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"Next\\":\\"\\\\\\"Add to catalog.json\\\\\\" throttled\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"Next\\":\\"\\\\\\"Add to catalog.json\\\\\\" failure\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"Next\\":\\"\\\\\\"Add to catalog.json\\\\\\" fault\\"}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.catalogBuilderOutput\\",\\"ResultSelector\\":{\\"ETag.$\\":\\"$.Payload.ETag\\",\\"VersionId.$\\":\\"$.Payload.VersionId\\"},\\"Resource\\":\\"arn:",
               Object {
                 "Ref": "AWS::Partition",
               },
@@ -4037,7 +4261,7 @@ Direct link to function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersdef5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9S3Bucket693007CE",
+            "Ref": "AssetParameterse0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813S3Bucket55321DF2",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -4050,7 +4274,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersdef5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9S3VersionKeyA7862DEC",
+                          "Ref": "AssetParameterse0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813S3VersionKey325A408D",
                         },
                       ],
                     },
@@ -4063,7 +4287,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersdef5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9S3VersionKeyA7862DEC",
+                          "Ref": "AssetParameterse0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813S3VersionKey325A408D",
                         },
                       ],
                     },
@@ -4356,15 +4580,15 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "ConstructHubOrchestrationDocGenpython77179663": Object {
+    "ConstructHubOrchestrationDocGenjava0F6D30AF": Object {
       "DependsOn": Array [
-        "ConstructHubOrchestrationDocGenpythonServiceRoleDefaultPolicy7A9DA724",
-        "ConstructHubOrchestrationDocGenpythonServiceRoleD16CBDB2",
+        "ConstructHubOrchestrationDocGenjavaServiceRoleDefaultPolicy8819DA50",
+        "ConstructHubOrchestrationDocGenjavaServiceRoleA6039136",
       ],
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7",
+            "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3Bucket38537BD6",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -4377,7 +4601,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35",
                         },
                       ],
                     },
@@ -4390,7 +4614,419 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            ],
+          },
+        },
+        "Description": "Creates java documentation from jsii-enabled npm packages",
+        "Environment": Object {
+          "Variables": Object {
+            "CODE_ARTIFACT_API_ENDPOINT": Object {
+              "Fn::Select": Array [
+                1,
+                Object {
+                  "Fn::Split": Array [
+                    ":",
+                    Object {
+                      "Fn::Select": Array [
+                        0,
+                        Object {
+                          "Fn::GetAtt": Array [
+                            "ConstructHubLambdaVPCCodeArtifactAPI0A2356B9",
+                            "DnsEntries",
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            "CODE_ARTIFACT_DOMAIN_NAME": Object {
+              "Fn::GetAtt": Array [
+                "ConstructHubCodeArtifact1188409E",
+                "DomainName",
+              ],
+            },
+            "CODE_ARTIFACT_DOMAIN_OWNER": Object {
+              "Fn::GetAtt": Array [
+                "ConstructHubCodeArtifact1188409E",
+                "DomainOwner",
+              ],
+            },
+            "CODE_ARTIFACT_REPOSITORY_ENDPOINT": Object {
+              "Fn::GetAtt": Array [
+                "ConstructHubCodeArtifactGetEndpoint9A458FEF",
+                "repositoryEndpoint",
+              ],
+            },
+            "HEADER_SPAN": "true",
+            "TARGET_LANGUAGE": "java",
+          },
+        },
+        "Handler": "index.handler",
+        "MemorySize": 10240,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "ConstructHubOrchestrationDocGenjavaServiceRoleA6039136",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+        "Timeout": 900,
+        "TracingConfig": Object {
+          "Mode": "PassThrough",
+        },
+        "VpcConfig": Object {
+          "SecurityGroupIds": Array [
+            Object {
+              "Fn::GetAtt": Array [
+                "ConstructHubOrchestrationDocGenjavaSecurityGroup72D0C513",
+                "GroupId",
+              ],
+            },
+          ],
+          "SubnetIds": Array [
+            Object {
+              "Ref": "ConstructHubLambdaVPCIsolatedSubnet1Subnet33EDE47B",
+            },
+            Object {
+              "Ref": "ConstructHubLambdaVPCIsolatedSubnet2Subnet825B4A7B",
+            },
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "ConstructHubOrchestrationDocGenjavaLogRetention55FBE552": Object {
+      "Properties": Object {
+        "LogGroupName": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "/aws/lambda/",
+              Object {
+                "Ref": "ConstructHubOrchestrationDocGenjava0F6D30AF",
+              },
+            ],
+          ],
+        },
+        "RetentionInDays": 3653,
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::LogRetention",
+    },
+    "ConstructHubOrchestrationDocGenjavaSecurityGroup72D0C513": Object {
+      "Properties": Object {
+        "GroupDescription": "Automatic security group for Lambda Function TestConstructHubOrchestrationDocGenjava7634BAF0",
+        "SecurityGroupEgress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound traffic by default",
+            "IpProtocol": "-1",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "ConstructHubLambdaVPCE85ABF51",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "ConstructHubOrchestrationDocGenjavaServiceRoleA6039136": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ConstructHubOrchestrationDocGenjavaServiceRoleDefaultPolicy8819DA50": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "xray:PutTraceSegments",
+                "xray:PutTelemetryRecords",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            Object {
+              "Action": "sts:GetServiceBearerToken",
+              "Condition": Object {
+                "StringEquals": Object {
+                  "sts:AWSServiceName": "codeartifact.amazonaws.com",
+                },
+              },
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            Object {
+              "Action": Array [
+                "codeartifact:GetAuthorizationToken",
+                "codeartifact:GetRepositoryEndpoint",
+                "codeartifact:ReadFromRepository",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubCodeArtifactDomainFC30B796",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubCodeArtifact1188409E",
+                    "Arn",
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/assembly.json",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-java.md",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-java.md",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-java.md.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-java.md.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ConstructHubOrchestrationDocGenjavaServiceRoleDefaultPolicy8819DA50",
+        "Roles": Array [
+          Object {
+            "Ref": "ConstructHubOrchestrationDocGenjavaServiceRoleA6039136",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ConstructHubOrchestrationDocGenpython77179663": Object {
+      "DependsOn": Array [
+        "ConstructHubOrchestrationDocGenpythonServiceRoleDefaultPolicy7A9DA724",
+        "ConstructHubOrchestrationDocGenpythonServiceRoleD16CBDB2",
+      ],
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3Bucket38537BD6",
+          },
+          "S3Key": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                Object {
+                  "Fn::Select": Array [
+                    0,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                Object {
+                  "Fn::Select": Array [
+                    1,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35",
                         },
                       ],
                     },
@@ -4776,7 +5412,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7",
+            "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3Bucket38537BD6",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -4789,7 +5425,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35",
                         },
                       ],
                     },
@@ -4802,7 +5438,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35",
                         },
                       ],
                     },
@@ -5378,7 +6014,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersb191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17S3Bucket60674A76",
+            "Ref": "AssetParameters68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513S3Bucket942ED5A2",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -5391,7 +6027,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersb191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17S3VersionKey724F7AFD",
+                          "Ref": "AssetParameters68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513S3VersionKeyF5E68355",
                         },
                       ],
                     },
@@ -5404,7 +6040,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersb191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17S3VersionKey724F7AFD",
+                          "Ref": "AssetParameters68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513S3VersionKeyF5E68355",
                         },
                       ],
                     },
@@ -5586,6 +6222,16 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
               "Resource": Object {
                 "Fn::GetAtt": Array [
                   "ConstructHubOrchestrationDocGentypescriptF9C30384",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "ConstructHubOrchestrationDocGenjava0F6D30AF",
                   "Arn",
                 ],
               },
@@ -7250,6 +7896,18 @@ Object {
     },
   },
   "Parameters": Object {
+    "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15ArtifactHash2AA5202D": Object {
+      "Description": "Artifact hash for asset \\"1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15\\"",
+      "Type": "String",
+    },
+    "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3Bucket38537BD6": Object {
+      "Description": "S3 bucket for asset \\"1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15\\"",
+      "Type": "String",
+    },
+    "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35": Object {
+      "Description": "S3 key for asset version \\"1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15\\"",
+      "Type": "String",
+    },
     "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49ArtifactHashA1145632": Object {
       "Description": "Artifact hash for asset \\"1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49\\"",
       "Type": "String",
@@ -7298,6 +7956,18 @@ Object {
       "Description": "S3 key for asset version \\"67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24\\"",
       "Type": "String",
     },
+    "AssetParameters68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513ArtifactHash02422EA3": Object {
+      "Description": "Artifact hash for asset \\"68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513\\"",
+      "Type": "String",
+    },
+    "AssetParameters68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513S3Bucket942ED5A2": Object {
+      "Description": "S3 bucket for asset \\"68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513\\"",
+      "Type": "String",
+    },
+    "AssetParameters68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513S3VersionKeyF5E68355": Object {
+      "Description": "S3 key for asset version \\"68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513\\"",
+      "Type": "String",
+    },
     "AssetParameters7ee6e37c4f89b09a6b3c50e513093daf23a858809daed5a6703095d14955c9b2ArtifactHash65BC41FC": Object {
       "Description": "Artifact hash for asset \\"7ee6e37c4f89b09a6b3c50e513093daf23a858809daed5a6703095d14955c9b2\\"",
       "Type": "String",
@@ -7322,18 +7992,6 @@ Object {
       "Description": "S3 key for asset version \\"8265ccdf680d2fc53b19193e2b93340a27f335cc3be02b673f0742d7700fd6ac\\"",
       "Type": "String",
     },
-    "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9ArtifactHash7A6CE4F0": Object {
-      "Description": "Artifact hash for asset \\"8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9\\"",
-      "Type": "String",
-    },
-    "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7": Object {
-      "Description": "S3 bucket for asset \\"8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9\\"",
-      "Type": "String",
-    },
-    "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9": Object {
-      "Description": "S3 key for asset version \\"8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9\\"",
-      "Type": "String",
-    },
     "AssetParameters8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064ArtifactHashEA963870": Object {
       "Description": "Artifact hash for asset \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
@@ -7346,40 +8004,16 @@ Object {
       "Description": "S3 key for asset version \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
     },
-    "AssetParametersa7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100ArtifactHashB98D2EC5": Object {
-      "Description": "Artifact hash for asset \\"a7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100\\"",
+    "AssetParameters9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4bArtifactHash9C520604": Object {
+      "Description": "Artifact hash for asset \\"9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4b\\"",
       "Type": "String",
     },
-    "AssetParametersa7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100S3BucketA07EA20C": Object {
-      "Description": "S3 bucket for asset \\"a7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100\\"",
+    "AssetParameters9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4bS3BucketF0A4F598": Object {
+      "Description": "S3 bucket for asset \\"9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4b\\"",
       "Type": "String",
     },
-    "AssetParametersa7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100S3VersionKeyBF4D0B81": Object {
-      "Description": "S3 key for asset version \\"a7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100\\"",
-      "Type": "String",
-    },
-    "AssetParametersb191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17ArtifactHash65E20850": Object {
-      "Description": "Artifact hash for asset \\"b191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17\\"",
-      "Type": "String",
-    },
-    "AssetParametersb191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17S3Bucket60674A76": Object {
-      "Description": "S3 bucket for asset \\"b191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17\\"",
-      "Type": "String",
-    },
-    "AssetParametersb191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17S3VersionKey724F7AFD": Object {
-      "Description": "S3 key for asset version \\"b191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17\\"",
-      "Type": "String",
-    },
-    "AssetParametersbec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ecArtifactHash04B28626": Object {
-      "Description": "Artifact hash for asset \\"bec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ec\\"",
-      "Type": "String",
-    },
-    "AssetParametersbec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ecS3BucketE3CFE68F": Object {
-      "Description": "S3 bucket for asset \\"bec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ec\\"",
-      "Type": "String",
-    },
-    "AssetParametersbec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ecS3VersionKey6D99058D": Object {
-      "Description": "S3 key for asset version \\"bec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ec\\"",
+    "AssetParameters9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4bS3VersionKey5E4628BC": Object {
+      "Description": "S3 key for asset version \\"9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4b\\"",
       "Type": "String",
     },
     "AssetParametersc24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cfArtifactHash85F58E48": Object {
@@ -7418,16 +8052,16 @@ Object {
       "Description": "S3 key for asset version \\"d5ce621914a7c3f15cf5d46823956ea431a98db7cf8d22b7af369eb6d01413c7\\"",
       "Type": "String",
     },
-    "AssetParametersdef5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9ArtifactHashB9B2536A": Object {
-      "Description": "Artifact hash for asset \\"def5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9\\"",
+    "AssetParameterse0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813ArtifactHashAC8102A5": Object {
+      "Description": "Artifact hash for asset \\"e0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813\\"",
       "Type": "String",
     },
-    "AssetParametersdef5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9S3Bucket693007CE": Object {
-      "Description": "S3 bucket for asset \\"def5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9\\"",
+    "AssetParameterse0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813S3Bucket55321DF2": Object {
+      "Description": "S3 bucket for asset \\"e0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813\\"",
       "Type": "String",
     },
-    "AssetParametersdef5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9S3VersionKeyA7862DEC": Object {
-      "Description": "S3 key for asset version \\"def5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9\\"",
+    "AssetParameterse0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813S3VersionKey325A408D": Object {
+      "Description": "S3 key for asset version \\"e0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813\\"",
       "Type": "String",
     },
     "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68ArtifactHashD9A515C3": Object {
@@ -7464,6 +8098,18 @@ Object {
     },
     "AssetParametersfab52dab596e8f8b4fc5a26e9882c7509290ba057320ed7864232c0f290b5750S3VersionKey79B2C284": Object {
       "Description": "S3 key for asset version \\"fab52dab596e8f8b4fc5a26e9882c7509290ba057320ed7864232c0f290b5750\\"",
+      "Type": "String",
+    },
+    "AssetParametersff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2ArtifactHash58196055": Object {
+      "Description": "Artifact hash for asset \\"ff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2\\"",
+      "Type": "String",
+    },
+    "AssetParametersff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2S3BucketBC914BA2": Object {
+      "Description": "S3 bucket for asset \\"ff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2\\"",
+      "Type": "String",
+    },
+    "AssetParametersff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2S3VersionKey1681742D": Object {
+      "Description": "S3 key for asset version \\"ff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2\\"",
       "Type": "String",
     },
   },
@@ -7791,7 +8437,23 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"stacked\\":true,\\"metrics\\":[[\\"ConstructHub/Inventory\\",\\"SupportedSubmoduleCount\\",\\"Language\\",\\"python\\",{\\"color\\":\\"#2ca02c\\",\\"label\\":\\"Available\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"UnsupportedSubmoduleCount\\",\\"Language\\",\\"python\\",{\\"color\\":\\"#9467bd\\",\\"label\\":\\"Unsupported\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"MissingSubmoduleCount\\",\\"Language\\",\\"python\\",{\\"color\\":\\"#d62728\\",\\"label\\":\\"Missing\\",\\"stat\\":\\"Maximum\\"}]],\\"yAxis\\":{\\"left\\":{\\"showUnits\\":false}}}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":24,\\"properties\\":{\\"markdown\\":\\"# Test/ConstructHub/Sources/NpmJs\\\\n\\\\n[button:primary:NpmJs Follower](/lambda/home#/functions/",
+              "\\",\\"stacked\\":true,\\"metrics\\":[[\\"ConstructHub/Inventory\\",\\"SupportedSubmoduleCount\\",\\"Language\\",\\"python\\",{\\"color\\":\\"#2ca02c\\",\\"label\\":\\"Available\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"UnsupportedSubmoduleCount\\",\\"Language\\",\\"python\\",{\\"color\\":\\"#9467bd\\",\\"label\\":\\"Unsupported\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"MissingSubmoduleCount\\",\\"Language\\",\\"python\\",{\\"color\\":\\"#d62728\\",\\"label\\":\\"Missing\\",\\"stat\\":\\"Maximum\\"}]],\\"yAxis\\":{\\"left\\":{\\"showUnits\\":false}}}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":24,\\"properties\\":{\\"markdown\\":\\"## Language: java\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":6,\\"x\\":0,\\"y\\":25,\\"properties\\":{\\"view\\":\\"pie\\",\\"title\\":\\"Package Versions\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"ConstructHub/Inventory\\",\\"SupportedPackageVersionCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#2ca02c\\",\\"label\\":\\"Available\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"UnsupportedPackageVersionCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#9467bd\\",\\"label\\":\\"Unsupported\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"MissingPackageVersionCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#d62728\\",\\"label\\":\\"Missing\\",\\"stat\\":\\"Maximum\\"}]],\\"yAxis\\":{\\"left\\":{\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":6,\\"x\\":6,\\"y\\":25,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Package Versions\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"stacked\\":true,\\"metrics\\":[[\\"ConstructHub/Inventory\\",\\"SupportedPackageVersionCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#2ca02c\\",\\"label\\":\\"Available\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"UnsupportedPackageVersionCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#9467bd\\",\\"label\\":\\"Unsupported\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"MissingPackageVersionCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#d62728\\",\\"label\\":\\"Missing\\",\\"stat\\":\\"Maximum\\"}]],\\"yAxis\\":{\\"left\\":{\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":6,\\"x\\":12,\\"y\\":25,\\"properties\\":{\\"view\\":\\"pie\\",\\"title\\":\\"Package Version Submodules\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"ConstructHub/Inventory\\",\\"SupportedSubmoduleCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#2ca02c\\",\\"label\\":\\"Available\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"UnsupportedSubmoduleCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#9467bd\\",\\"label\\":\\"Unsupported\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"MissingSubmoduleCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#d62728\\",\\"label\\":\\"Missing\\",\\"stat\\":\\"Maximum\\"}]],\\"yAxis\\":{\\"left\\":{\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":6,\\"x\\":18,\\"y\\":25,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Package Version Submodules\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"stacked\\":true,\\"metrics\\":[[\\"ConstructHub/Inventory\\",\\"SupportedSubmoduleCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#2ca02c\\",\\"label\\":\\"Available\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"UnsupportedSubmoduleCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#9467bd\\",\\"label\\":\\"Unsupported\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"MissingSubmoduleCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#d62728\\",\\"label\\":\\"Missing\\",\\"stat\\":\\"Maximum\\"}]],\\"yAxis\\":{\\"left\\":{\\"showUnits\\":false}}}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":31,\\"properties\\":{\\"markdown\\":\\"# Test/ConstructHub/Sources/NpmJs\\\\n\\\\n[button:primary:NpmJs Follower](/lambda/home#/functions/",
               Object {
                 "Ref": "ConstructHubSourcesNpmJs15A77D2D",
               },
@@ -7799,7 +8461,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubSourcesNpmJsStagingBucketB286F0E6",
               },
-              "?prefix=couchdb-last-transaction-id.2)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":26,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Function Health\\",\\"region\\":\\"",
+              "?prefix=couchdb-last-transaction-id.2)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":33,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Function Health\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -7811,11 +8473,11 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubSourcesNpmJs15A77D2D",
               },
-              "\\",{\\"label\\":\\"Errors\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55\\"}],[\\"ConstructHub/PackageSource/NpmJs/Follower\\",\\"RemainingTime\\",{\\"label\\":\\"Remaining Time\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":900}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":26,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"CouchDB Follower\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Errors\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55\\"}],[\\"ConstructHub/PackageSource/NpmJs/Follower\\",\\"RemainingTime\\",{\\"label\\":\\"Remaining Time\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":900}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":33,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"CouchDB Follower\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[\\"ConstructHub/PackageSource/NpmJs/Follower\\",\\"ChangeCount\\",{\\"label\\":\\"Change Count\\",\\"stat\\":\\"Sum\\"}],[\\"ConstructHub/PackageSource/NpmJs/Follower\\",\\"UnprocessableEntity\\",{\\"label\\":\\"Unprocessable\\",\\"stat\\":\\"Sum\\"}],[{\\"label\\":\\"Lag to npmjs.com\\",\\"expression\\":\\"FILL(m4d6c513faac55be4bca785e8587a9a145b65f5fe675318c9c5c52f3ada197b7b, REPEAT)\\",\\"yAxis\\":\\"right\\"}],[\\"ConstructHub/PackageSource/NpmJs/Follower\\",\\"NpmJsChangeAge\\",{\\"label\\":\\"Lag to npmjs.com\\",\\"stat\\":\\"Minimum\\",\\"visible\\":false,\\"id\\":\\"m4d6c513faac55be4bca785e8587a9a145b65f5fe675318c9c5c52f3ada197b7b\\"}],[{\\"label\\":\\"Package Version Age\\",\\"expression\\":\\"FILL(mec485aa83505431ed7a356970082cd4815c310504ff176dd3eeb241ae7bbf0c4, REPEAT)\\",\\"yAxis\\":\\"right\\"}],[\\"ConstructHub/PackageSource/NpmJs/Follower\\",\\"PackageVersionAge\\",{\\"label\\":\\"Package Version Age\\",\\"stat\\":\\"Maximum\\",\\"visible\\":false,\\"id\\":\\"mec485aa83505431ed7a356970082cd4815c310504ff176dd3eeb241ae7bbf0c4\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"label\\":\\"Milliseconds\\",\\"min\\":0,\\"showUnits\\":false}},\\"period\\":900}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":32,\\"properties\\":{\\"markdown\\":\\"# Ingestion Function\\\\n\\\\n[button:Ingestion Function](/lambda/home#/functions/",
+              "\\",\\"metrics\\":[[\\"ConstructHub/PackageSource/NpmJs/Follower\\",\\"ChangeCount\\",{\\"label\\":\\"Change Count\\",\\"stat\\":\\"Sum\\"}],[\\"ConstructHub/PackageSource/NpmJs/Follower\\",\\"UnprocessableEntity\\",{\\"label\\":\\"Unprocessable\\",\\"stat\\":\\"Sum\\"}],[{\\"label\\":\\"Lag to npmjs.com\\",\\"expression\\":\\"FILL(m4d6c513faac55be4bca785e8587a9a145b65f5fe675318c9c5c52f3ada197b7b, REPEAT)\\",\\"yAxis\\":\\"right\\"}],[\\"ConstructHub/PackageSource/NpmJs/Follower\\",\\"NpmJsChangeAge\\",{\\"label\\":\\"Lag to npmjs.com\\",\\"stat\\":\\"Minimum\\",\\"visible\\":false,\\"id\\":\\"m4d6c513faac55be4bca785e8587a9a145b65f5fe675318c9c5c52f3ada197b7b\\"}],[{\\"label\\":\\"Package Version Age\\",\\"expression\\":\\"FILL(mec485aa83505431ed7a356970082cd4815c310504ff176dd3eeb241ae7bbf0c4, REPEAT)\\",\\"yAxis\\":\\"right\\"}],[\\"ConstructHub/PackageSource/NpmJs/Follower\\",\\"PackageVersionAge\\",{\\"label\\":\\"Package Version Age\\",\\"stat\\":\\"Maximum\\",\\"visible\\":false,\\"id\\":\\"mec485aa83505431ed7a356970082cd4815c310504ff176dd3eeb241ae7bbf0c4\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"label\\":\\"Milliseconds\\",\\"min\\":0,\\"showUnits\\":false}},\\"period\\":900}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":39,\\"properties\\":{\\"markdown\\":\\"# Ingestion Function\\\\n\\\\n[button:Ingestion Function](/lambda/home#/functions/",
               Object {
                 "Ref": "ConstructHubIngestion407909CE",
               },
@@ -7838,7 +8500,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              ")\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":34,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Function Health\\",\\"region\\":\\"",
+              ")\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":41,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Function Health\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -7850,7 +8512,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubIngestion407909CE",
               },
-              "\\",{\\"label\\":\\"Errors\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":34,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Input Queue\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Errors\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":41,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Input Queue\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -7875,11 +8537,11 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"period\\":60,\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ffa500\\",\\"label\\":\\"10 Minutes\\",\\"value\\":600,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":40,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Input Quality\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"period\\":60,\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ffa500\\",\\"label\\":\\"10 Minutes\\",\\"value\\":600,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":47,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Input Quality\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"stacked\\":true,\\"metrics\\":[[{\\"label\\":\\"Invalid Assemblies\\",\\"expression\\":\\"FILL(m0c5f10aa73687a21aa44b8985d19311246bca6c2cd1b2256b9f3e78c71e94fa3, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"InvalidAssembly\\",{\\"label\\":\\"Invalid Assemblies\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m0c5f10aa73687a21aa44b8985d19311246bca6c2cd1b2256b9f3e78c71e94fa3\\"}],[{\\"label\\":\\"Invalid Tarball\\",\\"expression\\":\\"FILL(m3a39d9b0bf974255f27dc95e44c8574bdfce2b97e49a7504346a77c5c9f6a3e1, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"InvalidTarball\\",{\\"label\\":\\"Invalid Tarball\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3a39d9b0bf974255f27dc95e44c8574bdfce2b97e49a7504346a77c5c9f6a3e1\\"}],[{\\"label\\":\\"Ineligible License\\",\\"expression\\":\\"FILL(me19ae9c3f20ae715e3462f9402684a3817282218f36e69494a60bc251e3435a6, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"IneligibleLicense\\",{\\"label\\":\\"Ineligible License\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"me19ae9c3f20ae715e3462f9402684a3817282218f36e69494a60bc251e3435a6\\"}],[{\\"label\\":\\"Mismatched Identity\\",\\"expression\\":\\"FILL(m7c1d407f17f8d2452a0bf87ac06fdd032de385a2758254f4192d6e17ed40d44b, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"MismatchedIdentityRejections\\",{\\"label\\":\\"Mismatched Identity\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m7c1d407f17f8d2452a0bf87ac06fdd032de385a2758254f4192d6e17ed40d44b\\"}],[{\\"label\\":\\"Found License file\\",\\"expression\\":\\"FILL(m7084dfec3c5bab86694d7ae438460f471c174a94bc67c9c9738e3ab60246b661, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"FoundLicenseFile\\",{\\"label\\":\\"Found License file\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m7084dfec3c5bab86694d7ae438460f471c174a94bc67c9c9738e3ab60246b661\\"}]],\\"yAxis\\":{\\"left\\":{\\"label\\":\\"Count\\",\\"min\\":0,\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":40,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Dead Letters\\",\\"region\\":\\"",
+              "\\",\\"stacked\\":true,\\"metrics\\":[[{\\"label\\":\\"Invalid Assemblies\\",\\"expression\\":\\"FILL(m0c5f10aa73687a21aa44b8985d19311246bca6c2cd1b2256b9f3e78c71e94fa3, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"InvalidAssembly\\",{\\"label\\":\\"Invalid Assemblies\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m0c5f10aa73687a21aa44b8985d19311246bca6c2cd1b2256b9f3e78c71e94fa3\\"}],[{\\"label\\":\\"Invalid Tarball\\",\\"expression\\":\\"FILL(m3a39d9b0bf974255f27dc95e44c8574bdfce2b97e49a7504346a77c5c9f6a3e1, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"InvalidTarball\\",{\\"label\\":\\"Invalid Tarball\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3a39d9b0bf974255f27dc95e44c8574bdfce2b97e49a7504346a77c5c9f6a3e1\\"}],[{\\"label\\":\\"Ineligible License\\",\\"expression\\":\\"FILL(me19ae9c3f20ae715e3462f9402684a3817282218f36e69494a60bc251e3435a6, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"IneligibleLicense\\",{\\"label\\":\\"Ineligible License\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"me19ae9c3f20ae715e3462f9402684a3817282218f36e69494a60bc251e3435a6\\"}],[{\\"label\\":\\"Mismatched Identity\\",\\"expression\\":\\"FILL(m7c1d407f17f8d2452a0bf87ac06fdd032de385a2758254f4192d6e17ed40d44b, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"MismatchedIdentityRejections\\",{\\"label\\":\\"Mismatched Identity\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m7c1d407f17f8d2452a0bf87ac06fdd032de385a2758254f4192d6e17ed40d44b\\"}],[{\\"label\\":\\"Found License file\\",\\"expression\\":\\"FILL(m7084dfec3c5bab86694d7ae438460f471c174a94bc67c9c9738e3ab60246b661, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"FoundLicenseFile\\",{\\"label\\":\\"Found License file\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m7084dfec3c5bab86694d7ae438460f471c174a94bc67c9c9738e3ab60246b661\\"}]],\\"yAxis\\":{\\"left\\":{\\"label\\":\\"Count\\",\\"min\\":0,\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":47,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Dead Letters\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -7904,7 +8566,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":46,\\"properties\\":{\\"markdown\\":\\"# Orchestration\\\\n\\\\n[button:State Machine](/states/home#/statemachines/view/",
+              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":53,\\"properties\\":{\\"markdown\\":\\"# Orchestration\\\\n\\\\n[button:State Machine](/states/home#/statemachines/view/",
               Object {
                 "Ref": "ConstructHubOrchestration39161A46",
               },
@@ -7931,7 +8593,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubOrchestrationReprocessAllFF2F2455",
               },
-              ")\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":48,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"State Machine Executions\\",\\"region\\":\\"",
+              ")\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":55,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"State Machine Executions\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -7963,7 +8625,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubOrchestration39161A46",
               },
-              "\\",{\\"label\\":\\"Duration\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":48,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Dead Letter Queue\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Duration\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":55,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Dead Letter Queue\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -7988,7 +8650,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":54,\\"properties\\":{\\"markdown\\":\\"# Deny List\\\\n\\\\n[button:Deny List Object](/s3/object/",
+              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":61,\\"properties\\":{\\"markdown\\":\\"# Deny List\\\\n\\\\n[button:Deny List Object](/s3/object/",
               Object {
                 "Ref": "ConstructHubDenyListBucket1B3C2C2E",
               },
@@ -8019,7 +8681,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubDenyListPrunePruneQueueHandlerF7EB599B",
               },
-              "/log-events)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":56,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Deny List\\",\\"region\\":\\"",
+              "/log-events)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":63,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Deny List\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -8030,7 +8692,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              "\\",{\\"label\\":\\"Deleted Files\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":300}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":56,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Prune Function Health\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Deleted Files\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":300}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":63,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Prune Function Health\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -8920,7 +9582,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersbec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ecS3BucketE3CFE68F",
+            "Ref": "AssetParametersff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2S3BucketBC914BA2",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -8933,7 +9595,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersbec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ecS3VersionKey6D99058D",
+                          "Ref": "AssetParametersff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2S3VersionKey1681742D",
                         },
                       ],
                     },
@@ -8946,7 +9608,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersbec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ecS3VersionKey6D99058D",
+                          "Ref": "AssetParametersff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2S3VersionKey1681742D",
                         },
                       ],
                     },
@@ -9341,7 +10003,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersa7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100S3BucketA07EA20C",
+            "Ref": "AssetParameters9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4bS3BucketF0A4F598",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -9354,7 +10016,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersa7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100S3VersionKeyBF4D0B81",
+                          "Ref": "AssetParameters9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4bS3VersionKey5E4628BC",
                         },
                       ],
                     },
@@ -9367,7 +10029,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersa7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100S3VersionKeyBF4D0B81",
+                          "Ref": "AssetParameters9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4bS3VersionKey5E4628BC",
                         },
                       ],
                     },
@@ -9722,6 +10384,67 @@ Direct link to function: /lambda/home#/functions/",
                 },
               ],
             },
+            Object {
+              "Action": "sts:GetServiceBearerToken",
+              "Condition": Object {
+                "StringEquals": Object {
+                  "sts:AWSServiceName": "codeartifact.amazonaws.com",
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubOrchestrationDocGenjavaServiceRoleA6039136",
+                    "Arn",
+                  ],
+                },
+              },
+              "Resource": "*",
+            },
+            Object {
+              "Action": Array [
+                "codeartifact:GetAuthorizationToken",
+                "codeartifact:GetRepositoryEndpoint",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubOrchestrationDocGenjavaServiceRoleA6039136",
+                    "Arn",
+                  ],
+                },
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":codeartifact:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":domain/existing-domain-name",
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubCodeArtifact1188409E",
+                    "Arn",
+                  ],
+                },
+              ],
+            },
           ],
           "Version": "2012-10-17",
         },
@@ -9840,6 +10563,24 @@ Direct link to function: /lambda/home#/functions/",
                 "AWS": Object {
                   "Fn::GetAtt": Array [
                     "ConstructHubOrchestrationDocGentypescriptServiceRoleB56C2B19",
+                    "Arn",
+                  ],
+                },
+              },
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "ConstructHubCodeArtifact1188409E",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": "codeartifact:ReadFromRepository",
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubOrchestrationDocGenjavaServiceRoleA6039136",
                     "Arn",
                   ],
                 },
@@ -10398,6 +11139,138 @@ Direct link to function: /lambda/home#/functions/",
                         ],
                       },
                       "/data/*/docs-*-typescript.md.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:Abort*",
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-java.md",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:Abort*",
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-java.md",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:Abort*",
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-java.md.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:Abort*",
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-java.md.not-supported",
                     ],
                   ],
                 },
@@ -11245,7 +12118,18 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              "\\",\\"Payload.$\\":\\"$\\"}},\\"\\\\\\"Generate typescript docs\\\\\\" throttled\\":{\\"Type\\":\\"Pass\\",\\"Parameters\\":{\\"error.$\\":\\"$.Cause\\",\\"language\\":{\\"lang\\":\\"typescript\\"}},\\"End\\":true},\\"\\\\\\"Generate typescript docs\\\\\\" failure\\":{\\"Type\\":\\"Pass\\",\\"Parameters\\":{\\"error.$\\":\\"States.StringToJson($.Cause)\\",\\"language\\":{\\"lang\\":\\"typescript\\"}},\\"End\\":true},\\"\\\\\\"Generate typescript docs\\\\\\" fault\\":{\\"Type\\":\\"Pass\\",\\"Parameters\\":{\\"error.$\\":\\"$.Cause\\",\\"language\\":{\\"lang\\":\\"typescript\\"}},\\"End\\":true}}}]},\\"Any Success?\\":{\\"Type\\":\\"Choice\\",\\"Choices\\":[{\\"Or\\":[{\\"Variable\\":\\"$.DocGen[0].error\\",\\"IsPresent\\":false},{\\"Variable\\":\\"$.DocGen[1].error\\",\\"IsPresent\\":false}],\\"Next\\":\\"Add to catalog.json\\"}],\\"Default\\":\\"Any Failure?\\"},\\"Any Failure?\\":{\\"Type\\":\\"Choice\\",\\"Choices\\":[{\\"Or\\":[{\\"Variable\\":\\"$.DocGen[0].error\\",\\"IsPresent\\":true},{\\"Variable\\":\\"$.DocGen[1].error\\",\\"IsPresent\\":true}],\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Default\\":\\"Success\\"},\\"Add to catalog.json\\":{\\"Next\\":\\"Any Failure?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"Lambda.ServiceException\\",\\"Lambda.AWSLambdaException\\",\\"Lambda.SdkClientException\\"],\\"IntervalSeconds\\":2,\\"MaxAttempts\\":6,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":5}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"Next\\":\\"\\\\\\"Add to catalog.json\\\\\\" throttled\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"Next\\":\\"\\\\\\"Add to catalog.json\\\\\\" failure\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"Next\\":\\"\\\\\\"Add to catalog.json\\\\\\" fault\\"}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.catalogBuilderOutput\\",\\"ResultSelector\\":{\\"ETag.$\\":\\"$.Payload.ETag\\",\\"VersionId.$\\":\\"$.Payload.VersionId\\"},\\"Resource\\":\\"arn:",
+              "\\",\\"Payload.$\\":\\"$\\"}},\\"\\\\\\"Generate typescript docs\\\\\\" throttled\\":{\\"Type\\":\\"Pass\\",\\"Parameters\\":{\\"error.$\\":\\"$.Cause\\",\\"language\\":{\\"lang\\":\\"typescript\\"}},\\"End\\":true},\\"\\\\\\"Generate typescript docs\\\\\\" failure\\":{\\"Type\\":\\"Pass\\",\\"Parameters\\":{\\"error.$\\":\\"States.StringToJson($.Cause)\\",\\"language\\":{\\"lang\\":\\"typescript\\"}},\\"End\\":true},\\"\\\\\\"Generate typescript docs\\\\\\" fault\\":{\\"Type\\":\\"Pass\\",\\"Parameters\\":{\\"error.$\\":\\"$.Cause\\",\\"language\\":{\\"lang\\":\\"typescript\\"}},\\"End\\":true}}},{\\"StartAt\\":\\"Generate java docs\\",\\"States\\":{\\"Generate java docs\\":{\\"End\\":true,\\"Retry\\":[{\\"ErrorEquals\\":[\\"Lambda.ServiceException\\",\\"Lambda.AWSLambdaException\\",\\"Lambda.SdkClientException\\"],\\"IntervalSeconds\\":2,\\"MaxAttempts\\":6,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"IntervalSeconds\\":30}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"Next\\":\\"\\\\\\"Generate java docs\\\\\\" throttled\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"Next\\":\\"\\\\\\"Generate java docs\\\\\\" failure\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"Next\\":\\"\\\\\\"Generate java docs\\\\\\" fault\\"}],\\"Type\\":\\"Task\\",\\"OutputPath\\":\\"$.result\\",\\"ResultSelector\\":{\\"result\\":{\\"language\\":{\\"lang\\":\\"java\\"},\\"success.$\\":\\"$.Payload\\"}},\\"Resource\\":\\"arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":states:::lambda:invoke\\",\\"Parameters\\":{\\"FunctionName\\":\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ConstructHubOrchestrationDocGenjava0F6D30AF",
+                  "Arn",
+                ],
+              },
+              "\\",\\"Payload.$\\":\\"$\\"}},\\"\\\\\\"Generate java docs\\\\\\" throttled\\":{\\"Type\\":\\"Pass\\",\\"Parameters\\":{\\"error.$\\":\\"$.Cause\\",\\"language\\":{\\"lang\\":\\"java\\"}},\\"End\\":true},\\"\\\\\\"Generate java docs\\\\\\" failure\\":{\\"Type\\":\\"Pass\\",\\"Parameters\\":{\\"error.$\\":\\"States.StringToJson($.Cause)\\",\\"language\\":{\\"lang\\":\\"java\\"}},\\"End\\":true},\\"\\\\\\"Generate java docs\\\\\\" fault\\":{\\"Type\\":\\"Pass\\",\\"Parameters\\":{\\"error.$\\":\\"$.Cause\\",\\"language\\":{\\"lang\\":\\"java\\"}},\\"End\\":true}}}]},\\"Any Success?\\":{\\"Type\\":\\"Choice\\",\\"Choices\\":[{\\"Or\\":[{\\"Variable\\":\\"$.DocGen[0].error\\",\\"IsPresent\\":false},{\\"Variable\\":\\"$.DocGen[1].error\\",\\"IsPresent\\":false},{\\"Variable\\":\\"$.DocGen[2].error\\",\\"IsPresent\\":false}],\\"Next\\":\\"Add to catalog.json\\"}],\\"Default\\":\\"Any Failure?\\"},\\"Any Failure?\\":{\\"Type\\":\\"Choice\\",\\"Choices\\":[{\\"Or\\":[{\\"Variable\\":\\"$.DocGen[0].error\\",\\"IsPresent\\":true},{\\"Variable\\":\\"$.DocGen[1].error\\",\\"IsPresent\\":true},{\\"Variable\\":\\"$.DocGen[2].error\\",\\"IsPresent\\":true}],\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Default\\":\\"Success\\"},\\"Add to catalog.json\\":{\\"Next\\":\\"Any Failure?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"Lambda.ServiceException\\",\\"Lambda.AWSLambdaException\\",\\"Lambda.SdkClientException\\"],\\"IntervalSeconds\\":2,\\"MaxAttempts\\":6,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":5}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"Next\\":\\"\\\\\\"Add to catalog.json\\\\\\" throttled\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"Next\\":\\"\\\\\\"Add to catalog.json\\\\\\" failure\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"Next\\":\\"\\\\\\"Add to catalog.json\\\\\\" fault\\"}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.catalogBuilderOutput\\",\\"ResultSelector\\":{\\"ETag.$\\":\\"$.Payload.ETag\\",\\"VersionId.$\\":\\"$.Payload.VersionId\\"},\\"Resource\\":\\"arn:",
               Object {
                 "Ref": "AWS::Partition",
               },
@@ -11289,7 +12173,7 @@ Direct link to function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersdef5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9S3Bucket693007CE",
+            "Ref": "AssetParameterse0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813S3Bucket55321DF2",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -11302,7 +12186,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersdef5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9S3VersionKeyA7862DEC",
+                          "Ref": "AssetParameterse0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813S3VersionKey325A408D",
                         },
                       ],
                     },
@@ -11315,7 +12199,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersdef5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9S3VersionKeyA7862DEC",
+                          "Ref": "AssetParameterse0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813S3VersionKey325A408D",
                         },
                       ],
                     },
@@ -11608,15 +12492,15 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "ConstructHubOrchestrationDocGenpython77179663": Object {
+    "ConstructHubOrchestrationDocGenjava0F6D30AF": Object {
       "DependsOn": Array [
-        "ConstructHubOrchestrationDocGenpythonServiceRoleDefaultPolicy7A9DA724",
-        "ConstructHubOrchestrationDocGenpythonServiceRoleD16CBDB2",
+        "ConstructHubOrchestrationDocGenjavaServiceRoleDefaultPolicy8819DA50",
+        "ConstructHubOrchestrationDocGenjavaServiceRoleA6039136",
       ],
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7",
+            "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3Bucket38537BD6",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -11629,7 +12513,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35",
                         },
                       ],
                     },
@@ -11642,7 +12526,433 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            ],
+          },
+        },
+        "Description": "Creates java documentation from jsii-enabled npm packages",
+        "Environment": Object {
+          "Variables": Object {
+            "CODE_ARTIFACT_API_ENDPOINT": Object {
+              "Fn::Select": Array [
+                1,
+                Object {
+                  "Fn::Split": Array [
+                    ":",
+                    Object {
+                      "Fn::Select": Array [
+                        0,
+                        Object {
+                          "Fn::GetAtt": Array [
+                            "ConstructHubLambdaVPCCodeArtifactAPI0A2356B9",
+                            "DnsEntries",
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            "CODE_ARTIFACT_DOMAIN_NAME": Object {
+              "Fn::GetAtt": Array [
+                "ConstructHubCodeArtifact1188409E",
+                "DomainName",
+              ],
+            },
+            "CODE_ARTIFACT_DOMAIN_OWNER": Object {
+              "Fn::GetAtt": Array [
+                "ConstructHubCodeArtifact1188409E",
+                "DomainOwner",
+              ],
+            },
+            "CODE_ARTIFACT_REPOSITORY_ENDPOINT": Object {
+              "Fn::GetAtt": Array [
+                "ConstructHubCodeArtifactGetEndpoint9A458FEF",
+                "repositoryEndpoint",
+              ],
+            },
+            "HEADER_SPAN": "true",
+            "TARGET_LANGUAGE": "java",
+          },
+        },
+        "Handler": "index.handler",
+        "MemorySize": 10240,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "ConstructHubOrchestrationDocGenjavaServiceRoleA6039136",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+        "Timeout": 900,
+        "TracingConfig": Object {
+          "Mode": "PassThrough",
+        },
+        "VpcConfig": Object {
+          "SecurityGroupIds": Array [
+            Object {
+              "Fn::GetAtt": Array [
+                "ConstructHubOrchestrationDocGenjavaSecurityGroup72D0C513",
+                "GroupId",
+              ],
+            },
+          ],
+          "SubnetIds": Array [
+            Object {
+              "Ref": "ConstructHubLambdaVPCIsolatedSubnet1Subnet33EDE47B",
+            },
+            Object {
+              "Ref": "ConstructHubLambdaVPCIsolatedSubnet2Subnet825B4A7B",
+            },
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "ConstructHubOrchestrationDocGenjavaLogRetention55FBE552": Object {
+      "Properties": Object {
+        "LogGroupName": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "/aws/lambda/",
+              Object {
+                "Ref": "ConstructHubOrchestrationDocGenjava0F6D30AF",
+              },
+            ],
+          ],
+        },
+        "RetentionInDays": 3653,
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::LogRetention",
+    },
+    "ConstructHubOrchestrationDocGenjavaSecurityGroup72D0C513": Object {
+      "Properties": Object {
+        "GroupDescription": "Automatic security group for Lambda Function TestConstructHubOrchestrationDocGenjava7634BAF0",
+        "SecurityGroupEgress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound traffic by default",
+            "IpProtocol": "-1",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "ConstructHubLambdaVPCE85ABF51",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "ConstructHubOrchestrationDocGenjavaServiceRoleA6039136": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ConstructHubOrchestrationDocGenjavaServiceRoleDefaultPolicy8819DA50": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "xray:PutTraceSegments",
+                "xray:PutTelemetryRecords",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            Object {
+              "Action": "sts:GetServiceBearerToken",
+              "Condition": Object {
+                "StringEquals": Object {
+                  "sts:AWSServiceName": "codeartifact.amazonaws.com",
+                },
+              },
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            Object {
+              "Action": Array [
+                "codeartifact:GetAuthorizationToken",
+                "codeartifact:GetRepositoryEndpoint",
+                "codeartifact:ReadFromRepository",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":codeartifact:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":domain/existing-domain-name",
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubCodeArtifact1188409E",
+                    "Arn",
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/assembly.json",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-java.md",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-java.md",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-java.md.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-java.md.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ConstructHubOrchestrationDocGenjavaServiceRoleDefaultPolicy8819DA50",
+        "Roles": Array [
+          Object {
+            "Ref": "ConstructHubOrchestrationDocGenjavaServiceRoleA6039136",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ConstructHubOrchestrationDocGenpython77179663": Object {
+      "DependsOn": Array [
+        "ConstructHubOrchestrationDocGenpythonServiceRoleDefaultPolicy7A9DA724",
+        "ConstructHubOrchestrationDocGenpythonServiceRoleD16CBDB2",
+      ],
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3Bucket38537BD6",
+          },
+          "S3Key": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                Object {
+                  "Fn::Select": Array [
+                    0,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                Object {
+                  "Fn::Select": Array [
+                    1,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35",
                         },
                       ],
                     },
@@ -12042,7 +13352,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7",
+            "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3Bucket38537BD6",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -12055,7 +13365,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35",
                         },
                       ],
                     },
@@ -12068,7 +13378,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35",
                         },
                       ],
                     },
@@ -12658,7 +13968,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersb191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17S3Bucket60674A76",
+            "Ref": "AssetParameters68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513S3Bucket942ED5A2",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -12671,7 +13981,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersb191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17S3VersionKey724F7AFD",
+                          "Ref": "AssetParameters68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513S3VersionKeyF5E68355",
                         },
                       ],
                     },
@@ -12684,7 +13994,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersb191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17S3VersionKey724F7AFD",
+                          "Ref": "AssetParameters68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513S3VersionKeyF5E68355",
                         },
                       ],
                     },
@@ -12866,6 +14176,16 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
               "Resource": Object {
                 "Fn::GetAtt": Array [
                   "ConstructHubOrchestrationDocGentypescriptF9C30384",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "ConstructHubOrchestrationDocGenjava0F6D30AF",
                   "Arn",
                 ],
               },
@@ -14540,6 +15860,18 @@ Object {
     },
   },
   "Parameters": Object {
+    "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15ArtifactHash2AA5202D": Object {
+      "Description": "Artifact hash for asset \\"1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15\\"",
+      "Type": "String",
+    },
+    "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3Bucket38537BD6": Object {
+      "Description": "S3 bucket for asset \\"1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15\\"",
+      "Type": "String",
+    },
+    "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35": Object {
+      "Description": "S3 key for asset version \\"1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15\\"",
+      "Type": "String",
+    },
     "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49ArtifactHashA1145632": Object {
       "Description": "Artifact hash for asset \\"1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49\\"",
       "Type": "String",
@@ -14586,6 +15918,18 @@ Object {
     },
     "AssetParameters67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24S3VersionKeyB0F28861": Object {
       "Description": "S3 key for asset version \\"67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24\\"",
+      "Type": "String",
+    },
+    "AssetParameters68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513ArtifactHash02422EA3": Object {
+      "Description": "Artifact hash for asset \\"68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513\\"",
+      "Type": "String",
+    },
+    "AssetParameters68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513S3Bucket942ED5A2": Object {
+      "Description": "S3 bucket for asset \\"68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513\\"",
+      "Type": "String",
+    },
+    "AssetParameters68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513S3VersionKeyF5E68355": Object {
+      "Description": "S3 key for asset version \\"68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513\\"",
       "Type": "String",
     },
     "AssetParameters79e603efe968ac49808df5587ffabdc3a5dbf21d0284a3ddac62e3eac7db12a6ArtifactHash905316EF": Object {
@@ -14636,18 +15980,6 @@ Object {
       "Description": "S3 key for asset version \\"8265ccdf680d2fc53b19193e2b93340a27f335cc3be02b673f0742d7700fd6ac\\"",
       "Type": "String",
     },
-    "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9ArtifactHash7A6CE4F0": Object {
-      "Description": "Artifact hash for asset \\"8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9\\"",
-      "Type": "String",
-    },
-    "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7": Object {
-      "Description": "S3 bucket for asset \\"8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9\\"",
-      "Type": "String",
-    },
-    "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9": Object {
-      "Description": "S3 key for asset version \\"8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9\\"",
-      "Type": "String",
-    },
     "AssetParameters8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064ArtifactHashEA963870": Object {
       "Description": "Artifact hash for asset \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
@@ -14660,40 +15992,16 @@ Object {
       "Description": "S3 key for asset version \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
     },
-    "AssetParametersa7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100ArtifactHashB98D2EC5": Object {
-      "Description": "Artifact hash for asset \\"a7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100\\"",
+    "AssetParameters9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4bArtifactHash9C520604": Object {
+      "Description": "Artifact hash for asset \\"9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4b\\"",
       "Type": "String",
     },
-    "AssetParametersa7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100S3BucketA07EA20C": Object {
-      "Description": "S3 bucket for asset \\"a7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100\\"",
+    "AssetParameters9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4bS3BucketF0A4F598": Object {
+      "Description": "S3 bucket for asset \\"9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4b\\"",
       "Type": "String",
     },
-    "AssetParametersa7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100S3VersionKeyBF4D0B81": Object {
-      "Description": "S3 key for asset version \\"a7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100\\"",
-      "Type": "String",
-    },
-    "AssetParametersb191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17ArtifactHash65E20850": Object {
-      "Description": "Artifact hash for asset \\"b191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17\\"",
-      "Type": "String",
-    },
-    "AssetParametersb191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17S3Bucket60674A76": Object {
-      "Description": "S3 bucket for asset \\"b191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17\\"",
-      "Type": "String",
-    },
-    "AssetParametersb191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17S3VersionKey724F7AFD": Object {
-      "Description": "S3 key for asset version \\"b191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17\\"",
-      "Type": "String",
-    },
-    "AssetParametersbec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ecArtifactHash04B28626": Object {
-      "Description": "Artifact hash for asset \\"bec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ec\\"",
-      "Type": "String",
-    },
-    "AssetParametersbec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ecS3BucketE3CFE68F": Object {
-      "Description": "S3 bucket for asset \\"bec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ec\\"",
-      "Type": "String",
-    },
-    "AssetParametersbec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ecS3VersionKey6D99058D": Object {
-      "Description": "S3 key for asset version \\"bec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ec\\"",
+    "AssetParameters9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4bS3VersionKey5E4628BC": Object {
+      "Description": "S3 key for asset version \\"9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4b\\"",
       "Type": "String",
     },
     "AssetParametersc24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cfArtifactHash85F58E48": Object {
@@ -14732,16 +16040,16 @@ Object {
       "Description": "S3 key for asset version \\"d5ce621914a7c3f15cf5d46823956ea431a98db7cf8d22b7af369eb6d01413c7\\"",
       "Type": "String",
     },
-    "AssetParametersdef5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9ArtifactHashB9B2536A": Object {
-      "Description": "Artifact hash for asset \\"def5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9\\"",
+    "AssetParameterse0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813ArtifactHashAC8102A5": Object {
+      "Description": "Artifact hash for asset \\"e0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813\\"",
       "Type": "String",
     },
-    "AssetParametersdef5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9S3Bucket693007CE": Object {
-      "Description": "S3 bucket for asset \\"def5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9\\"",
+    "AssetParameterse0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813S3Bucket55321DF2": Object {
+      "Description": "S3 bucket for asset \\"e0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813\\"",
       "Type": "String",
     },
-    "AssetParametersdef5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9S3VersionKeyA7862DEC": Object {
-      "Description": "S3 key for asset version \\"def5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9\\"",
+    "AssetParameterse0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813S3VersionKey325A408D": Object {
+      "Description": "S3 key for asset version \\"e0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813\\"",
       "Type": "String",
     },
     "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68ArtifactHashD9A515C3": Object {
@@ -14778,6 +16086,18 @@ Object {
     },
     "AssetParametersfab52dab596e8f8b4fc5a26e9882c7509290ba057320ed7864232c0f290b5750S3VersionKey79B2C284": Object {
       "Description": "S3 key for asset version \\"fab52dab596e8f8b4fc5a26e9882c7509290ba057320ed7864232c0f290b5750\\"",
+      "Type": "String",
+    },
+    "AssetParametersff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2ArtifactHash58196055": Object {
+      "Description": "Artifact hash for asset \\"ff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2\\"",
+      "Type": "String",
+    },
+    "AssetParametersff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2S3BucketBC914BA2": Object {
+      "Description": "S3 bucket for asset \\"ff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2\\"",
+      "Type": "String",
+    },
+    "AssetParametersff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2S3VersionKey1681742D": Object {
+      "Description": "S3 key for asset version \\"ff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2\\"",
       "Type": "String",
     },
   },
@@ -15254,7 +16574,23 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"stacked\\":true,\\"metrics\\":[[\\"ConstructHub/Inventory\\",\\"SupportedSubmoduleCount\\",\\"Language\\",\\"python\\",{\\"color\\":\\"#2ca02c\\",\\"label\\":\\"Available\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"UnsupportedSubmoduleCount\\",\\"Language\\",\\"python\\",{\\"color\\":\\"#9467bd\\",\\"label\\":\\"Unsupported\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"MissingSubmoduleCount\\",\\"Language\\",\\"python\\",{\\"color\\":\\"#d62728\\",\\"label\\":\\"Missing\\",\\"stat\\":\\"Maximum\\"}]],\\"yAxis\\":{\\"left\\":{\\"showUnits\\":false}}}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":24,\\"properties\\":{\\"markdown\\":\\"# Test/ConstructHub/Sources/NpmJs\\\\n\\\\n[button:primary:NpmJs Follower](/lambda/home#/functions/",
+              "\\",\\"stacked\\":true,\\"metrics\\":[[\\"ConstructHub/Inventory\\",\\"SupportedSubmoduleCount\\",\\"Language\\",\\"python\\",{\\"color\\":\\"#2ca02c\\",\\"label\\":\\"Available\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"UnsupportedSubmoduleCount\\",\\"Language\\",\\"python\\",{\\"color\\":\\"#9467bd\\",\\"label\\":\\"Unsupported\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"MissingSubmoduleCount\\",\\"Language\\",\\"python\\",{\\"color\\":\\"#d62728\\",\\"label\\":\\"Missing\\",\\"stat\\":\\"Maximum\\"}]],\\"yAxis\\":{\\"left\\":{\\"showUnits\\":false}}}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":24,\\"properties\\":{\\"markdown\\":\\"## Language: java\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":6,\\"x\\":0,\\"y\\":25,\\"properties\\":{\\"view\\":\\"pie\\",\\"title\\":\\"Package Versions\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"ConstructHub/Inventory\\",\\"SupportedPackageVersionCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#2ca02c\\",\\"label\\":\\"Available\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"UnsupportedPackageVersionCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#9467bd\\",\\"label\\":\\"Unsupported\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"MissingPackageVersionCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#d62728\\",\\"label\\":\\"Missing\\",\\"stat\\":\\"Maximum\\"}]],\\"yAxis\\":{\\"left\\":{\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":6,\\"x\\":6,\\"y\\":25,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Package Versions\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"stacked\\":true,\\"metrics\\":[[\\"ConstructHub/Inventory\\",\\"SupportedPackageVersionCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#2ca02c\\",\\"label\\":\\"Available\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"UnsupportedPackageVersionCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#9467bd\\",\\"label\\":\\"Unsupported\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"MissingPackageVersionCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#d62728\\",\\"label\\":\\"Missing\\",\\"stat\\":\\"Maximum\\"}]],\\"yAxis\\":{\\"left\\":{\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":6,\\"x\\":12,\\"y\\":25,\\"properties\\":{\\"view\\":\\"pie\\",\\"title\\":\\"Package Version Submodules\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"ConstructHub/Inventory\\",\\"SupportedSubmoduleCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#2ca02c\\",\\"label\\":\\"Available\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"UnsupportedSubmoduleCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#9467bd\\",\\"label\\":\\"Unsupported\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"MissingSubmoduleCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#d62728\\",\\"label\\":\\"Missing\\",\\"stat\\":\\"Maximum\\"}]],\\"yAxis\\":{\\"left\\":{\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":6,\\"x\\":18,\\"y\\":25,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Package Version Submodules\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"stacked\\":true,\\"metrics\\":[[\\"ConstructHub/Inventory\\",\\"SupportedSubmoduleCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#2ca02c\\",\\"label\\":\\"Available\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"UnsupportedSubmoduleCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#9467bd\\",\\"label\\":\\"Unsupported\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"MissingSubmoduleCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#d62728\\",\\"label\\":\\"Missing\\",\\"stat\\":\\"Maximum\\"}]],\\"yAxis\\":{\\"left\\":{\\"showUnits\\":false}}}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":31,\\"properties\\":{\\"markdown\\":\\"# Test/ConstructHub/Sources/NpmJs\\\\n\\\\n[button:primary:NpmJs Follower](/lambda/home#/functions/",
               Object {
                 "Ref": "ConstructHubSourcesNpmJs15A77D2D",
               },
@@ -15262,7 +16598,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubSourcesNpmJsStagingBucketB286F0E6",
               },
-              "?prefix=couchdb-last-transaction-id.2)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":26,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Function Health\\",\\"region\\":\\"",
+              "?prefix=couchdb-last-transaction-id.2)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":33,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Function Health\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -15274,11 +16610,11 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubSourcesNpmJs15A77D2D",
               },
-              "\\",{\\"label\\":\\"Errors\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55\\"}],[\\"ConstructHub/PackageSource/NpmJs/Follower\\",\\"RemainingTime\\",{\\"label\\":\\"Remaining Time\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":900}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":26,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"CouchDB Follower\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Errors\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55\\"}],[\\"ConstructHub/PackageSource/NpmJs/Follower\\",\\"RemainingTime\\",{\\"label\\":\\"Remaining Time\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":900}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":33,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"CouchDB Follower\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[\\"ConstructHub/PackageSource/NpmJs/Follower\\",\\"ChangeCount\\",{\\"label\\":\\"Change Count\\",\\"stat\\":\\"Sum\\"}],[\\"ConstructHub/PackageSource/NpmJs/Follower\\",\\"UnprocessableEntity\\",{\\"label\\":\\"Unprocessable\\",\\"stat\\":\\"Sum\\"}],[{\\"label\\":\\"Lag to npmjs.com\\",\\"expression\\":\\"FILL(m4d6c513faac55be4bca785e8587a9a145b65f5fe675318c9c5c52f3ada197b7b, REPEAT)\\",\\"yAxis\\":\\"right\\"}],[\\"ConstructHub/PackageSource/NpmJs/Follower\\",\\"NpmJsChangeAge\\",{\\"label\\":\\"Lag to npmjs.com\\",\\"stat\\":\\"Minimum\\",\\"visible\\":false,\\"id\\":\\"m4d6c513faac55be4bca785e8587a9a145b65f5fe675318c9c5c52f3ada197b7b\\"}],[{\\"label\\":\\"Package Version Age\\",\\"expression\\":\\"FILL(mec485aa83505431ed7a356970082cd4815c310504ff176dd3eeb241ae7bbf0c4, REPEAT)\\",\\"yAxis\\":\\"right\\"}],[\\"ConstructHub/PackageSource/NpmJs/Follower\\",\\"PackageVersionAge\\",{\\"label\\":\\"Package Version Age\\",\\"stat\\":\\"Maximum\\",\\"visible\\":false,\\"id\\":\\"mec485aa83505431ed7a356970082cd4815c310504ff176dd3eeb241ae7bbf0c4\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"label\\":\\"Milliseconds\\",\\"min\\":0,\\"showUnits\\":false}},\\"period\\":900}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":32,\\"properties\\":{\\"markdown\\":\\"# Ingestion Function\\\\n\\\\n[button:Ingestion Function](/lambda/home#/functions/",
+              "\\",\\"metrics\\":[[\\"ConstructHub/PackageSource/NpmJs/Follower\\",\\"ChangeCount\\",{\\"label\\":\\"Change Count\\",\\"stat\\":\\"Sum\\"}],[\\"ConstructHub/PackageSource/NpmJs/Follower\\",\\"UnprocessableEntity\\",{\\"label\\":\\"Unprocessable\\",\\"stat\\":\\"Sum\\"}],[{\\"label\\":\\"Lag to npmjs.com\\",\\"expression\\":\\"FILL(m4d6c513faac55be4bca785e8587a9a145b65f5fe675318c9c5c52f3ada197b7b, REPEAT)\\",\\"yAxis\\":\\"right\\"}],[\\"ConstructHub/PackageSource/NpmJs/Follower\\",\\"NpmJsChangeAge\\",{\\"label\\":\\"Lag to npmjs.com\\",\\"stat\\":\\"Minimum\\",\\"visible\\":false,\\"id\\":\\"m4d6c513faac55be4bca785e8587a9a145b65f5fe675318c9c5c52f3ada197b7b\\"}],[{\\"label\\":\\"Package Version Age\\",\\"expression\\":\\"FILL(mec485aa83505431ed7a356970082cd4815c310504ff176dd3eeb241ae7bbf0c4, REPEAT)\\",\\"yAxis\\":\\"right\\"}],[\\"ConstructHub/PackageSource/NpmJs/Follower\\",\\"PackageVersionAge\\",{\\"label\\":\\"Package Version Age\\",\\"stat\\":\\"Maximum\\",\\"visible\\":false,\\"id\\":\\"mec485aa83505431ed7a356970082cd4815c310504ff176dd3eeb241ae7bbf0c4\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"label\\":\\"Milliseconds\\",\\"min\\":0,\\"showUnits\\":false}},\\"period\\":900}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":39,\\"properties\\":{\\"markdown\\":\\"# Ingestion Function\\\\n\\\\n[button:Ingestion Function](/lambda/home#/functions/",
               Object {
                 "Ref": "ConstructHubIngestion407909CE",
               },
@@ -15301,7 +16637,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              ")\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":34,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Function Health\\",\\"region\\":\\"",
+              ")\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":41,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Function Health\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -15313,7 +16649,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubIngestion407909CE",
               },
-              "\\",{\\"label\\":\\"Errors\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":34,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Input Queue\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Errors\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":41,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Input Queue\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -15338,11 +16674,11 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"period\\":60,\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ffa500\\",\\"label\\":\\"10 Minutes\\",\\"value\\":600,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":40,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Input Quality\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"period\\":60,\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ffa500\\",\\"label\\":\\"10 Minutes\\",\\"value\\":600,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":47,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Input Quality\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"stacked\\":true,\\"metrics\\":[[{\\"label\\":\\"Invalid Assemblies\\",\\"expression\\":\\"FILL(m0c5f10aa73687a21aa44b8985d19311246bca6c2cd1b2256b9f3e78c71e94fa3, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"InvalidAssembly\\",{\\"label\\":\\"Invalid Assemblies\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m0c5f10aa73687a21aa44b8985d19311246bca6c2cd1b2256b9f3e78c71e94fa3\\"}],[{\\"label\\":\\"Invalid Tarball\\",\\"expression\\":\\"FILL(m3a39d9b0bf974255f27dc95e44c8574bdfce2b97e49a7504346a77c5c9f6a3e1, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"InvalidTarball\\",{\\"label\\":\\"Invalid Tarball\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3a39d9b0bf974255f27dc95e44c8574bdfce2b97e49a7504346a77c5c9f6a3e1\\"}],[{\\"label\\":\\"Ineligible License\\",\\"expression\\":\\"FILL(me19ae9c3f20ae715e3462f9402684a3817282218f36e69494a60bc251e3435a6, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"IneligibleLicense\\",{\\"label\\":\\"Ineligible License\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"me19ae9c3f20ae715e3462f9402684a3817282218f36e69494a60bc251e3435a6\\"}],[{\\"label\\":\\"Mismatched Identity\\",\\"expression\\":\\"FILL(m7c1d407f17f8d2452a0bf87ac06fdd032de385a2758254f4192d6e17ed40d44b, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"MismatchedIdentityRejections\\",{\\"label\\":\\"Mismatched Identity\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m7c1d407f17f8d2452a0bf87ac06fdd032de385a2758254f4192d6e17ed40d44b\\"}],[{\\"label\\":\\"Found License file\\",\\"expression\\":\\"FILL(m7084dfec3c5bab86694d7ae438460f471c174a94bc67c9c9738e3ab60246b661, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"FoundLicenseFile\\",{\\"label\\":\\"Found License file\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m7084dfec3c5bab86694d7ae438460f471c174a94bc67c9c9738e3ab60246b661\\"}]],\\"yAxis\\":{\\"left\\":{\\"label\\":\\"Count\\",\\"min\\":0,\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":40,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Dead Letters\\",\\"region\\":\\"",
+              "\\",\\"stacked\\":true,\\"metrics\\":[[{\\"label\\":\\"Invalid Assemblies\\",\\"expression\\":\\"FILL(m0c5f10aa73687a21aa44b8985d19311246bca6c2cd1b2256b9f3e78c71e94fa3, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"InvalidAssembly\\",{\\"label\\":\\"Invalid Assemblies\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m0c5f10aa73687a21aa44b8985d19311246bca6c2cd1b2256b9f3e78c71e94fa3\\"}],[{\\"label\\":\\"Invalid Tarball\\",\\"expression\\":\\"FILL(m3a39d9b0bf974255f27dc95e44c8574bdfce2b97e49a7504346a77c5c9f6a3e1, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"InvalidTarball\\",{\\"label\\":\\"Invalid Tarball\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3a39d9b0bf974255f27dc95e44c8574bdfce2b97e49a7504346a77c5c9f6a3e1\\"}],[{\\"label\\":\\"Ineligible License\\",\\"expression\\":\\"FILL(me19ae9c3f20ae715e3462f9402684a3817282218f36e69494a60bc251e3435a6, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"IneligibleLicense\\",{\\"label\\":\\"Ineligible License\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"me19ae9c3f20ae715e3462f9402684a3817282218f36e69494a60bc251e3435a6\\"}],[{\\"label\\":\\"Mismatched Identity\\",\\"expression\\":\\"FILL(m7c1d407f17f8d2452a0bf87ac06fdd032de385a2758254f4192d6e17ed40d44b, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"MismatchedIdentityRejections\\",{\\"label\\":\\"Mismatched Identity\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m7c1d407f17f8d2452a0bf87ac06fdd032de385a2758254f4192d6e17ed40d44b\\"}],[{\\"label\\":\\"Found License file\\",\\"expression\\":\\"FILL(m7084dfec3c5bab86694d7ae438460f471c174a94bc67c9c9738e3ab60246b661, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"FoundLicenseFile\\",{\\"label\\":\\"Found License file\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m7084dfec3c5bab86694d7ae438460f471c174a94bc67c9c9738e3ab60246b661\\"}]],\\"yAxis\\":{\\"left\\":{\\"label\\":\\"Count\\",\\"min\\":0,\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":47,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Dead Letters\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -15367,7 +16703,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":46,\\"properties\\":{\\"markdown\\":\\"# Orchestration\\\\n\\\\n[button:State Machine](/states/home#/statemachines/view/",
+              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":53,\\"properties\\":{\\"markdown\\":\\"# Orchestration\\\\n\\\\n[button:State Machine](/states/home#/statemachines/view/",
               Object {
                 "Ref": "ConstructHubOrchestration39161A46",
               },
@@ -15394,7 +16730,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubOrchestrationReprocessAllFF2F2455",
               },
-              ")\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":48,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"State Machine Executions\\",\\"region\\":\\"",
+              ")\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":55,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"State Machine Executions\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -15426,7 +16762,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubOrchestration39161A46",
               },
-              "\\",{\\"label\\":\\"Duration\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":48,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Dead Letter Queue\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Duration\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":55,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Dead Letter Queue\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -15451,7 +16787,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":54,\\"properties\\":{\\"markdown\\":\\"# Deny List\\\\n\\\\n[button:Deny List Object](/s3/object/",
+              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":61,\\"properties\\":{\\"markdown\\":\\"# Deny List\\\\n\\\\n[button:Deny List Object](/s3/object/",
               Object {
                 "Ref": "ConstructHubDenyListBucket1B3C2C2E",
               },
@@ -15482,7 +16818,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubDenyListPrunePruneQueueHandlerF7EB599B",
               },
-              "/log-events)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":56,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Deny List\\",\\"region\\":\\"",
+              "/log-events)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":63,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Deny List\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -15493,7 +16829,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              "\\",{\\"label\\":\\"Deleted Files\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":300}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":56,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Prune Function Health\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Deleted Files\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":300}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":63,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Prune Function Health\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -16376,7 +17712,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersbec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ecS3BucketE3CFE68F",
+            "Ref": "AssetParametersff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2S3BucketBC914BA2",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -16389,7 +17725,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersbec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ecS3VersionKey6D99058D",
+                          "Ref": "AssetParametersff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2S3VersionKey1681742D",
                         },
                       ],
                     },
@@ -16402,7 +17738,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersbec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ecS3VersionKey6D99058D",
+                          "Ref": "AssetParametersff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2S3VersionKey1681742D",
                         },
                       ],
                     },
@@ -16797,7 +18133,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersa7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100S3BucketA07EA20C",
+            "Ref": "AssetParameters9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4bS3BucketF0A4F598",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -16810,7 +18146,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersa7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100S3VersionKeyBF4D0B81",
+                          "Ref": "AssetParameters9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4bS3VersionKey5E4628BC",
                         },
                       ],
                     },
@@ -16823,7 +18159,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersa7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100S3VersionKeyBF4D0B81",
+                          "Ref": "AssetParameters9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4bS3VersionKey5E4628BC",
                         },
                       ],
                     },
@@ -17150,6 +18486,53 @@ Direct link to function: /lambda/home#/functions/",
                 },
               ],
             },
+            Object {
+              "Action": "sts:GetServiceBearerToken",
+              "Condition": Object {
+                "StringEquals": Object {
+                  "sts:AWSServiceName": "codeartifact.amazonaws.com",
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubOrchestrationDocGenjavaServiceRoleA6039136",
+                    "Arn",
+                  ],
+                },
+              },
+              "Resource": "*",
+            },
+            Object {
+              "Action": Array [
+                "codeartifact:GetAuthorizationToken",
+                "codeartifact:GetRepositoryEndpoint",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubOrchestrationDocGenjavaServiceRoleA6039136",
+                    "Arn",
+                  ],
+                },
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubCodeArtifactDomainFC30B796",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubCodeArtifact1188409E",
+                    "Arn",
+                  ],
+                },
+              ],
+            },
           ],
           "Version": "2012-10-17",
         },
@@ -17268,6 +18651,24 @@ Direct link to function: /lambda/home#/functions/",
                 "AWS": Object {
                   "Fn::GetAtt": Array [
                     "ConstructHubOrchestrationDocGentypescriptServiceRoleB56C2B19",
+                    "Arn",
+                  ],
+                },
+              },
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "ConstructHubCodeArtifact1188409E",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": "codeartifact:ReadFromRepository",
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubOrchestrationDocGenjavaServiceRoleA6039136",
                     "Arn",
                   ],
                 },
@@ -17826,6 +19227,138 @@ Direct link to function: /lambda/home#/functions/",
                         ],
                       },
                       "/data/*/docs-*-typescript.md.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:Abort*",
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-java.md",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:Abort*",
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-java.md",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:Abort*",
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-java.md.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:Abort*",
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-java.md.not-supported",
                     ],
                   ],
                 },
@@ -18695,7 +20228,18 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              "\\",\\"Payload.$\\":\\"$\\"}},\\"\\\\\\"Generate typescript docs\\\\\\" throttled\\":{\\"Type\\":\\"Pass\\",\\"Parameters\\":{\\"error.$\\":\\"$.Cause\\",\\"language\\":{\\"lang\\":\\"typescript\\"}},\\"End\\":true},\\"\\\\\\"Generate typescript docs\\\\\\" failure\\":{\\"Type\\":\\"Pass\\",\\"Parameters\\":{\\"error.$\\":\\"States.StringToJson($.Cause)\\",\\"language\\":{\\"lang\\":\\"typescript\\"}},\\"End\\":true},\\"\\\\\\"Generate typescript docs\\\\\\" fault\\":{\\"Type\\":\\"Pass\\",\\"Parameters\\":{\\"error.$\\":\\"$.Cause\\",\\"language\\":{\\"lang\\":\\"typescript\\"}},\\"End\\":true}}}]},\\"Any Success?\\":{\\"Type\\":\\"Choice\\",\\"Choices\\":[{\\"Or\\":[{\\"Variable\\":\\"$.DocGen[0].error\\",\\"IsPresent\\":false},{\\"Variable\\":\\"$.DocGen[1].error\\",\\"IsPresent\\":false}],\\"Next\\":\\"Add to catalog.json\\"}],\\"Default\\":\\"Any Failure?\\"},\\"Any Failure?\\":{\\"Type\\":\\"Choice\\",\\"Choices\\":[{\\"Or\\":[{\\"Variable\\":\\"$.DocGen[0].error\\",\\"IsPresent\\":true},{\\"Variable\\":\\"$.DocGen[1].error\\",\\"IsPresent\\":true}],\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Default\\":\\"Success\\"},\\"Add to catalog.json\\":{\\"Next\\":\\"Any Failure?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"Lambda.ServiceException\\",\\"Lambda.AWSLambdaException\\",\\"Lambda.SdkClientException\\"],\\"IntervalSeconds\\":2,\\"MaxAttempts\\":6,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":5}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"Next\\":\\"\\\\\\"Add to catalog.json\\\\\\" throttled\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"Next\\":\\"\\\\\\"Add to catalog.json\\\\\\" failure\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"Next\\":\\"\\\\\\"Add to catalog.json\\\\\\" fault\\"}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.catalogBuilderOutput\\",\\"ResultSelector\\":{\\"ETag.$\\":\\"$.Payload.ETag\\",\\"VersionId.$\\":\\"$.Payload.VersionId\\"},\\"Resource\\":\\"arn:",
+              "\\",\\"Payload.$\\":\\"$\\"}},\\"\\\\\\"Generate typescript docs\\\\\\" throttled\\":{\\"Type\\":\\"Pass\\",\\"Parameters\\":{\\"error.$\\":\\"$.Cause\\",\\"language\\":{\\"lang\\":\\"typescript\\"}},\\"End\\":true},\\"\\\\\\"Generate typescript docs\\\\\\" failure\\":{\\"Type\\":\\"Pass\\",\\"Parameters\\":{\\"error.$\\":\\"States.StringToJson($.Cause)\\",\\"language\\":{\\"lang\\":\\"typescript\\"}},\\"End\\":true},\\"\\\\\\"Generate typescript docs\\\\\\" fault\\":{\\"Type\\":\\"Pass\\",\\"Parameters\\":{\\"error.$\\":\\"$.Cause\\",\\"language\\":{\\"lang\\":\\"typescript\\"}},\\"End\\":true}}},{\\"StartAt\\":\\"Generate java docs\\",\\"States\\":{\\"Generate java docs\\":{\\"End\\":true,\\"Retry\\":[{\\"ErrorEquals\\":[\\"Lambda.ServiceException\\",\\"Lambda.AWSLambdaException\\",\\"Lambda.SdkClientException\\"],\\"IntervalSeconds\\":2,\\"MaxAttempts\\":6,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"IntervalSeconds\\":30}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"Next\\":\\"\\\\\\"Generate java docs\\\\\\" throttled\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"Next\\":\\"\\\\\\"Generate java docs\\\\\\" failure\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"Next\\":\\"\\\\\\"Generate java docs\\\\\\" fault\\"}],\\"Type\\":\\"Task\\",\\"OutputPath\\":\\"$.result\\",\\"ResultSelector\\":{\\"result\\":{\\"language\\":{\\"lang\\":\\"java\\"},\\"success.$\\":\\"$.Payload\\"}},\\"Resource\\":\\"arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":states:::lambda:invoke\\",\\"Parameters\\":{\\"FunctionName\\":\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ConstructHubOrchestrationDocGenjava0F6D30AF",
+                  "Arn",
+                ],
+              },
+              "\\",\\"Payload.$\\":\\"$\\"}},\\"\\\\\\"Generate java docs\\\\\\" throttled\\":{\\"Type\\":\\"Pass\\",\\"Parameters\\":{\\"error.$\\":\\"$.Cause\\",\\"language\\":{\\"lang\\":\\"java\\"}},\\"End\\":true},\\"\\\\\\"Generate java docs\\\\\\" failure\\":{\\"Type\\":\\"Pass\\",\\"Parameters\\":{\\"error.$\\":\\"States.StringToJson($.Cause)\\",\\"language\\":{\\"lang\\":\\"java\\"}},\\"End\\":true},\\"\\\\\\"Generate java docs\\\\\\" fault\\":{\\"Type\\":\\"Pass\\",\\"Parameters\\":{\\"error.$\\":\\"$.Cause\\",\\"language\\":{\\"lang\\":\\"java\\"}},\\"End\\":true}}}]},\\"Any Success?\\":{\\"Type\\":\\"Choice\\",\\"Choices\\":[{\\"Or\\":[{\\"Variable\\":\\"$.DocGen[0].error\\",\\"IsPresent\\":false},{\\"Variable\\":\\"$.DocGen[1].error\\",\\"IsPresent\\":false},{\\"Variable\\":\\"$.DocGen[2].error\\",\\"IsPresent\\":false}],\\"Next\\":\\"Add to catalog.json\\"}],\\"Default\\":\\"Any Failure?\\"},\\"Any Failure?\\":{\\"Type\\":\\"Choice\\",\\"Choices\\":[{\\"Or\\":[{\\"Variable\\":\\"$.DocGen[0].error\\",\\"IsPresent\\":true},{\\"Variable\\":\\"$.DocGen[1].error\\",\\"IsPresent\\":true},{\\"Variable\\":\\"$.DocGen[2].error\\",\\"IsPresent\\":true}],\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Default\\":\\"Success\\"},\\"Add to catalog.json\\":{\\"Next\\":\\"Any Failure?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"Lambda.ServiceException\\",\\"Lambda.AWSLambdaException\\",\\"Lambda.SdkClientException\\"],\\"IntervalSeconds\\":2,\\"MaxAttempts\\":6,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":5}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"Next\\":\\"\\\\\\"Add to catalog.json\\\\\\" throttled\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"Next\\":\\"\\\\\\"Add to catalog.json\\\\\\" failure\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"Next\\":\\"\\\\\\"Add to catalog.json\\\\\\" fault\\"}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.catalogBuilderOutput\\",\\"ResultSelector\\":{\\"ETag.$\\":\\"$.Payload.ETag\\",\\"VersionId.$\\":\\"$.Payload.VersionId\\"},\\"Resource\\":\\"arn:",
               Object {
                 "Ref": "AWS::Partition",
               },
@@ -18739,7 +20283,7 @@ Direct link to function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersdef5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9S3Bucket693007CE",
+            "Ref": "AssetParameterse0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813S3Bucket55321DF2",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -18752,7 +20296,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersdef5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9S3VersionKeyA7862DEC",
+                          "Ref": "AssetParameterse0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813S3VersionKey325A408D",
                         },
                       ],
                     },
@@ -18765,7 +20309,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersdef5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9S3VersionKeyA7862DEC",
+                          "Ref": "AssetParameterse0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813S3VersionKey325A408D",
                         },
                       ],
                     },
@@ -19058,15 +20602,15 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "ConstructHubOrchestrationDocGenpython77179663": Object {
+    "ConstructHubOrchestrationDocGenjava0F6D30AF": Object {
       "DependsOn": Array [
-        "ConstructHubOrchestrationDocGenpythonServiceRoleDefaultPolicy7A9DA724",
-        "ConstructHubOrchestrationDocGenpythonServiceRoleD16CBDB2",
+        "ConstructHubOrchestrationDocGenjavaServiceRoleDefaultPolicy8819DA50",
+        "ConstructHubOrchestrationDocGenjavaServiceRoleA6039136",
       ],
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7",
+            "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3Bucket38537BD6",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -19079,7 +20623,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35",
                         },
                       ],
                     },
@@ -19092,7 +20636,419 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            ],
+          },
+        },
+        "Description": "Creates java documentation from jsii-enabled npm packages",
+        "Environment": Object {
+          "Variables": Object {
+            "CODE_ARTIFACT_API_ENDPOINT": Object {
+              "Fn::Select": Array [
+                1,
+                Object {
+                  "Fn::Split": Array [
+                    ":",
+                    Object {
+                      "Fn::Select": Array [
+                        0,
+                        Object {
+                          "Fn::GetAtt": Array [
+                            "ConstructHubLambdaVPCCodeArtifactAPI0A2356B9",
+                            "DnsEntries",
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            "CODE_ARTIFACT_DOMAIN_NAME": Object {
+              "Fn::GetAtt": Array [
+                "ConstructHubCodeArtifact1188409E",
+                "DomainName",
+              ],
+            },
+            "CODE_ARTIFACT_DOMAIN_OWNER": Object {
+              "Fn::GetAtt": Array [
+                "ConstructHubCodeArtifact1188409E",
+                "DomainOwner",
+              ],
+            },
+            "CODE_ARTIFACT_REPOSITORY_ENDPOINT": Object {
+              "Fn::GetAtt": Array [
+                "ConstructHubCodeArtifactGetEndpoint9A458FEF",
+                "repositoryEndpoint",
+              ],
+            },
+            "HEADER_SPAN": "true",
+            "TARGET_LANGUAGE": "java",
+          },
+        },
+        "Handler": "index.handler",
+        "MemorySize": 10240,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "ConstructHubOrchestrationDocGenjavaServiceRoleA6039136",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+        "Timeout": 900,
+        "TracingConfig": Object {
+          "Mode": "PassThrough",
+        },
+        "VpcConfig": Object {
+          "SecurityGroupIds": Array [
+            Object {
+              "Fn::GetAtt": Array [
+                "ConstructHubOrchestrationDocGenjavaSecurityGroup72D0C513",
+                "GroupId",
+              ],
+            },
+          ],
+          "SubnetIds": Array [
+            Object {
+              "Ref": "ConstructHubLambdaVPCIsolatedSubnet1Subnet33EDE47B",
+            },
+            Object {
+              "Ref": "ConstructHubLambdaVPCIsolatedSubnet2Subnet825B4A7B",
+            },
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "ConstructHubOrchestrationDocGenjavaLogRetention55FBE552": Object {
+      "Properties": Object {
+        "LogGroupName": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "/aws/lambda/",
+              Object {
+                "Ref": "ConstructHubOrchestrationDocGenjava0F6D30AF",
+              },
+            ],
+          ],
+        },
+        "RetentionInDays": 3653,
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::LogRetention",
+    },
+    "ConstructHubOrchestrationDocGenjavaSecurityGroup72D0C513": Object {
+      "Properties": Object {
+        "GroupDescription": "Automatic security group for Lambda Function TestConstructHubOrchestrationDocGenjava7634BAF0",
+        "SecurityGroupEgress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound traffic by default",
+            "IpProtocol": "-1",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "ConstructHubLambdaVPCE85ABF51",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "ConstructHubOrchestrationDocGenjavaServiceRoleA6039136": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ConstructHubOrchestrationDocGenjavaServiceRoleDefaultPolicy8819DA50": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "xray:PutTraceSegments",
+                "xray:PutTelemetryRecords",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            Object {
+              "Action": "sts:GetServiceBearerToken",
+              "Condition": Object {
+                "StringEquals": Object {
+                  "sts:AWSServiceName": "codeartifact.amazonaws.com",
+                },
+              },
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            Object {
+              "Action": Array [
+                "codeartifact:GetAuthorizationToken",
+                "codeartifact:GetRepositoryEndpoint",
+                "codeartifact:ReadFromRepository",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubCodeArtifactDomainFC30B796",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubCodeArtifact1188409E",
+                    "Arn",
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/assembly.json",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-java.md",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-java.md",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-java.md.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-java.md.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ConstructHubOrchestrationDocGenjavaServiceRoleDefaultPolicy8819DA50",
+        "Roles": Array [
+          Object {
+            "Ref": "ConstructHubOrchestrationDocGenjavaServiceRoleA6039136",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ConstructHubOrchestrationDocGenpython77179663": Object {
+      "DependsOn": Array [
+        "ConstructHubOrchestrationDocGenpythonServiceRoleDefaultPolicy7A9DA724",
+        "ConstructHubOrchestrationDocGenpythonServiceRoleD16CBDB2",
+      ],
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3Bucket38537BD6",
+          },
+          "S3Key": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                Object {
+                  "Fn::Select": Array [
+                    0,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                Object {
+                  "Fn::Select": Array [
+                    1,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35",
                         },
                       ],
                     },
@@ -19478,7 +21434,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7",
+            "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3Bucket38537BD6",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -19491,7 +21447,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35",
                         },
                       ],
                     },
@@ -19504,7 +21460,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35",
                         },
                       ],
                     },
@@ -20080,7 +22036,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersb191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17S3Bucket60674A76",
+            "Ref": "AssetParameters68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513S3Bucket942ED5A2",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -20093,7 +22049,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersb191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17S3VersionKey724F7AFD",
+                          "Ref": "AssetParameters68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513S3VersionKeyF5E68355",
                         },
                       ],
                     },
@@ -20106,7 +22062,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersb191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17S3VersionKey724F7AFD",
+                          "Ref": "AssetParameters68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513S3VersionKeyF5E68355",
                         },
                       ],
                     },
@@ -20288,6 +22244,16 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
               "Resource": Object {
                 "Fn::GetAtt": Array [
                   "ConstructHubOrchestrationDocGentypescriptF9C30384",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "ConstructHubOrchestrationDocGenjava0F6D30AF",
                   "Arn",
                 ],
               },
@@ -22230,6 +24196,18 @@ Object {
     },
   },
   "Parameters": Object {
+    "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15ArtifactHash2AA5202D": Object {
+      "Description": "Artifact hash for asset \\"1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15\\"",
+      "Type": "String",
+    },
+    "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3Bucket38537BD6": Object {
+      "Description": "S3 bucket for asset \\"1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15\\"",
+      "Type": "String",
+    },
+    "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35": Object {
+      "Description": "S3 key for asset version \\"1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15\\"",
+      "Type": "String",
+    },
     "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49ArtifactHashA1145632": Object {
       "Description": "Artifact hash for asset \\"1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49\\"",
       "Type": "String",
@@ -22278,6 +24256,18 @@ Object {
       "Description": "S3 key for asset version \\"67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24\\"",
       "Type": "String",
     },
+    "AssetParameters68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513ArtifactHash02422EA3": Object {
+      "Description": "Artifact hash for asset \\"68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513\\"",
+      "Type": "String",
+    },
+    "AssetParameters68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513S3Bucket942ED5A2": Object {
+      "Description": "S3 bucket for asset \\"68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513\\"",
+      "Type": "String",
+    },
+    "AssetParameters68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513S3VersionKeyF5E68355": Object {
+      "Description": "S3 key for asset version \\"68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513\\"",
+      "Type": "String",
+    },
     "AssetParameters7ee6e37c4f89b09a6b3c50e513093daf23a858809daed5a6703095d14955c9b2ArtifactHash65BC41FC": Object {
       "Description": "Artifact hash for asset \\"7ee6e37c4f89b09a6b3c50e513093daf23a858809daed5a6703095d14955c9b2\\"",
       "Type": "String",
@@ -22302,18 +24292,6 @@ Object {
       "Description": "S3 key for asset version \\"8265ccdf680d2fc53b19193e2b93340a27f335cc3be02b673f0742d7700fd6ac\\"",
       "Type": "String",
     },
-    "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9ArtifactHash7A6CE4F0": Object {
-      "Description": "Artifact hash for asset \\"8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9\\"",
-      "Type": "String",
-    },
-    "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7": Object {
-      "Description": "S3 bucket for asset \\"8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9\\"",
-      "Type": "String",
-    },
-    "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9": Object {
-      "Description": "S3 key for asset version \\"8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9\\"",
-      "Type": "String",
-    },
     "AssetParameters8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064ArtifactHashEA963870": Object {
       "Description": "Artifact hash for asset \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
@@ -22326,40 +24304,16 @@ Object {
       "Description": "S3 key for asset version \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
     },
-    "AssetParametersa7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100ArtifactHashB98D2EC5": Object {
-      "Description": "Artifact hash for asset \\"a7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100\\"",
+    "AssetParameters9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4bArtifactHash9C520604": Object {
+      "Description": "Artifact hash for asset \\"9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4b\\"",
       "Type": "String",
     },
-    "AssetParametersa7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100S3BucketA07EA20C": Object {
-      "Description": "S3 bucket for asset \\"a7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100\\"",
+    "AssetParameters9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4bS3BucketF0A4F598": Object {
+      "Description": "S3 bucket for asset \\"9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4b\\"",
       "Type": "String",
     },
-    "AssetParametersa7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100S3VersionKeyBF4D0B81": Object {
-      "Description": "S3 key for asset version \\"a7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100\\"",
-      "Type": "String",
-    },
-    "AssetParametersb191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17ArtifactHash65E20850": Object {
-      "Description": "Artifact hash for asset \\"b191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17\\"",
-      "Type": "String",
-    },
-    "AssetParametersb191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17S3Bucket60674A76": Object {
-      "Description": "S3 bucket for asset \\"b191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17\\"",
-      "Type": "String",
-    },
-    "AssetParametersb191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17S3VersionKey724F7AFD": Object {
-      "Description": "S3 key for asset version \\"b191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17\\"",
-      "Type": "String",
-    },
-    "AssetParametersbec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ecArtifactHash04B28626": Object {
-      "Description": "Artifact hash for asset \\"bec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ec\\"",
-      "Type": "String",
-    },
-    "AssetParametersbec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ecS3BucketE3CFE68F": Object {
-      "Description": "S3 bucket for asset \\"bec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ec\\"",
-      "Type": "String",
-    },
-    "AssetParametersbec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ecS3VersionKey6D99058D": Object {
-      "Description": "S3 key for asset version \\"bec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ec\\"",
+    "AssetParameters9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4bS3VersionKey5E4628BC": Object {
+      "Description": "S3 key for asset version \\"9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4b\\"",
       "Type": "String",
     },
     "AssetParametersc24b999656e4fe6c609c31bae56a1cf4717a405619c3aa6ba1bc686b8c2c86cfArtifactHash85F58E48": Object {
@@ -22398,16 +24352,16 @@ Object {
       "Description": "S3 key for asset version \\"d5ce621914a7c3f15cf5d46823956ea431a98db7cf8d22b7af369eb6d01413c7\\"",
       "Type": "String",
     },
-    "AssetParametersdef5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9ArtifactHashB9B2536A": Object {
-      "Description": "Artifact hash for asset \\"def5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9\\"",
+    "AssetParameterse0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813ArtifactHashAC8102A5": Object {
+      "Description": "Artifact hash for asset \\"e0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813\\"",
       "Type": "String",
     },
-    "AssetParametersdef5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9S3Bucket693007CE": Object {
-      "Description": "S3 bucket for asset \\"def5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9\\"",
+    "AssetParameterse0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813S3Bucket55321DF2": Object {
+      "Description": "S3 bucket for asset \\"e0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813\\"",
       "Type": "String",
     },
-    "AssetParametersdef5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9S3VersionKeyA7862DEC": Object {
-      "Description": "S3 key for asset version \\"def5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9\\"",
+    "AssetParameterse0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813S3VersionKey325A408D": Object {
+      "Description": "S3 key for asset version \\"e0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813\\"",
       "Type": "String",
     },
     "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68ArtifactHashD9A515C3": Object {
@@ -22444,6 +24398,18 @@ Object {
     },
     "AssetParametersfab52dab596e8f8b4fc5a26e9882c7509290ba057320ed7864232c0f290b5750S3VersionKey79B2C284": Object {
       "Description": "S3 key for asset version \\"fab52dab596e8f8b4fc5a26e9882c7509290ba057320ed7864232c0f290b5750\\"",
+      "Type": "String",
+    },
+    "AssetParametersff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2ArtifactHash58196055": Object {
+      "Description": "Artifact hash for asset \\"ff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2\\"",
+      "Type": "String",
+    },
+    "AssetParametersff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2S3BucketBC914BA2": Object {
+      "Description": "S3 bucket for asset \\"ff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2\\"",
+      "Type": "String",
+    },
+    "AssetParametersff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2S3VersionKey1681742D": Object {
+      "Description": "S3 key for asset version \\"ff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2\\"",
       "Type": "String",
     },
   },
@@ -22771,7 +24737,23 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"stacked\\":true,\\"metrics\\":[[\\"ConstructHub/Inventory\\",\\"SupportedSubmoduleCount\\",\\"Language\\",\\"python\\",{\\"color\\":\\"#2ca02c\\",\\"label\\":\\"Available\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"UnsupportedSubmoduleCount\\",\\"Language\\",\\"python\\",{\\"color\\":\\"#9467bd\\",\\"label\\":\\"Unsupported\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"MissingSubmoduleCount\\",\\"Language\\",\\"python\\",{\\"color\\":\\"#d62728\\",\\"label\\":\\"Missing\\",\\"stat\\":\\"Maximum\\"}]],\\"yAxis\\":{\\"left\\":{\\"showUnits\\":false}}}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":24,\\"properties\\":{\\"markdown\\":\\"# Test/ConstructHub/Sources/NpmJs\\\\n\\\\n[button:primary:NpmJs Follower](/lambda/home#/functions/",
+              "\\",\\"stacked\\":true,\\"metrics\\":[[\\"ConstructHub/Inventory\\",\\"SupportedSubmoduleCount\\",\\"Language\\",\\"python\\",{\\"color\\":\\"#2ca02c\\",\\"label\\":\\"Available\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"UnsupportedSubmoduleCount\\",\\"Language\\",\\"python\\",{\\"color\\":\\"#9467bd\\",\\"label\\":\\"Unsupported\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"MissingSubmoduleCount\\",\\"Language\\",\\"python\\",{\\"color\\":\\"#d62728\\",\\"label\\":\\"Missing\\",\\"stat\\":\\"Maximum\\"}]],\\"yAxis\\":{\\"left\\":{\\"showUnits\\":false}}}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":24,\\"properties\\":{\\"markdown\\":\\"## Language: java\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":6,\\"x\\":0,\\"y\\":25,\\"properties\\":{\\"view\\":\\"pie\\",\\"title\\":\\"Package Versions\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"ConstructHub/Inventory\\",\\"SupportedPackageVersionCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#2ca02c\\",\\"label\\":\\"Available\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"UnsupportedPackageVersionCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#9467bd\\",\\"label\\":\\"Unsupported\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"MissingPackageVersionCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#d62728\\",\\"label\\":\\"Missing\\",\\"stat\\":\\"Maximum\\"}]],\\"yAxis\\":{\\"left\\":{\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":6,\\"x\\":6,\\"y\\":25,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Package Versions\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"stacked\\":true,\\"metrics\\":[[\\"ConstructHub/Inventory\\",\\"SupportedPackageVersionCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#2ca02c\\",\\"label\\":\\"Available\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"UnsupportedPackageVersionCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#9467bd\\",\\"label\\":\\"Unsupported\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"MissingPackageVersionCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#d62728\\",\\"label\\":\\"Missing\\",\\"stat\\":\\"Maximum\\"}]],\\"yAxis\\":{\\"left\\":{\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":6,\\"x\\":12,\\"y\\":25,\\"properties\\":{\\"view\\":\\"pie\\",\\"title\\":\\"Package Version Submodules\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"ConstructHub/Inventory\\",\\"SupportedSubmoduleCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#2ca02c\\",\\"label\\":\\"Available\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"UnsupportedSubmoduleCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#9467bd\\",\\"label\\":\\"Unsupported\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"MissingSubmoduleCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#d62728\\",\\"label\\":\\"Missing\\",\\"stat\\":\\"Maximum\\"}]],\\"yAxis\\":{\\"left\\":{\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":6,\\"x\\":18,\\"y\\":25,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Package Version Submodules\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"stacked\\":true,\\"metrics\\":[[\\"ConstructHub/Inventory\\",\\"SupportedSubmoduleCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#2ca02c\\",\\"label\\":\\"Available\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"UnsupportedSubmoduleCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#9467bd\\",\\"label\\":\\"Unsupported\\",\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/Inventory\\",\\"MissingSubmoduleCount\\",\\"Language\\",\\"java\\",{\\"color\\":\\"#d62728\\",\\"label\\":\\"Missing\\",\\"stat\\":\\"Maximum\\"}]],\\"yAxis\\":{\\"left\\":{\\"showUnits\\":false}}}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":31,\\"properties\\":{\\"markdown\\":\\"# Test/ConstructHub/Sources/NpmJs\\\\n\\\\n[button:primary:NpmJs Follower](/lambda/home#/functions/",
               Object {
                 "Ref": "ConstructHubSourcesNpmJs15A77D2D",
               },
@@ -22779,7 +24761,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubSourcesNpmJsStagingBucketB286F0E6",
               },
-              "?prefix=couchdb-last-transaction-id.2)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":26,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Function Health\\",\\"region\\":\\"",
+              "?prefix=couchdb-last-transaction-id.2)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":33,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Function Health\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -22791,11 +24773,11 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubSourcesNpmJs15A77D2D",
               },
-              "\\",{\\"label\\":\\"Errors\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55\\"}],[\\"ConstructHub/PackageSource/NpmJs/Follower\\",\\"RemainingTime\\",{\\"label\\":\\"Remaining Time\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":900}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":26,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"CouchDB Follower\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Errors\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55\\"}],[\\"ConstructHub/PackageSource/NpmJs/Follower\\",\\"RemainingTime\\",{\\"label\\":\\"Remaining Time\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":900}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":33,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"CouchDB Follower\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[\\"ConstructHub/PackageSource/NpmJs/Follower\\",\\"ChangeCount\\",{\\"label\\":\\"Change Count\\",\\"stat\\":\\"Sum\\"}],[\\"ConstructHub/PackageSource/NpmJs/Follower\\",\\"UnprocessableEntity\\",{\\"label\\":\\"Unprocessable\\",\\"stat\\":\\"Sum\\"}],[{\\"label\\":\\"Lag to npmjs.com\\",\\"expression\\":\\"FILL(m4d6c513faac55be4bca785e8587a9a145b65f5fe675318c9c5c52f3ada197b7b, REPEAT)\\",\\"yAxis\\":\\"right\\"}],[\\"ConstructHub/PackageSource/NpmJs/Follower\\",\\"NpmJsChangeAge\\",{\\"label\\":\\"Lag to npmjs.com\\",\\"stat\\":\\"Minimum\\",\\"visible\\":false,\\"id\\":\\"m4d6c513faac55be4bca785e8587a9a145b65f5fe675318c9c5c52f3ada197b7b\\"}],[{\\"label\\":\\"Package Version Age\\",\\"expression\\":\\"FILL(mec485aa83505431ed7a356970082cd4815c310504ff176dd3eeb241ae7bbf0c4, REPEAT)\\",\\"yAxis\\":\\"right\\"}],[\\"ConstructHub/PackageSource/NpmJs/Follower\\",\\"PackageVersionAge\\",{\\"label\\":\\"Package Version Age\\",\\"stat\\":\\"Maximum\\",\\"visible\\":false,\\"id\\":\\"mec485aa83505431ed7a356970082cd4815c310504ff176dd3eeb241ae7bbf0c4\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"label\\":\\"Milliseconds\\",\\"min\\":0,\\"showUnits\\":false}},\\"period\\":900}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":32,\\"properties\\":{\\"markdown\\":\\"# Ingestion Function\\\\n\\\\n[button:Ingestion Function](/lambda/home#/functions/",
+              "\\",\\"metrics\\":[[\\"ConstructHub/PackageSource/NpmJs/Follower\\",\\"ChangeCount\\",{\\"label\\":\\"Change Count\\",\\"stat\\":\\"Sum\\"}],[\\"ConstructHub/PackageSource/NpmJs/Follower\\",\\"UnprocessableEntity\\",{\\"label\\":\\"Unprocessable\\",\\"stat\\":\\"Sum\\"}],[{\\"label\\":\\"Lag to npmjs.com\\",\\"expression\\":\\"FILL(m4d6c513faac55be4bca785e8587a9a145b65f5fe675318c9c5c52f3ada197b7b, REPEAT)\\",\\"yAxis\\":\\"right\\"}],[\\"ConstructHub/PackageSource/NpmJs/Follower\\",\\"NpmJsChangeAge\\",{\\"label\\":\\"Lag to npmjs.com\\",\\"stat\\":\\"Minimum\\",\\"visible\\":false,\\"id\\":\\"m4d6c513faac55be4bca785e8587a9a145b65f5fe675318c9c5c52f3ada197b7b\\"}],[{\\"label\\":\\"Package Version Age\\",\\"expression\\":\\"FILL(mec485aa83505431ed7a356970082cd4815c310504ff176dd3eeb241ae7bbf0c4, REPEAT)\\",\\"yAxis\\":\\"right\\"}],[\\"ConstructHub/PackageSource/NpmJs/Follower\\",\\"PackageVersionAge\\",{\\"label\\":\\"Package Version Age\\",\\"stat\\":\\"Maximum\\",\\"visible\\":false,\\"id\\":\\"mec485aa83505431ed7a356970082cd4815c310504ff176dd3eeb241ae7bbf0c4\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"label\\":\\"Milliseconds\\",\\"min\\":0,\\"showUnits\\":false}},\\"period\\":900}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":39,\\"properties\\":{\\"markdown\\":\\"# Ingestion Function\\\\n\\\\n[button:Ingestion Function](/lambda/home#/functions/",
               Object {
                 "Ref": "ConstructHubIngestion407909CE",
               },
@@ -22818,7 +24800,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              ")\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":34,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Function Health\\",\\"region\\":\\"",
+              ")\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":41,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Function Health\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -22830,7 +24812,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubIngestion407909CE",
               },
-              "\\",{\\"label\\":\\"Errors\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":34,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Input Queue\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Errors\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":41,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Input Queue\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -22855,11 +24837,11 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"period\\":60,\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ffa500\\",\\"label\\":\\"10 Minutes\\",\\"value\\":600,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":40,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Input Quality\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"period\\":60,\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ffa500\\",\\"label\\":\\"10 Minutes\\",\\"value\\":600,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":47,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Input Quality\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"stacked\\":true,\\"metrics\\":[[{\\"label\\":\\"Invalid Assemblies\\",\\"expression\\":\\"FILL(m0c5f10aa73687a21aa44b8985d19311246bca6c2cd1b2256b9f3e78c71e94fa3, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"InvalidAssembly\\",{\\"label\\":\\"Invalid Assemblies\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m0c5f10aa73687a21aa44b8985d19311246bca6c2cd1b2256b9f3e78c71e94fa3\\"}],[{\\"label\\":\\"Invalid Tarball\\",\\"expression\\":\\"FILL(m3a39d9b0bf974255f27dc95e44c8574bdfce2b97e49a7504346a77c5c9f6a3e1, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"InvalidTarball\\",{\\"label\\":\\"Invalid Tarball\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3a39d9b0bf974255f27dc95e44c8574bdfce2b97e49a7504346a77c5c9f6a3e1\\"}],[{\\"label\\":\\"Ineligible License\\",\\"expression\\":\\"FILL(me19ae9c3f20ae715e3462f9402684a3817282218f36e69494a60bc251e3435a6, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"IneligibleLicense\\",{\\"label\\":\\"Ineligible License\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"me19ae9c3f20ae715e3462f9402684a3817282218f36e69494a60bc251e3435a6\\"}],[{\\"label\\":\\"Mismatched Identity\\",\\"expression\\":\\"FILL(m7c1d407f17f8d2452a0bf87ac06fdd032de385a2758254f4192d6e17ed40d44b, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"MismatchedIdentityRejections\\",{\\"label\\":\\"Mismatched Identity\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m7c1d407f17f8d2452a0bf87ac06fdd032de385a2758254f4192d6e17ed40d44b\\"}],[{\\"label\\":\\"Found License file\\",\\"expression\\":\\"FILL(m7084dfec3c5bab86694d7ae438460f471c174a94bc67c9c9738e3ab60246b661, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"FoundLicenseFile\\",{\\"label\\":\\"Found License file\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m7084dfec3c5bab86694d7ae438460f471c174a94bc67c9c9738e3ab60246b661\\"}]],\\"yAxis\\":{\\"left\\":{\\"label\\":\\"Count\\",\\"min\\":0,\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":40,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Dead Letters\\",\\"region\\":\\"",
+              "\\",\\"stacked\\":true,\\"metrics\\":[[{\\"label\\":\\"Invalid Assemblies\\",\\"expression\\":\\"FILL(m0c5f10aa73687a21aa44b8985d19311246bca6c2cd1b2256b9f3e78c71e94fa3, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"InvalidAssembly\\",{\\"label\\":\\"Invalid Assemblies\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m0c5f10aa73687a21aa44b8985d19311246bca6c2cd1b2256b9f3e78c71e94fa3\\"}],[{\\"label\\":\\"Invalid Tarball\\",\\"expression\\":\\"FILL(m3a39d9b0bf974255f27dc95e44c8574bdfce2b97e49a7504346a77c5c9f6a3e1, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"InvalidTarball\\",{\\"label\\":\\"Invalid Tarball\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3a39d9b0bf974255f27dc95e44c8574bdfce2b97e49a7504346a77c5c9f6a3e1\\"}],[{\\"label\\":\\"Ineligible License\\",\\"expression\\":\\"FILL(me19ae9c3f20ae715e3462f9402684a3817282218f36e69494a60bc251e3435a6, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"IneligibleLicense\\",{\\"label\\":\\"Ineligible License\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"me19ae9c3f20ae715e3462f9402684a3817282218f36e69494a60bc251e3435a6\\"}],[{\\"label\\":\\"Mismatched Identity\\",\\"expression\\":\\"FILL(m7c1d407f17f8d2452a0bf87ac06fdd032de385a2758254f4192d6e17ed40d44b, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"MismatchedIdentityRejections\\",{\\"label\\":\\"Mismatched Identity\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m7c1d407f17f8d2452a0bf87ac06fdd032de385a2758254f4192d6e17ed40d44b\\"}],[{\\"label\\":\\"Found License file\\",\\"expression\\":\\"FILL(m7084dfec3c5bab86694d7ae438460f471c174a94bc67c9c9738e3ab60246b661, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"FoundLicenseFile\\",{\\"label\\":\\"Found License file\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m7084dfec3c5bab86694d7ae438460f471c174a94bc67c9c9738e3ab60246b661\\"}]],\\"yAxis\\":{\\"left\\":{\\"label\\":\\"Count\\",\\"min\\":0,\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":47,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Dead Letters\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -22884,7 +24866,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":46,\\"properties\\":{\\"markdown\\":\\"# Orchestration\\\\n\\\\n[button:State Machine](/states/home#/statemachines/view/",
+              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":53,\\"properties\\":{\\"markdown\\":\\"# Orchestration\\\\n\\\\n[button:State Machine](/states/home#/statemachines/view/",
               Object {
                 "Ref": "ConstructHubOrchestration39161A46",
               },
@@ -22911,7 +24893,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubOrchestrationReprocessAllFF2F2455",
               },
-              ")\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":48,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"State Machine Executions\\",\\"region\\":\\"",
+              ")\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":55,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"State Machine Executions\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -22943,7 +24925,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubOrchestration39161A46",
               },
-              "\\",{\\"label\\":\\"Duration\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":48,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Dead Letter Queue\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Duration\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":55,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Dead Letter Queue\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -22968,7 +24950,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":54,\\"properties\\":{\\"markdown\\":\\"# Deny List\\\\n\\\\n[button:Deny List Object](/s3/object/",
+              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":61,\\"properties\\":{\\"markdown\\":\\"# Deny List\\\\n\\\\n[button:Deny List Object](/s3/object/",
               Object {
                 "Ref": "ConstructHubDenyListBucket1B3C2C2E",
               },
@@ -22999,7 +24981,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubDenyListPrunePruneQueueHandlerF7EB599B",
               },
-              "/log-events)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":56,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Deny List\\",\\"region\\":\\"",
+              "/log-events)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":63,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Deny List\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -23010,7 +24992,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              "\\",{\\"label\\":\\"Deleted Files\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":300}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":56,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Prune Function Health\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Deleted Files\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":300}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":63,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Prune Function Health\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -23828,7 +25810,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersbec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ecS3BucketE3CFE68F",
+            "Ref": "AssetParametersff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2S3BucketBC914BA2",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -23841,7 +25823,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersbec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ecS3VersionKey6D99058D",
+                          "Ref": "AssetParametersff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2S3VersionKey1681742D",
                         },
                       ],
                     },
@@ -23854,7 +25836,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersbec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ecS3VersionKey6D99058D",
+                          "Ref": "AssetParametersff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2S3VersionKey1681742D",
                         },
                       ],
                     },
@@ -24249,7 +26231,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersa7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100S3BucketA07EA20C",
+            "Ref": "AssetParameters9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4bS3BucketF0A4F598",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -24262,7 +26244,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersa7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100S3VersionKeyBF4D0B81",
+                          "Ref": "AssetParameters9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4bS3VersionKey5E4628BC",
                         },
                       ],
                     },
@@ -24275,7 +26257,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersa7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100S3VersionKeyBF4D0B81",
+                          "Ref": "AssetParameters9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4bS3VersionKey5E4628BC",
                         },
                       ],
                     },
@@ -25304,7 +27286,18 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              "\\",\\"Payload.$\\":\\"$\\"}},\\"\\\\\\"Generate typescript docs\\\\\\" throttled\\":{\\"Type\\":\\"Pass\\",\\"Parameters\\":{\\"error.$\\":\\"$.Cause\\",\\"language\\":{\\"lang\\":\\"typescript\\"}},\\"End\\":true},\\"\\\\\\"Generate typescript docs\\\\\\" failure\\":{\\"Type\\":\\"Pass\\",\\"Parameters\\":{\\"error.$\\":\\"States.StringToJson($.Cause)\\",\\"language\\":{\\"lang\\":\\"typescript\\"}},\\"End\\":true},\\"\\\\\\"Generate typescript docs\\\\\\" fault\\":{\\"Type\\":\\"Pass\\",\\"Parameters\\":{\\"error.$\\":\\"$.Cause\\",\\"language\\":{\\"lang\\":\\"typescript\\"}},\\"End\\":true}}}]},\\"Any Success?\\":{\\"Type\\":\\"Choice\\",\\"Choices\\":[{\\"Or\\":[{\\"Variable\\":\\"$.DocGen[0].error\\",\\"IsPresent\\":false},{\\"Variable\\":\\"$.DocGen[1].error\\",\\"IsPresent\\":false}],\\"Next\\":\\"Add to catalog.json\\"}],\\"Default\\":\\"Any Failure?\\"},\\"Any Failure?\\":{\\"Type\\":\\"Choice\\",\\"Choices\\":[{\\"Or\\":[{\\"Variable\\":\\"$.DocGen[0].error\\",\\"IsPresent\\":true},{\\"Variable\\":\\"$.DocGen[1].error\\",\\"IsPresent\\":true}],\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Default\\":\\"Success\\"},\\"Add to catalog.json\\":{\\"Next\\":\\"Any Failure?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"Lambda.ServiceException\\",\\"Lambda.AWSLambdaException\\",\\"Lambda.SdkClientException\\"],\\"IntervalSeconds\\":2,\\"MaxAttempts\\":6,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":5}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"Next\\":\\"\\\\\\"Add to catalog.json\\\\\\" throttled\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"Next\\":\\"\\\\\\"Add to catalog.json\\\\\\" failure\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"Next\\":\\"\\\\\\"Add to catalog.json\\\\\\" fault\\"}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.catalogBuilderOutput\\",\\"ResultSelector\\":{\\"ETag.$\\":\\"$.Payload.ETag\\",\\"VersionId.$\\":\\"$.Payload.VersionId\\"},\\"Resource\\":\\"arn:",
+              "\\",\\"Payload.$\\":\\"$\\"}},\\"\\\\\\"Generate typescript docs\\\\\\" throttled\\":{\\"Type\\":\\"Pass\\",\\"Parameters\\":{\\"error.$\\":\\"$.Cause\\",\\"language\\":{\\"lang\\":\\"typescript\\"}},\\"End\\":true},\\"\\\\\\"Generate typescript docs\\\\\\" failure\\":{\\"Type\\":\\"Pass\\",\\"Parameters\\":{\\"error.$\\":\\"States.StringToJson($.Cause)\\",\\"language\\":{\\"lang\\":\\"typescript\\"}},\\"End\\":true},\\"\\\\\\"Generate typescript docs\\\\\\" fault\\":{\\"Type\\":\\"Pass\\",\\"Parameters\\":{\\"error.$\\":\\"$.Cause\\",\\"language\\":{\\"lang\\":\\"typescript\\"}},\\"End\\":true}}},{\\"StartAt\\":\\"Generate java docs\\",\\"States\\":{\\"Generate java docs\\":{\\"End\\":true,\\"Retry\\":[{\\"ErrorEquals\\":[\\"Lambda.ServiceException\\",\\"Lambda.AWSLambdaException\\",\\"Lambda.SdkClientException\\"],\\"IntervalSeconds\\":2,\\"MaxAttempts\\":6,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"IntervalSeconds\\":30}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"Next\\":\\"\\\\\\"Generate java docs\\\\\\" throttled\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"Next\\":\\"\\\\\\"Generate java docs\\\\\\" failure\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"Next\\":\\"\\\\\\"Generate java docs\\\\\\" fault\\"}],\\"Type\\":\\"Task\\",\\"OutputPath\\":\\"$.result\\",\\"ResultSelector\\":{\\"result\\":{\\"language\\":{\\"lang\\":\\"java\\"},\\"success.$\\":\\"$.Payload\\"}},\\"Resource\\":\\"arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":states:::lambda:invoke\\",\\"Parameters\\":{\\"FunctionName\\":\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ConstructHubOrchestrationDocGenjava0F6D30AF",
+                  "Arn",
+                ],
+              },
+              "\\",\\"Payload.$\\":\\"$\\"}},\\"\\\\\\"Generate java docs\\\\\\" throttled\\":{\\"Type\\":\\"Pass\\",\\"Parameters\\":{\\"error.$\\":\\"$.Cause\\",\\"language\\":{\\"lang\\":\\"java\\"}},\\"End\\":true},\\"\\\\\\"Generate java docs\\\\\\" failure\\":{\\"Type\\":\\"Pass\\",\\"Parameters\\":{\\"error.$\\":\\"States.StringToJson($.Cause)\\",\\"language\\":{\\"lang\\":\\"java\\"}},\\"End\\":true},\\"\\\\\\"Generate java docs\\\\\\" fault\\":{\\"Type\\":\\"Pass\\",\\"Parameters\\":{\\"error.$\\":\\"$.Cause\\",\\"language\\":{\\"lang\\":\\"java\\"}},\\"End\\":true}}}]},\\"Any Success?\\":{\\"Type\\":\\"Choice\\",\\"Choices\\":[{\\"Or\\":[{\\"Variable\\":\\"$.DocGen[0].error\\",\\"IsPresent\\":false},{\\"Variable\\":\\"$.DocGen[1].error\\",\\"IsPresent\\":false},{\\"Variable\\":\\"$.DocGen[2].error\\",\\"IsPresent\\":false}],\\"Next\\":\\"Add to catalog.json\\"}],\\"Default\\":\\"Any Failure?\\"},\\"Any Failure?\\":{\\"Type\\":\\"Choice\\",\\"Choices\\":[{\\"Or\\":[{\\"Variable\\":\\"$.DocGen[0].error\\",\\"IsPresent\\":true},{\\"Variable\\":\\"$.DocGen[1].error\\",\\"IsPresent\\":true},{\\"Variable\\":\\"$.DocGen[2].error\\",\\"IsPresent\\":true}],\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Default\\":\\"Success\\"},\\"Add to catalog.json\\":{\\"Next\\":\\"Any Failure?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"Lambda.ServiceException\\",\\"Lambda.AWSLambdaException\\",\\"Lambda.SdkClientException\\"],\\"IntervalSeconds\\":2,\\"MaxAttempts\\":6,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":5}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"Next\\":\\"\\\\\\"Add to catalog.json\\\\\\" throttled\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"Next\\":\\"\\\\\\"Add to catalog.json\\\\\\" failure\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"Next\\":\\"\\\\\\"Add to catalog.json\\\\\\" fault\\"}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.catalogBuilderOutput\\",\\"ResultSelector\\":{\\"ETag.$\\":\\"$.Payload.ETag\\",\\"VersionId.$\\":\\"$.Payload.VersionId\\"},\\"Resource\\":\\"arn:",
               Object {
                 "Ref": "AWS::Partition",
               },
@@ -25348,7 +27341,7 @@ Direct link to function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersdef5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9S3Bucket693007CE",
+            "Ref": "AssetParameterse0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813S3Bucket55321DF2",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -25361,7 +27354,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersdef5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9S3VersionKeyA7862DEC",
+                          "Ref": "AssetParameterse0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813S3VersionKey325A408D",
                         },
                       ],
                     },
@@ -25374,7 +27367,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersdef5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9S3VersionKeyA7862DEC",
+                          "Ref": "AssetParameterse0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813S3VersionKey325A408D",
                         },
                       ],
                     },
@@ -25667,15 +27660,15 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "ConstructHubOrchestrationDocGenpython77179663": Object {
+    "ConstructHubOrchestrationDocGenjava0F6D30AF": Object {
       "DependsOn": Array [
-        "ConstructHubOrchestrationDocGenpythonServiceRoleDefaultPolicy7A9DA724",
-        "ConstructHubOrchestrationDocGenpythonServiceRoleD16CBDB2",
+        "ConstructHubOrchestrationDocGenjavaServiceRoleDefaultPolicy8819DA50",
+        "ConstructHubOrchestrationDocGenjavaServiceRoleA6039136",
       ],
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7",
+            "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3Bucket38537BD6",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -25688,7 +27681,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35",
                         },
                       ],
                     },
@@ -25701,7 +27694,352 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            ],
+          },
+        },
+        "Description": "Creates java documentation from jsii-enabled npm packages",
+        "Environment": Object {
+          "Variables": Object {
+            "CODE_ARTIFACT_DOMAIN_NAME": Object {
+              "Fn::GetAtt": Array [
+                "ConstructHubCodeArtifact1188409E",
+                "DomainName",
+              ],
+            },
+            "CODE_ARTIFACT_DOMAIN_OWNER": Object {
+              "Fn::GetAtt": Array [
+                "ConstructHubCodeArtifact1188409E",
+                "DomainOwner",
+              ],
+            },
+            "CODE_ARTIFACT_REPOSITORY_ENDPOINT": Object {
+              "Fn::GetAtt": Array [
+                "ConstructHubCodeArtifactGetEndpoint9A458FEF",
+                "repositoryEndpoint",
+              ],
+            },
+            "HEADER_SPAN": "true",
+            "TARGET_LANGUAGE": "java",
+          },
+        },
+        "Handler": "index.handler",
+        "MemorySize": 10240,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "ConstructHubOrchestrationDocGenjavaServiceRoleA6039136",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+        "Timeout": 900,
+        "TracingConfig": Object {
+          "Mode": "PassThrough",
+        },
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "ConstructHubOrchestrationDocGenjavaLogRetention55FBE552": Object {
+      "Properties": Object {
+        "LogGroupName": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "/aws/lambda/",
+              Object {
+                "Ref": "ConstructHubOrchestrationDocGenjava0F6D30AF",
+              },
+            ],
+          ],
+        },
+        "RetentionInDays": 3653,
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::LogRetention",
+    },
+    "ConstructHubOrchestrationDocGenjavaServiceRoleA6039136": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ConstructHubOrchestrationDocGenjavaServiceRoleDefaultPolicy8819DA50": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "xray:PutTraceSegments",
+                "xray:PutTelemetryRecords",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            Object {
+              "Action": "sts:GetServiceBearerToken",
+              "Condition": Object {
+                "StringEquals": Object {
+                  "sts:AWSServiceName": "codeartifact.amazonaws.com",
+                },
+              },
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            Object {
+              "Action": Array [
+                "codeartifact:GetAuthorizationToken",
+                "codeartifact:GetRepositoryEndpoint",
+                "codeartifact:ReadFromRepository",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubCodeArtifactDomainFC30B796",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubCodeArtifact1188409E",
+                    "Arn",
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/assembly.json",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-java.md",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-java.md",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-java.md.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-java.md.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ConstructHubOrchestrationDocGenjavaServiceRoleDefaultPolicy8819DA50",
+        "Roles": Array [
+          Object {
+            "Ref": "ConstructHubOrchestrationDocGenjavaServiceRoleA6039136",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ConstructHubOrchestrationDocGenpython77179663": Object {
+      "DependsOn": Array [
+        "ConstructHubOrchestrationDocGenpythonServiceRoleDefaultPolicy7A9DA724",
+        "ConstructHubOrchestrationDocGenpythonServiceRoleD16CBDB2",
+      ],
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3Bucket38537BD6",
+          },
+          "S3Key": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                Object {
+                  "Fn::Select": Array [
+                    0,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                Object {
+                  "Fn::Select": Array [
+                    1,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35",
                         },
                       ],
                     },
@@ -26020,7 +28358,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7",
+            "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3Bucket38537BD6",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -26033,7 +28371,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35",
                         },
                       ],
                     },
@@ -26046,7 +28384,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35",
                         },
                       ],
                     },
@@ -26555,7 +28893,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersb191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17S3Bucket60674A76",
+            "Ref": "AssetParameters68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513S3Bucket942ED5A2",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -26568,7 +28906,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersb191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17S3VersionKey724F7AFD",
+                          "Ref": "AssetParameters68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513S3VersionKeyF5E68355",
                         },
                       ],
                     },
@@ -26581,7 +28919,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersb191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17S3VersionKey724F7AFD",
+                          "Ref": "AssetParameters68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513S3VersionKeyF5E68355",
                         },
                       ],
                     },
@@ -26760,6 +29098,16 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
               "Resource": Object {
                 "Fn::GetAtt": Array [
                   "ConstructHubOrchestrationDocGentypescriptF9C30384",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "ConstructHubOrchestrationDocGenjava0F6D30AF",
                   "Arn",
                 ],
               },

--- a/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
+++ b/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
@@ -216,7 +216,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7",
+            "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3Bucket38537BD6",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -229,7 +229,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35",
                         },
                       ],
                     },
@@ -242,7 +242,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35",
                         },
                       ],
                     },
@@ -683,7 +683,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7",
+            "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3Bucket38537BD6",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -696,7 +696,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35",
                         },
                       ],
                     },
@@ -709,7 +709,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35",
                         },
                       ],
                     },
@@ -1269,7 +1269,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7",
+            "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3Bucket38537BD6",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -1282,7 +1282,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35",
                         },
                       ],
                     },
@@ -1295,7 +1295,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35",
                         },
                       ],
                     },
@@ -1815,7 +1815,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7",
+            "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3Bucket38537BD6",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -1828,7 +1828,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35",
                         },
                       ],
                     },
@@ -1841,7 +1841,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9",
+                          "Ref": "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35",
                         },
                       ],
                     },

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -782,6 +782,33 @@ Resources:
               - Fn::GetAtt:
                   - ConstructHubCodeArtifact1188409E
                   - Arn
+          - Action: sts:GetServiceBearerToken
+            Condition:
+              StringEquals:
+                sts:AWSServiceName: codeartifact.amazonaws.com
+            Effect: Allow
+            Principal:
+              AWS:
+                Fn::GetAtt:
+                  - ConstructHubOrchestrationDocGenjavaServiceRoleA6039136
+                  - Arn
+            Resource: "*"
+          - Action:
+              - codeartifact:GetAuthorizationToken
+              - codeartifact:GetRepositoryEndpoint
+            Effect: Allow
+            Principal:
+              AWS:
+                Fn::GetAtt:
+                  - ConstructHubOrchestrationDocGenjavaServiceRoleA6039136
+                  - Arn
+            Resource:
+              - Fn::GetAtt:
+                  - ConstructHubCodeArtifactDomainFC30B796
+                  - Arn
+              - Fn::GetAtt:
+                  - ConstructHubCodeArtifact1188409E
+                  - Arn
         Version: 2012-10-17
       PrivateDnsEnabled: false
       SecurityGroupIds:
@@ -851,6 +878,17 @@ Resources:
               AWS:
                 Fn::GetAtt:
                   - ConstructHubOrchestrationDocGentypescriptServiceRoleB56C2B19
+                  - Arn
+            Resource:
+              Fn::GetAtt:
+                - ConstructHubCodeArtifact1188409E
+                - Arn
+          - Action: codeartifact:ReadFromRepository
+            Effect: Allow
+            Principal:
+              AWS:
+                Fn::GetAtt:
+                  - ConstructHubOrchestrationDocGenjavaServiceRoleA6039136
                   - Arn
             Resource:
               Fn::GetAtt:
@@ -1044,6 +1082,74 @@ Resources:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
                     - /data/*/docs-*-typescript.md.not-supported
+          - Action:
+              - s3:Abort*
+              - s3:DeleteObject*
+              - s3:PutObject*
+            Effect: Allow
+            Principal:
+              AWS: "*"
+            Resource:
+              - Fn::GetAtt:
+                  - ConstructHubPackageDataDC5EF35E
+                  - Arn
+              - Fn::Join:
+                  - ""
+                  - - Fn::GetAtt:
+                        - ConstructHubPackageDataDC5EF35E
+                        - Arn
+                    - /data/*/docs-java.md
+          - Action:
+              - s3:Abort*
+              - s3:DeleteObject*
+              - s3:PutObject*
+            Effect: Allow
+            Principal:
+              AWS: "*"
+            Resource:
+              - Fn::GetAtt:
+                  - ConstructHubPackageDataDC5EF35E
+                  - Arn
+              - Fn::Join:
+                  - ""
+                  - - Fn::GetAtt:
+                        - ConstructHubPackageDataDC5EF35E
+                        - Arn
+                    - /data/*/docs-*-java.md
+          - Action:
+              - s3:Abort*
+              - s3:DeleteObject*
+              - s3:PutObject*
+            Effect: Allow
+            Principal:
+              AWS: "*"
+            Resource:
+              - Fn::GetAtt:
+                  - ConstructHubPackageDataDC5EF35E
+                  - Arn
+              - Fn::Join:
+                  - ""
+                  - - Fn::GetAtt:
+                        - ConstructHubPackageDataDC5EF35E
+                        - Arn
+                    - /data/*/docs-java.md.not-supported
+          - Action:
+              - s3:Abort*
+              - s3:DeleteObject*
+              - s3:PutObject*
+            Effect: Allow
+            Principal:
+              AWS: "*"
+            Resource:
+              - Fn::GetAtt:
+                  - ConstructHubPackageDataDC5EF35E
+                  - Arn
+              - Fn::Join:
+                  - ""
+                  - - Fn::GetAtt:
+                        - ConstructHubPackageDataDC5EF35E
+                        - Arn
+                    - /data/*/docs-*-java.md.not-supported
         Version: 2012-10-17
       RouteTableIds:
         - Ref: ConstructHubLambdaVPCIsolatedSubnet1RouteTable65529AB4
@@ -1558,7 +1664,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParametersdef5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9S3Bucket693007CE
+          Ref: AssetParameterse0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813S3Bucket55321DF2
         S3Key:
           Fn::Join:
             - ""
@@ -1566,12 +1672,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersdef5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9S3VersionKeyA7862DEC
+                      - Ref: AssetParameterse0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813S3VersionKey325A408D
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersdef5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9S3VersionKeyA7862DEC
+                      - Ref: AssetParameterse0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813S3VersionKey325A408D
       Role:
         Fn::GetAtt:
           - ConstructHubOrchestrationCatalogBuilderServiceRole851C750C
@@ -1755,7 +1861,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7
+          Ref: AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3Bucket38537BD6
         S3Key:
           Fn::Join:
             - ""
@@ -1763,12 +1869,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9
+                      - Ref: AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9
+                      - Ref: AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35
       Role:
         Fn::GetAtt:
           - ConstructHubOrchestrationDocGenpythonServiceRoleD16CBDB2
@@ -1974,7 +2080,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7
+          Ref: AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3Bucket38537BD6
         S3Key:
           Fn::Join:
             - ""
@@ -1982,12 +2088,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9
+                      - Ref: AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9
+                      - Ref: AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35
       Role:
         Fn::GetAtt:
           - ConstructHubOrchestrationDocGentypescriptServiceRoleB56C2B19
@@ -2049,6 +2155,225 @@ Resources:
           - - /aws/lambda/
             - Ref: ConstructHubOrchestrationDocGentypescriptF9C30384
       RetentionInDays: 3653
+  ConstructHubOrchestrationDocGenjavaServiceRoleA6039136:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: 2012-10-17
+      ManagedPolicyArns:
+        - Fn::Join:
+            - ""
+            - - "arn:"
+              - Ref: AWS::Partition
+              - :iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - Fn::Join:
+            - ""
+            - - "arn:"
+              - Ref: AWS::Partition
+              - :iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+  ConstructHubOrchestrationDocGenjavaServiceRoleDefaultPolicy8819DA50:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - xray:PutTraceSegments
+              - xray:PutTelemetryRecords
+            Effect: Allow
+            Resource: "*"
+          - Action: sts:GetServiceBearerToken
+            Condition:
+              StringEquals:
+                sts:AWSServiceName: codeartifact.amazonaws.com
+            Effect: Allow
+            Resource: "*"
+          - Action:
+              - codeartifact:GetAuthorizationToken
+              - codeartifact:GetRepositoryEndpoint
+              - codeartifact:ReadFromRepository
+            Effect: Allow
+            Resource:
+              - Fn::GetAtt:
+                  - ConstructHubCodeArtifactDomainFC30B796
+                  - Arn
+              - Fn::GetAtt:
+                  - ConstructHubCodeArtifact1188409E
+                  - Arn
+          - Action:
+              - s3:GetObject*
+              - s3:GetBucket*
+              - s3:List*
+            Effect: Allow
+            Resource:
+              - Fn::GetAtt:
+                  - ConstructHubPackageDataDC5EF35E
+                  - Arn
+              - Fn::Join:
+                  - ""
+                  - - Fn::GetAtt:
+                        - ConstructHubPackageDataDC5EF35E
+                        - Arn
+                    - /data/*/assembly.json
+          - Action:
+              - s3:DeleteObject*
+              - s3:PutObject*
+              - s3:Abort*
+            Effect: Allow
+            Resource:
+              - Fn::GetAtt:
+                  - ConstructHubPackageDataDC5EF35E
+                  - Arn
+              - Fn::Join:
+                  - ""
+                  - - Fn::GetAtt:
+                        - ConstructHubPackageDataDC5EF35E
+                        - Arn
+                    - /data/*/docs-java.md
+          - Action:
+              - s3:DeleteObject*
+              - s3:PutObject*
+              - s3:Abort*
+            Effect: Allow
+            Resource:
+              - Fn::GetAtt:
+                  - ConstructHubPackageDataDC5EF35E
+                  - Arn
+              - Fn::Join:
+                  - ""
+                  - - Fn::GetAtt:
+                        - ConstructHubPackageDataDC5EF35E
+                        - Arn
+                    - /data/*/docs-*-java.md
+          - Action:
+              - s3:DeleteObject*
+              - s3:PutObject*
+              - s3:Abort*
+            Effect: Allow
+            Resource:
+              - Fn::GetAtt:
+                  - ConstructHubPackageDataDC5EF35E
+                  - Arn
+              - Fn::Join:
+                  - ""
+                  - - Fn::GetAtt:
+                        - ConstructHubPackageDataDC5EF35E
+                        - Arn
+                    - /data/*/docs-java.md.not-supported
+          - Action:
+              - s3:DeleteObject*
+              - s3:PutObject*
+              - s3:Abort*
+            Effect: Allow
+            Resource:
+              - Fn::GetAtt:
+                  - ConstructHubPackageDataDC5EF35E
+                  - Arn
+              - Fn::Join:
+                  - ""
+                  - - Fn::GetAtt:
+                        - ConstructHubPackageDataDC5EF35E
+                        - Arn
+                    - /data/*/docs-*-java.md.not-supported
+        Version: 2012-10-17
+      PolicyName: ConstructHubOrchestrationDocGenjavaServiceRoleDefaultPolicy8819DA50
+      Roles:
+        - Ref: ConstructHubOrchestrationDocGenjavaServiceRoleA6039136
+  ConstructHubOrchestrationDocGenjavaSecurityGroup72D0C513:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Automatic security group for Lambda Function
+        devConstructHubOrchestrationDocGenjavaE9C0271C
+      SecurityGroupEgress:
+        - CidrIp: 0.0.0.0/0
+          Description: Allow all outbound traffic by default
+          IpProtocol: "-1"
+      VpcId:
+        Ref: ConstructHubLambdaVPCE85ABF51
+  ConstructHubOrchestrationDocGenjava0F6D30AF:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        S3Bucket:
+          Ref: AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3Bucket38537BD6
+        S3Key:
+          Fn::Join:
+            - ""
+            - - Fn::Select:
+                  - 0
+                  - Fn::Split:
+                      - "||"
+                      - Ref: AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35
+              - Fn::Select:
+                  - 1
+                  - Fn::Split:
+                      - "||"
+                      - Ref: AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35
+      Role:
+        Fn::GetAtt:
+          - ConstructHubOrchestrationDocGenjavaServiceRoleA6039136
+          - Arn
+      Description: Creates java documentation from jsii-enabled npm packages
+      Environment:
+        Variables:
+          HEADER_SPAN: "true"
+          TARGET_LANGUAGE: java
+          CODE_ARTIFACT_API_ENDPOINT:
+            Fn::Select:
+              - 1
+              - Fn::Split:
+                  - ":"
+                  - Fn::Select:
+                      - 0
+                      - Fn::GetAtt:
+                          - ConstructHubLambdaVPCCodeArtifactAPI0A2356B9
+                          - DnsEntries
+          CODE_ARTIFACT_DOMAIN_NAME:
+            Fn::GetAtt:
+              - ConstructHubCodeArtifact1188409E
+              - DomainName
+          CODE_ARTIFACT_DOMAIN_OWNER:
+            Fn::GetAtt:
+              - ConstructHubCodeArtifact1188409E
+              - DomainOwner
+          CODE_ARTIFACT_REPOSITORY_ENDPOINT:
+            Fn::GetAtt:
+              - ConstructHubCodeArtifactGetEndpoint9A458FEF
+              - repositoryEndpoint
+      Handler: index.handler
+      MemorySize: 10240
+      Runtime: nodejs14.x
+      Timeout: 900
+      TracingConfig:
+        Mode: PassThrough
+      VpcConfig:
+        SecurityGroupIds:
+          - Fn::GetAtt:
+              - ConstructHubOrchestrationDocGenjavaSecurityGroup72D0C513
+              - GroupId
+        SubnetIds:
+          - Ref: ConstructHubLambdaVPCIsolatedSubnet1Subnet33EDE47B
+          - Ref: ConstructHubLambdaVPCIsolatedSubnet2Subnet825B4A7B
+    DependsOn:
+      - ConstructHubOrchestrationDocGenjavaServiceRoleDefaultPolicy8819DA50
+      - ConstructHubOrchestrationDocGenjavaServiceRoleA6039136
+  ConstructHubOrchestrationDocGenjavaLogRetention55FBE552:
+    Type: Custom::LogRetention
+    Properties:
+      ServiceToken:
+        Fn::GetAtt:
+          - LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A
+          - Arn
+      LogGroupName:
+        Fn::Join:
+          - ""
+          - - /aws/lambda/
+            - Ref: ConstructHubOrchestrationDocGenjava0F6D30AF
+      RetentionInDays: 3653
   ConstructHubOrchestrationRoleF4CF6987:
     Type: AWS::IAM::Role
     Properties:
@@ -2101,6 +2426,12 @@ Resources:
             Resource:
               Fn::GetAtt:
                 - ConstructHubOrchestrationDocGentypescriptF9C30384
+                - Arn
+          - Action: lambda:InvokeFunction
+            Effect: Allow
+            Resource:
+              Fn::GetAtt:
+                - ConstructHubOrchestrationDocGenjava0F6D30AF
                 - Arn
         Version: 2012-10-17
       PolicyName: ConstructHubOrchestrationRoleDefaultPolicyEACD181F
@@ -2158,10 +2489,29 @@ Resources:
               typescript docs\\"
               failure":{"Type":"Pass","Parameters":{"error.$":"States.StringToJson($.Cause)","language":{"lang":"typescript"}},"End":true},"\\"Generate
               typescript docs\\"
-              fault":{"Type":"Pass","Parameters":{"error.$":"$.Cause","language":{"lang":"typescript"}},"End":true}}}]},"Any
-              Success?":{"Type":"Choice","Choices":[{"Or":[{"Variable":"$.DocGen[0].error","IsPresent":false},{"Variable":"$.DocGen[1].error","IsPresent":false}],"Next":"Add
+              fault":{"Type":"Pass","Parameters":{"error.$":"$.Cause","language":{"lang":"typescript"}},"End":true}}},{"StartAt":"Generate
+              java docs","States":{"Generate java
+              docs":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":30}],"Catch":[{"ErrorEquals":["Lambda.TooManyRequestsException"],"Next":"\\"Generate
+              java docs\\"
+              throttled"},{"ErrorEquals":["States.TaskFailed"],"Next":"\\"Generate
+              java docs\\"
+              failure"},{"ErrorEquals":["States.ALL"],"Next":"\\"Generate java
+              docs\\"
+              fault"}],"Type":"Task","OutputPath":"$.result","ResultSelector":{"result":{"language":{"lang":"java"},"success.$":"$.Payload"}},"Resource":"arn:'
+            - Ref: AWS::Partition
+            - :states:::lambda:invoke","Parameters":{"FunctionName":"
+            - Fn::GetAtt:
+                - ConstructHubOrchestrationDocGenjava0F6D30AF
+                - Arn
+            - '","Payload.$":"$"}},"\\"Generate java docs\\"
+              throttled":{"Type":"Pass","Parameters":{"error.$":"$.Cause","language":{"lang":"java"}},"End":true},"\\"Generate
+              java docs\\"
+              failure":{"Type":"Pass","Parameters":{"error.$":"States.StringToJson($.Cause)","language":{"lang":"java"}},"End":true},"\\"Generate
+              java docs\\"
+              fault":{"Type":"Pass","Parameters":{"error.$":"$.Cause","language":{"lang":"java"}},"End":true}}}]},"Any
+              Success?":{"Type":"Choice","Choices":[{"Or":[{"Variable":"$.DocGen[0].error","IsPresent":false},{"Variable":"$.DocGen[1].error","IsPresent":false},{"Variable":"$.DocGen[2].error","IsPresent":false}],"Next":"Add
               to catalog.json"}],"Default":"Any Failure?"},"Any
-              Failure?":{"Type":"Choice","Choices":[{"Or":[{"Variable":"$.DocGen[0].error","IsPresent":true},{"Variable":"$.DocGen[1].error","IsPresent":true}],"Next":"Send
+              Failure?":{"Type":"Choice","Choices":[{"Or":[{"Variable":"$.DocGen[0].error","IsPresent":true},{"Variable":"$.DocGen[1].error","IsPresent":true},{"Variable":"$.DocGen[2].error","IsPresent":true}],"Next":"Send
               to Dead Letter Queue"}],"Default":"Success"},"Add to
               catalog.json":{"Next":"Any
               Failure?","Retry":[{"ErrorEquals":["Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["Lambda.TooManyRequestsException"],"IntervalSeconds":60,"MaxAttempts":5}],"Catch":[{"ErrorEquals":["Lambda.TooManyRequestsException"],"Next":"\\"Add
@@ -2365,7 +2715,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParametersb191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17S3Bucket60674A76
+          Ref: AssetParameters68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513S3Bucket942ED5A2
         S3Key:
           Fn::Join:
             - ""
@@ -2373,12 +2723,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersb191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17S3VersionKey724F7AFD
+                      - Ref: AssetParameters68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513S3VersionKeyF5E68355
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersb191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17S3VersionKey724F7AFD
+                      - Ref: AssetParameters68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513S3VersionKeyF5E68355
       Role:
         Fn::GetAtt:
           - ConstructHubOrchestrationReprocessAllServiceRoleE23FF434
@@ -2513,7 +2863,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParametersbec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ecS3BucketE3CFE68F
+          Ref: AssetParametersff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2S3BucketBC914BA2
         S3Key:
           Fn::Join:
             - ""
@@ -2521,12 +2871,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersbec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ecS3VersionKey6D99058D
+                      - Ref: AssetParametersff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2S3VersionKey1681742D
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersbec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ecS3VersionKey6D99058D
+                      - Ref: AssetParametersff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2S3VersionKey1681742D
       Role:
         Fn::GetAtt:
           - ConstructHubIngestionServiceRole6380BAB6
@@ -2792,7 +3142,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParametersa7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100S3BucketA07EA20C
+          Ref: AssetParameters9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4bS3BucketF0A4F598
         S3Key:
           Fn::Join:
             - ""
@@ -2800,12 +3150,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersa7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100S3VersionKeyBF4D0B81
+                      - Ref: AssetParameters9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4bS3VersionKey5E4628BC
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersa7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100S3VersionKeyBF4D0B81
+                      - Ref: AssetParameters9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4bS3VersionKey5E4628BC
       Role:
         Fn::GetAtt:
           - ConstructHubInventoryCanaryServiceRole7684EDDE
@@ -3232,13 +3582,27 @@ Resources:
             - '","metrics":[["ConstructHub/Inventory","SupportedSubmoduleCount","Language","python",{"color":"#2ca02c","label":"Available","stat":"Maximum"}],["ConstructHub/Inventory","UnsupportedSubmoduleCount","Language","python",{"color":"#9467bd","label":"Unsupported","stat":"Maximum"}],["ConstructHub/Inventory","MissingSubmoduleCount","Language","python",{"color":"#d62728","label":"Missing","stat":"Maximum"}]],"yAxis":{"left":{"showUnits":false}}}},{"type":"metric","width":6,"height":6,"x":18,"y":18,"properties":{"view":"timeSeries","title":"Package
               Version Submodules","region":"'
             - Ref: AWS::Region
-            - '","stacked":true,"metrics":[["ConstructHub/Inventory","SupportedSubmoduleCount","Language","python",{"color":"#2ca02c","label":"Available","stat":"Maximum"}],["ConstructHub/Inventory","UnsupportedSubmoduleCount","Language","python",{"color":"#9467bd","label":"Unsupported","stat":"Maximum"}],["ConstructHub/Inventory","MissingSubmoduleCount","Language","python",{"color":"#d62728","label":"Missing","stat":"Maximum"}]],"yAxis":{"left":{"showUnits":false}}}},{"type":"text","width":24,"height":2,"x":0,"y":24,"properties":{"markdown":"#
+            - '","stacked":true,"metrics":[["ConstructHub/Inventory","SupportedSubmoduleCount","Language","python",{"color":"#2ca02c","label":"Available","stat":"Maximum"}],["ConstructHub/Inventory","UnsupportedSubmoduleCount","Language","python",{"color":"#9467bd","label":"Unsupported","stat":"Maximum"}],["ConstructHub/Inventory","MissingSubmoduleCount","Language","python",{"color":"#d62728","label":"Missing","stat":"Maximum"}]],"yAxis":{"left":{"showUnits":false}}}},{"type":"text","width":24,"height":1,"x":0,"y":24,"properties":{"markdown":"##
+              Language:
+              java"}},{"type":"metric","width":6,"height":6,"x":0,"y":25,"properties":{"view":"pie","title":"Package
+              Versions","region":"'
+            - Ref: AWS::Region
+            - '","metrics":[["ConstructHub/Inventory","SupportedPackageVersionCount","Language","java",{"color":"#2ca02c","label":"Available","stat":"Maximum"}],["ConstructHub/Inventory","UnsupportedPackageVersionCount","Language","java",{"color":"#9467bd","label":"Unsupported","stat":"Maximum"}],["ConstructHub/Inventory","MissingPackageVersionCount","Language","java",{"color":"#d62728","label":"Missing","stat":"Maximum"}]],"yAxis":{"left":{"showUnits":false}}}},{"type":"metric","width":6,"height":6,"x":6,"y":25,"properties":{"view":"timeSeries","title":"Package
+              Versions","region":"'
+            - Ref: AWS::Region
+            - '","stacked":true,"metrics":[["ConstructHub/Inventory","SupportedPackageVersionCount","Language","java",{"color":"#2ca02c","label":"Available","stat":"Maximum"}],["ConstructHub/Inventory","UnsupportedPackageVersionCount","Language","java",{"color":"#9467bd","label":"Unsupported","stat":"Maximum"}],["ConstructHub/Inventory","MissingPackageVersionCount","Language","java",{"color":"#d62728","label":"Missing","stat":"Maximum"}]],"yAxis":{"left":{"showUnits":false}}}},{"type":"metric","width":6,"height":6,"x":12,"y":25,"properties":{"view":"pie","title":"Package
+              Version Submodules","region":"'
+            - Ref: AWS::Region
+            - '","metrics":[["ConstructHub/Inventory","SupportedSubmoduleCount","Language","java",{"color":"#2ca02c","label":"Available","stat":"Maximum"}],["ConstructHub/Inventory","UnsupportedSubmoduleCount","Language","java",{"color":"#9467bd","label":"Unsupported","stat":"Maximum"}],["ConstructHub/Inventory","MissingSubmoduleCount","Language","java",{"color":"#d62728","label":"Missing","stat":"Maximum"}]],"yAxis":{"left":{"showUnits":false}}}},{"type":"metric","width":6,"height":6,"x":18,"y":25,"properties":{"view":"timeSeries","title":"Package
+              Version Submodules","region":"'
+            - Ref: AWS::Region
+            - '","stacked":true,"metrics":[["ConstructHub/Inventory","SupportedSubmoduleCount","Language","java",{"color":"#2ca02c","label":"Available","stat":"Maximum"}],["ConstructHub/Inventory","UnsupportedSubmoduleCount","Language","java",{"color":"#9467bd","label":"Unsupported","stat":"Maximum"}],["ConstructHub/Inventory","MissingSubmoduleCount","Language","java",{"color":"#d62728","label":"Missing","stat":"Maximum"}]],"yAxis":{"left":{"showUnits":false}}}},{"type":"text","width":24,"height":2,"x":0,"y":31,"properties":{"markdown":"#
               dev/ConstructHub/Sources/NpmJs\\n\\n[button:primary:NpmJs
               Follower](/lambda/home#/functions/'
             - Ref: ConstructHubSourcesNpmJs15A77D2D
             - )\\n[button:Marker Object](/s3/object/
             - Ref: ConstructHubSourcesNpmJsStagingBucketB286F0E6
-            - ?prefix=couchdb-last-transaction-id.2)"}},{"type":"metric","width":12,"height":6,"x":0,"y":26,"properties":{"view":"timeSeries","title":"Function
+            - ?prefix=couchdb-last-transaction-id.2)"}},{"type":"metric","width":12,"height":6,"x":0,"y":33,"properties":{"view":"timeSeries","title":"Function
               Health","region":"
             - Ref: AWS::Region
             - '","metrics":[[{"label":"Invocations","expression":"FILL(m9ff955bd33652ecefb4dd9402064988aa5e418fcf59360156ff8c9e38dbde5e2,
@@ -3248,7 +3612,7 @@ Resources:
               0)"}],["AWS/Lambda","Errors","FunctionName","'
             - Ref: ConstructHubSourcesNpmJs15A77D2D
             - '",{"label":"Errors","stat":"Sum","visible":false,"id":"m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55"}],["ConstructHub/PackageSource/NpmJs/Follower","RemainingTime",{"label":"Remaining
-              Time","yAxis":"right"}]],"yAxis":{"left":{"min":0},"right":{"min":0}},"period":900}},{"type":"metric","width":12,"height":6,"x":12,"y":26,"properties":{"view":"timeSeries","title":"CouchDB
+              Time","yAxis":"right"}]],"yAxis":{"left":{"min":0},"right":{"min":0}},"period":900}},{"type":"metric","width":12,"height":6,"x":12,"y":33,"properties":{"view":"timeSeries","title":"CouchDB
               Follower","region":"'
             - Ref: AWS::Region
             - '","metrics":[["ConstructHub/PackageSource/NpmJs/Follower","ChangeCount",{"label":"Change
@@ -3262,7 +3626,7 @@ Resources:
               Age","expression":"FILL(mec485aa83505431ed7a356970082cd4815c310504ff176dd3eeb241ae7bbf0c4,
               REPEAT)","yAxis":"right"}],["ConstructHub/PackageSource/NpmJs/Follower","PackageVersionAge",{"label":"Package
               Version
-              Age","stat":"Maximum","visible":false,"id":"mec485aa83505431ed7a356970082cd4815c310504ff176dd3eeb241ae7bbf0c4"}]],"yAxis":{"left":{"min":0},"right":{"label":"Milliseconds","min":0,"showUnits":false}},"period":900}},{"type":"text","width":24,"height":2,"x":0,"y":32,"properties":{"markdown":"#
+              Age","stat":"Maximum","visible":false,"id":"mec485aa83505431ed7a356970082cd4815c310504ff176dd3eeb241ae7bbf0c4"}]],"yAxis":{"left":{"min":0},"right":{"label":"Milliseconds","min":0,"showUnits":false}},"period":900}},{"type":"text","width":24,"height":2,"x":0,"y":39,"properties":{"markdown":"#
               Ingestion Function\\n\\n[button:Ingestion
               Function](/lambda/home#/functions/'
             - Ref: ConstructHubIngestion407909CE
@@ -3277,7 +3641,7 @@ Resources:
             - Fn::GetAtt:
                 - ConstructHubIngestionDLQ3E96A5F2
                 - QueueName
-            - )"}},{"type":"metric","width":12,"height":6,"x":0,"y":34,"properties":{"view":"timeSeries","title":"Function
+            - )"}},{"type":"metric","width":12,"height":6,"x":0,"y":41,"properties":{"view":"timeSeries","title":"Function
               Health","region":"
             - Ref: AWS::Region
             - '","metrics":[[{"label":"Invocations","expression":"FILL(m9ff955bd33652ecefb4dd9402064988aa5e418fcf59360156ff8c9e38dbde5e2,
@@ -3286,7 +3650,7 @@ Resources:
             - '",{"label":"Invocations","stat":"Sum","visible":false,"id":"m9ff955bd33652ecefb4dd9402064988aa5e418fcf59360156ff8c9e38dbde5e2"}],[{"label":"Errors","expression":"FILL(m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55,
               0)"}],["AWS/Lambda","Errors","FunctionName","'
             - Ref: ConstructHubIngestion407909CE
-            - '",{"label":"Errors","stat":"Sum","visible":false,"id":"m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55"}]],"yAxis":{"left":{"min":0}},"period":60}},{"type":"metric","width":12,"height":6,"x":12,"y":34,"properties":{"view":"timeSeries","title":"Input
+            - '",{"label":"Errors","stat":"Sum","visible":false,"id":"m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55"}]],"yAxis":{"left":{"min":0}},"period":60}},{"type":"metric","width":12,"height":6,"x":12,"y":41,"properties":{"view":"timeSeries","title":"Input
               Queue","region":"'
             - Ref: AWS::Region
             - '","metrics":[["AWS/SQS","ApproximateNumberOfMessagesVisible","QueueName","'
@@ -3305,7 +3669,7 @@ Resources:
                 - QueueName
             - '",{"label":"Oldest Message
               Age","period":60,"stat":"Maximum","yAxis":"right"}]],"annotations":{"horizontal":[{"color":"#ffa500","label":"10
-              Minutes","value":600,"yAxis":"right"}]},"yAxis":{"left":{"min":0},"right":{"min":0}},"period":60}},{"type":"metric","width":12,"height":6,"x":0,"y":40,"properties":{"view":"timeSeries","title":"Input
+              Minutes","value":600,"yAxis":"right"}]},"yAxis":{"left":{"min":0},"right":{"min":0}},"period":60}},{"type":"metric","width":12,"height":6,"x":0,"y":47,"properties":{"view":"timeSeries","title":"Input
               Quality","region":"'
             - Ref: AWS::Region
             - '","stacked":true,"metrics":[[{"label":"Invalid
@@ -3325,7 +3689,7 @@ Resources:
               file","expression":"FILL(m7084dfec3c5bab86694d7ae438460f471c174a94bc67c9c9738e3ab60246b661,
               0)"}],["ConstructHub/Ingestion","FoundLicenseFile",{"label":"Found
               License
-              file","stat":"Sum","visible":false,"id":"m7084dfec3c5bab86694d7ae438460f471c174a94bc67c9c9738e3ab60246b661"}]],"yAxis":{"left":{"label":"Count","min":0,"showUnits":false}}}},{"type":"metric","width":12,"height":6,"x":12,"y":40,"properties":{"view":"timeSeries","title":"Dead
+              file","stat":"Sum","visible":false,"id":"m7084dfec3c5bab86694d7ae438460f471c174a94bc67c9c9738e3ab60246b661"}]],"yAxis":{"left":{"label":"Count","min":0,"showUnits":false}}}},{"type":"metric","width":12,"height":6,"x":12,"y":47,"properties":{"view":"timeSeries","title":"Dead
               Letters","region":"'
             - Ref: AWS::Region
             - '","metrics":[["AWS/SQS","ApproximateNumberOfMessagesVisible","QueueName","'
@@ -3343,7 +3707,7 @@ Resources:
                 - ConstructHubIngestionDLQ3E96A5F2
                 - QueueName
             - '",{"label":"Oldest Message
-              Age","stat":"Maximum","yAxis":"right"}]],"yAxis":{"left":{"min":0},"right":{"min":0}},"period":60}},{"type":"text","width":24,"height":2,"x":0,"y":46,"properties":{"markdown":"#
+              Age","stat":"Maximum","yAxis":"right"}]],"yAxis":{"left":{"min":0},"right":{"min":0}},"period":60}},{"type":"text","width":24,"height":2,"x":0,"y":53,"properties":{"markdown":"#
               Orchestration\\n\\n[button:State
               Machine](/states/home#/statemachines/view/'
             - Ref: ConstructHubOrchestration39161A46
@@ -3359,7 +3723,7 @@ Resources:
             - Ref: ConstructHubOrchestrationRedrive8DDBA67E
             - )\\n[button:Reprocess](/lambda/home#/functions/
             - Ref: ConstructHubOrchestrationReprocessAllFF2F2455
-            - )"}},{"type":"metric","width":12,"height":6,"x":0,"y":48,"properties":{"view":"timeSeries","title":"State
+            - )"}},{"type":"metric","width":12,"height":6,"x":0,"y":55,"properties":{"view":"timeSeries","title":"State
               Machine Executions","region":"
             - Ref: AWS::Region
             - '","metrics":[[{"label":"Started","expression":"FILL(m392141ff4cfa3bbe1889b2db42bcf20599513e199a0b9fb8dc736cde893c1d7c,
@@ -3384,7 +3748,7 @@ Resources:
             - '",{"label":"Timed
               Out","stat":"Sum","visible":false,"id":"m106d91118c893ec9037d16448722184f1ebdcca08a617e1f13758151a8c85a21"}],["AWS/States","ExecutionTime","StateMachineArn","'
             - Ref: ConstructHubOrchestration39161A46
-            - '",{"label":"Duration","yAxis":"right"}]],"yAxis":{"left":{"min":0},"right":{"min":0}}}},{"type":"metric","width":12,"height":6,"x":12,"y":48,"properties":{"view":"timeSeries","title":"Dead
+            - '",{"label":"Duration","yAxis":"right"}]],"yAxis":{"left":{"min":0},"right":{"min":0}}}},{"type":"metric","width":12,"height":6,"x":12,"y":55,"properties":{"view":"timeSeries","title":"Dead
               Letter Queue","region":"'
             - Ref: AWS::Region
             - '","metrics":[["AWS/SQS","ApproximateNumberOfMessagesVisible","QueueName","'
@@ -3402,7 +3766,7 @@ Resources:
                 - ConstructHubOrchestrationDLQ9C6D9BD4
                 - QueueName
             - '",{"label":"Oldest Message
-              Age","stat":"Maximum","yAxis":"right"}]],"yAxis":{"left":{"min":0},"right":{"min":0}},"period":60}},{"type":"text","width":24,"height":2,"x":0,"y":54,"properties":{"markdown":"#
+              Age","stat":"Maximum","yAxis":"right"}]],"yAxis":{"left":{"min":0},"right":{"min":0}},"period":60}},{"type":"text","width":24,"height":2,"x":0,"y":61,"properties":{"markdown":"#
               Deny List\\n\\n[button:Deny List Object](/s3/object/'
             - Ref: ConstructHubDenyListBucket1B3C2C2E
             - ?prefix=deny-list.json)\\n[button:Prune
@@ -3423,7 +3787,7 @@ Resources:
             - )\\n[button:Delete
               Logs](/cloudwatch/home#logsV2:log-groups/log-group/$252Faws$252flambda$252f
             - Ref: ConstructHubDenyListPrunePruneQueueHandlerF7EB599B
-            - /log-events)"}},{"type":"metric","width":12,"height":6,"x":0,"y":56,"properties":{"view":"timeSeries","title":"Deny
+            - /log-events)"}},{"type":"metric","width":12,"height":6,"x":0,"y":63,"properties":{"view":"timeSeries","title":"Deny
               List","region":"
             - Ref: AWS::Region
             - '","metrics":[[{"label":"Rules","expression":"FILL(m41327b0edbbef1ca627d9503d1b9b9fab401700118519537b58e0557adee7e4f,
@@ -3432,7 +3796,7 @@ Resources:
                 - ConstructHubDenyListPruneDeleteQueueBBF60185
                 - QueueName
             - '",{"label":"Deleted
-              Files","stat":"Sum"}]],"yAxis":{"left":{"min":0}},"period":300}},{"type":"metric","width":12,"height":6,"x":12,"y":56,"properties":{"view":"timeSeries","title":"Prune
+              Files","stat":"Sum"}]],"yAxis":{"left":{"min":0}},"period":300}},{"type":"metric","width":12,"height":6,"x":12,"y":63,"properties":{"view":"timeSeries","title":"Prune
               Function Health","region":"'
             - Ref: AWS::Region
             - '","metrics":[[{"label":"Invocations","expression":"FILL(m9ff955bd33652ecefb4dd9402064988aa5e418fcf59360156ff8c9e38dbde5e2,
@@ -4238,18 +4602,18 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "d5ce621914a7c3f15cf5d46823956ea431a98db7cf8d22b7af369eb6d01413c7"
-  AssetParametersdef5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9S3Bucket693007CE:
+  AssetParameterse0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813S3Bucket55321DF2:
     Type: String
     Description: S3 bucket for asset
-      "def5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9"
-  AssetParametersdef5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9S3VersionKeyA7862DEC:
+      "e0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813"
+  AssetParameterse0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813S3VersionKey325A408D:
     Type: String
     Description: S3 key for asset version
-      "def5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9"
-  AssetParametersdef5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9ArtifactHashB9B2536A:
+      "e0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813"
+  AssetParameterse0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813ArtifactHashAC8102A5:
     Type: String
     Description: Artifact hash for asset
-      "def5a4f8ddf709b51ebce34ccd424015f349a7c3ae7ba0b19f057e3f8a9f38e9"
+      "e0850c3316b9c616f9132aacefa4b72593adc28b34268d2e76c9cd2eb0256813"
   AssetParameters67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24S3Bucket4D46ABB5:
     Type: String
     Description: S3 bucket for asset
@@ -4262,18 +4626,18 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24"
-  AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3Bucket9F5C49D7:
+  AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3Bucket38537BD6:
     Type: String
     Description: S3 bucket for asset
-      "8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9"
-  AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9S3VersionKey8747EBE9:
+      "1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15"
+  AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35:
     Type: String
     Description: S3 key for asset version
-      "8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9"
-  AssetParameters8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9ArtifactHash7A6CE4F0:
+      "1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15"
+  AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15ArtifactHash2AA5202D:
     Type: String
     Description: Artifact hash for asset
-      "8788b02d861e52e91768589d39161b6231f16d00156288e15ec5f08a6d8dfaa9"
+      "1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15"
   AssetParameters8265ccdf680d2fc53b19193e2b93340a27f335cc3be02b673f0742d7700fd6acS3Bucket9B1F28E2:
     Type: String
     Description: S3 bucket for asset
@@ -4286,30 +4650,30 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "8265ccdf680d2fc53b19193e2b93340a27f335cc3be02b673f0742d7700fd6ac"
-  AssetParametersb191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17S3Bucket60674A76:
+  AssetParameters68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513S3Bucket942ED5A2:
     Type: String
     Description: S3 bucket for asset
-      "b191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17"
-  AssetParametersb191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17S3VersionKey724F7AFD:
+      "68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513"
+  AssetParameters68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513S3VersionKeyF5E68355:
     Type: String
     Description: S3 key for asset version
-      "b191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17"
-  AssetParametersb191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17ArtifactHash65E20850:
+      "68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513"
+  AssetParameters68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513ArtifactHash02422EA3:
     Type: String
     Description: Artifact hash for asset
-      "b191eac94c45062404e5c8019a48b252eab6ab82372aedcf526df0c91109ea17"
-  AssetParametersbec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ecS3BucketE3CFE68F:
+      "68e1e5283d8b413ab7c35cb5b226e107c16543cad6fd5cc12657265da4ea5513"
+  AssetParametersff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2S3BucketBC914BA2:
     Type: String
     Description: S3 bucket for asset
-      "bec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ec"
-  AssetParametersbec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ecS3VersionKey6D99058D:
+      "ff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2"
+  AssetParametersff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2S3VersionKey1681742D:
     Type: String
     Description: S3 key for asset version
-      "bec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ec"
-  AssetParametersbec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ecArtifactHash04B28626:
+      "ff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2"
+  AssetParametersff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2ArtifactHash58196055:
     Type: String
     Description: Artifact hash for asset
-      "bec22b479bb27040f989c8d9dac74896806079dae8538bfb38b94c4f7ac105ec"
+      "ff18d1eff571776f6c5a2418717dc94c5861c693acf3ba2523635c5869971ce2"
   AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3BucketF36A877E:
     Type: String
     Description: S3 bucket for asset
@@ -4322,18 +4686,18 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658"
-  AssetParametersa7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100S3BucketA07EA20C:
+  AssetParameters9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4bS3BucketF0A4F598:
     Type: String
     Description: S3 bucket for asset
-      "a7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100"
-  AssetParametersa7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100S3VersionKeyBF4D0B81:
+      "9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4b"
+  AssetParameters9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4bS3VersionKey5E4628BC:
     Type: String
     Description: S3 key for asset version
-      "a7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100"
-  AssetParametersa7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100ArtifactHashB98D2EC5:
+      "9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4b"
+  AssetParameters9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4bArtifactHash9C520604:
     Type: String
     Description: Artifact hash for asset
-      "a7b60478c58b29ac97ecae30d46966ed10713835d41172f97104fc7aa8144100"
+      "9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4b"
   AssetParameters2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00S3BucketC5860594:
     Type: String
     Description: S3 bucket for asset

--- a/src/backend/catalog-builder/catalog-builder.lambda.ts
+++ b/src/backend/catalog-builder/catalog-builder.lambda.ts
@@ -131,10 +131,13 @@ async function* relevantObjects(bucket: string) {
       if (!object.Key?.endsWith(constants.PACKAGE_KEY_SUFFIX)) {
         continue;
       }
-      // We only register packages if they have AT LEAST Python or TypeScript docs.
+      // We only register packages if they have AT LEAST docs in one language.
       const tsDocs = `${object.Key.substring(0, object.Key.length - constants.PACKAGE_KEY_SUFFIX.length)}${constants.DOCS_KEY_SUFFIX_TYPESCRIPT}`;
       const pyDocs = `${object.Key.substring(0, object.Key.length - constants.PACKAGE_KEY_SUFFIX.length)}${constants.DOCS_KEY_SUFFIX_PYTHON}`;
-      if (!(await aws.s3ObjectExists(bucket, tsDocs)) && !(await aws.s3ObjectExists(bucket, pyDocs))) {
+      const javaDocs = `${object.Key.substring(0, object.Key.length - constants.PACKAGE_KEY_SUFFIX.length)}${constants.DOCS_KEY_SUFFIX_JAVA}`;
+      if (!(await aws.s3ObjectExists(bucket, tsDocs)) &&
+          !(await aws.s3ObjectExists(bucket, pyDocs)) &&
+          !(await aws.s3ObjectExists(bucket, javaDocs))) {
         continue;
       }
       yield object;

--- a/src/backend/orchestration/index.ts
+++ b/src/backend/orchestration/index.ts
@@ -13,7 +13,7 @@ import { Transliterator, TransliteratorProps } from '../transliterator';
 import { RedriveStateMachine } from './redrive-state-machine';
 import { ReprocessAll } from './reprocess-all';
 
-const SUPPORTED_LANGUAGES = [DocumentationLanguage.PYTHON, DocumentationLanguage.TYPESCRIPT];
+const SUPPORTED_LANGUAGES = [DocumentationLanguage.PYTHON, DocumentationLanguage.TYPESCRIPT, DocumentationLanguage.JAVA];
 
 export interface OrchestrationProps extends Omit<TransliteratorProps, 'language'>{
   /**

--- a/src/backend/shared/constants.ts
+++ b/src/backend/shared/constants.ts
@@ -37,6 +37,11 @@ export const DOCS_KEY_SUFFIX_TYPESCRIPT = docsKeySuffix(DocumentationLanguage.TY
 export const DOCS_KEY_SUFFIX_PYTHON = docsKeySuffix(DocumentationLanguage.PYTHON);
 
 /**
+ * The key suffix for a Python doc artifact (root module).
+ */
+export const DOCS_KEY_SUFFIX_JAVA = docsKeySuffix(DocumentationLanguage.JAVA);
+
+/**
  * The key suffix matching any documentation artifact.
  */
 export const DOCS_KEY_SUFFIX_ANY = docsKeySuffix('*');

--- a/src/backend/shared/language.ts
+++ b/src/backend/shared/language.ts
@@ -13,9 +13,18 @@ export class DocumentationLanguage {
   public static readonly PYTHON = new DocumentationLanguage('python');
 
   /**
+   * Java.
+   */
+  public static readonly JAVA = new DocumentationLanguage('java');
+
+  /**
    * All supported languages.
    */
-  public static readonly ALL = [DocumentationLanguage.TYPESCRIPT, DocumentationLanguage.PYTHON] as const;
+  public static readonly ALL = [
+    DocumentationLanguage.TYPESCRIPT,
+    DocumentationLanguage.PYTHON,
+    DocumentationLanguage.JAVA,
+  ] as const;
 
   /**
    * Transform a literal string to the `DocumentationLanguage` object.
@@ -28,8 +37,10 @@ export class DocumentationLanguage {
         return DocumentationLanguage.TYPESCRIPT;
       case DocumentationLanguage.PYTHON.toString():
         return DocumentationLanguage.PYTHON;
+      case DocumentationLanguage.JAVA.toString():
+        return DocumentationLanguage.JAVA;
       default:
-        throw new UnsupportedLanguageError(lang, [DocumentationLanguage.TYPESCRIPT, DocumentationLanguage.PYTHON]);
+        throw new UnsupportedLanguageError(lang, DocumentationLanguage.ALL);
     }
   }
 
@@ -41,7 +52,7 @@ export class DocumentationLanguage {
 }
 
 export class UnsupportedLanguageError extends Error {
-  constructor(lang: string, supported: DocumentationLanguage[]) {
+  constructor(lang: string, supported: readonly DocumentationLanguage[]) {
     super(`Unsupported language: ${lang}. Supported languages are: [${supported}]`);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3275,10 +3275,25 @@
     chalk "^4.1.2"
     semver "^7.3.5"
 
+"@jsii/check-node@1.34.0":
+  version "1.34.0"
+  resolved "https://registry.yarnpkg.com/@jsii/check-node/-/check-node-1.34.0.tgz#24da38da36e18639c84787dabd464b8474ddee22"
+  integrity sha512-Z+eGyIoV6B6RNFCR+Z/p0ANnZA++bmCXhoU1RIwGh9RG39PAT38KkZZNr9ZHNTTQbVoTJMSatoX/9WQ33pQxAw==
+  dependencies:
+    chalk "^4.1.2"
+    semver "^7.3.5"
+
 "@jsii/spec@^1.33.0":
   version "1.33.0"
   resolved "https://registry.yarnpkg.com/@jsii/spec/-/spec-1.33.0.tgz#0cd8cf3dec506b0002ce2de6ed51671e9500b7bf"
   integrity sha512-JUu4NhmFQiLnzegaj4gJ5xAt7YjB2fUteJppIN/J49TQJd1kWxsFFmYIMJDuUiAUzo0Gx99N4YqgcfKK3kLAbQ==
+  dependencies:
+    jsonschema "^1.4.0"
+
+"@jsii/spec@^1.34.0":
+  version "1.34.0"
+  resolved "https://registry.yarnpkg.com/@jsii/spec/-/spec-1.34.0.tgz#8b78adf07518f567d2c44bf6c98c426e5c18e0cf"
+  integrity sha512-yAK8FrTRrZ3lQ+DmdyAFZuHmsTJ1ej0719+sVgjr5ahE9i64huStaraX/jJM+PniuUQwE7N+B49ue6X9qj7vJA==
   dependencies:
     jsonschema "^1.4.0"
 
@@ -4226,6 +4241,11 @@
     "@webassemblyjs/ast" "1.9.0"
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
+
+"@xmldom/xmldom@^0.7.0":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.7.4.tgz#93b2f9486c88b6464e97f76c9ab49b0a548fbe57"
+  integrity sha512-wdxC79cvO7PjSM34jATd/RYZuYWQ8y/R7MidZl1NYYlbpFn1+spfjkiR3ZsJfcaTs2IyslBN7VwBBJwrYKM+zw==
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -10504,18 +10524,18 @@ jsii-diff@^1.33.0:
     typescript "~3.9.10"
     yargs "^16.2.0"
 
-jsii-docgen@^3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/jsii-docgen/-/jsii-docgen-3.3.2.tgz#e931058f203f2bf995c1d18901dcf832913b90b6"
-  integrity sha512-ao1TYAhHwhlrAhh1wTeU1SzYb2M3CSjnhHFOX2AivayoUgGbZYfP+bMPj5kymP9stLT6C8en3hj7J11kSfGokg==
+jsii-docgen@^3.4.5:
+  version "3.4.6"
+  resolved "https://registry.yarnpkg.com/jsii-docgen/-/jsii-docgen-3.4.6.tgz#e65569e4b5362db43efd41ba74345fbea85ee80f"
+  integrity sha512-l+yP8rRhgeHJhOQCllj1jXhvzmmNm6vEwxKsDG3r8iR4BCO2bK0usc9tnTmgaCsyFAYppiOXHbuP26A3aNUkzQ==
   dependencies:
-    "@jsii/spec" "^1.33.0"
+    "@jsii/spec" "^1.34.0"
     case "^1.6.3"
     fs-extra "^9.1.0"
     glob "^7.1.7"
     glob-promise "^3.4.0"
-    jsii-reflect "^1.33.0"
-    jsii-rosetta "^1.33.0"
+    jsii-reflect "^1.34.0"
+    jsii-rosetta "^1.34.0"
     yargs "^16.2.0"
 
 jsii-pacmak@^1.33.0:
@@ -10549,6 +10569,18 @@ jsii-reflect@^1.33.0:
     oo-ascii-tree "^1.33.0"
     yargs "^16.2.0"
 
+jsii-reflect@^1.34.0:
+  version "1.34.0"
+  resolved "https://registry.yarnpkg.com/jsii-reflect/-/jsii-reflect-1.34.0.tgz#3d5c8f7c2e8310df2c8dea3aad5bef487fe1d0d9"
+  integrity sha512-IOEdwgeDCOq821PM3OfRro1Pgu0QzHFW7zQy3aN7/w5Fcb/tSYGxI9+Ykr6JCdg681LFzcMEgwJpCUHnfi/shw==
+  dependencies:
+    "@jsii/check-node" "1.34.0"
+    "@jsii/spec" "^1.34.0"
+    colors "^1.4.0"
+    fs-extra "^9.1.0"
+    oo-ascii-tree "^1.34.0"
+    yargs "^16.2.0"
+
 jsii-rosetta@^1.33.0:
   version "1.33.0"
   resolved "https://registry.yarnpkg.com/jsii-rosetta/-/jsii-rosetta-1.33.0.tgz#0f5b4005f5264f15583999e8718d382933b43e74"
@@ -10560,6 +10592,19 @@ jsii-rosetta@^1.33.0:
     fs-extra "^9.1.0"
     typescript "~3.9.10"
     xmldom "github:xmldom/xmldom#0.7.0"
+    yargs "^16.2.0"
+
+jsii-rosetta@^1.34.0:
+  version "1.34.0"
+  resolved "https://registry.yarnpkg.com/jsii-rosetta/-/jsii-rosetta-1.34.0.tgz#64b1233726a98a992be5cffd1d0f4b824346dbef"
+  integrity sha512-GOGAy5b+zCGeyYziBoNVXgamL2CEZKMj5moeemkyN4AUHUqugNk3fSul2Zdbxs2S13Suk0D9iYAgChDxew0bOw==
+  dependencies:
+    "@jsii/check-node" "1.34.0"
+    "@jsii/spec" "^1.34.0"
+    "@xmldom/xmldom" "^0.7.0"
+    commonmark "^0.30.0"
+    fs-extra "^9.1.0"
+    typescript "~3.9.10"
     yargs "^16.2.0"
 
 jsii@^1.33.0:
@@ -12224,6 +12269,11 @@ oo-ascii-tree@^1.33.0:
   version "1.33.0"
   resolved "https://registry.yarnpkg.com/oo-ascii-tree/-/oo-ascii-tree-1.33.0.tgz#34140c782a129ff9bcaee933d441869fa95c95b9"
   integrity sha512-pthBVMVqOl3GZ6t9WjgLP9p24Oz4oVQCabhhIsY+nG9rywUtHOfqgmSm5AD3BbrJc0cP84dyDJFVlu/bVaKyjw==
+
+oo-ascii-tree@^1.34.0:
+  version "1.34.0"
+  resolved "https://registry.yarnpkg.com/oo-ascii-tree/-/oo-ascii-tree-1.34.0.tgz#5528a52d92ef18b3860d0e784383007e476c18b3"
+  integrity sha512-gAY+yfKCskAk7mkfI8nOhkP12iTGE7b8UxnQuscN80vghrozt/E/2rLeKKMJFagJlm/NnnUmBA0tBQZ3oPHEKg==
 
 open@^7.0.2:
   version "7.4.2"


### PR DESCRIPTION
Adds Java API reference generation to the backend.

I tested this by deploying to my dev stack, and re-triggering the doc generating step function for cdk8s, and afterwards the Java docs were available successfully at <xxx.cloudfront.net>/data/cdk8s/v1.0.0-beta.41/docs-java.md.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*