### PR TITLE
fix: broken error handling in npmjs follower

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -33,18 +33,6 @@ Object {
     },
   },
   "Parameters": Object {
-    "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213ArtifactHash683011F5": Object {
-      "Description": "Artifact hash for asset \\"13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213\\"",
-      "Type": "String",
-    },
-    "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3Bucket73C0E892": Object {
-      "Description": "S3 bucket for asset \\"13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213\\"",
-      "Type": "String",
-    },
-    "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3VersionKey2FB0417C": Object {
-      "Description": "S3 key for asset version \\"13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213\\"",
-      "Type": "String",
-    },
     "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15ArtifactHash2AA5202D": Object {
       "Description": "Artifact hash for asset \\"1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15\\"",
       "Type": "String",
@@ -55,6 +43,18 @@ Object {
     },
     "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35": Object {
       "Description": "S3 key for asset version \\"1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15\\"",
+      "Type": "String",
+    },
+    "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49ArtifactHashA1145632": Object {
+      "Description": "Artifact hash for asset \\"1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49\\"",
+      "Type": "String",
+    },
+    "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3BucketBE09CC34": Object {
+      "Description": "S3 bucket for asset \\"1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49\\"",
+      "Type": "String",
+    },
+    "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3VersionKey82C26DDA": Object {
+      "Description": "S3 key for asset version \\"1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49\\"",
       "Type": "String",
     },
     "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658ArtifactHashA026490C": Object {
@@ -7143,7 +7143,7 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3Bucket73C0E892",
+            "Ref": "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3BucketBE09CC34",
           },
         ],
         "SourceObjectKeys": Array [
@@ -7158,7 +7158,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3VersionKey2FB0417C",
+                          "Ref": "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3VersionKey82C26DDA",
                         },
                       ],
                     },
@@ -7171,7 +7171,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3VersionKey2FB0417C",
+                          "Ref": "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3VersionKey82C26DDA",
                         },
                       ],
                     },
@@ -7673,7 +7673,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3Bucket73C0E892",
+                        "Ref": "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3BucketBE09CC34",
                       },
                     ],
                   ],
@@ -7688,7 +7688,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3Bucket73C0E892",
+                        "Ref": "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3BucketBE09CC34",
                       },
                       "/*",
                     ],
@@ -7896,18 +7896,6 @@ Object {
     },
   },
   "Parameters": Object {
-    "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213ArtifactHash683011F5": Object {
-      "Description": "Artifact hash for asset \\"13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213\\"",
-      "Type": "String",
-    },
-    "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3Bucket73C0E892": Object {
-      "Description": "S3 bucket for asset \\"13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213\\"",
-      "Type": "String",
-    },
-    "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3VersionKey2FB0417C": Object {
-      "Description": "S3 key for asset version \\"13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213\\"",
-      "Type": "String",
-    },
     "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15ArtifactHash2AA5202D": Object {
       "Description": "Artifact hash for asset \\"1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15\\"",
       "Type": "String",
@@ -7918,6 +7906,18 @@ Object {
     },
     "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35": Object {
       "Description": "S3 key for asset version \\"1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15\\"",
+      "Type": "String",
+    },
+    "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49ArtifactHashA1145632": Object {
+      "Description": "Artifact hash for asset \\"1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49\\"",
+      "Type": "String",
+    },
+    "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3BucketBE09CC34": Object {
+      "Description": "S3 bucket for asset \\"1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49\\"",
+      "Type": "String",
+    },
+    "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3VersionKey82C26DDA": Object {
+      "Description": "S3 key for asset version \\"1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49\\"",
       "Type": "String",
     },
     "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658ArtifactHashA026490C": Object {
@@ -15097,7 +15097,7 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3Bucket73C0E892",
+            "Ref": "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3BucketBE09CC34",
           },
         ],
         "SourceObjectKeys": Array [
@@ -15112,7 +15112,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3VersionKey2FB0417C",
+                          "Ref": "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3VersionKey82C26DDA",
                         },
                       ],
                     },
@@ -15125,7 +15125,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3VersionKey2FB0417C",
+                          "Ref": "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3VersionKey82C26DDA",
                         },
                       ],
                     },
@@ -15627,7 +15627,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3Bucket73C0E892",
+                        "Ref": "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3BucketBE09CC34",
                       },
                     ],
                   ],
@@ -15642,7 +15642,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3Bucket73C0E892",
+                        "Ref": "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3BucketBE09CC34",
                       },
                       "/*",
                     ],
@@ -15860,18 +15860,6 @@ Object {
     },
   },
   "Parameters": Object {
-    "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213ArtifactHash683011F5": Object {
-      "Description": "Artifact hash for asset \\"13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213\\"",
-      "Type": "String",
-    },
-    "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3Bucket73C0E892": Object {
-      "Description": "S3 bucket for asset \\"13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213\\"",
-      "Type": "String",
-    },
-    "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3VersionKey2FB0417C": Object {
-      "Description": "S3 key for asset version \\"13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213\\"",
-      "Type": "String",
-    },
     "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15ArtifactHash2AA5202D": Object {
       "Description": "Artifact hash for asset \\"1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15\\"",
       "Type": "String",
@@ -15882,6 +15870,18 @@ Object {
     },
     "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35": Object {
       "Description": "S3 key for asset version \\"1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15\\"",
+      "Type": "String",
+    },
+    "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49ArtifactHashA1145632": Object {
+      "Description": "Artifact hash for asset \\"1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49\\"",
+      "Type": "String",
+    },
+    "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3BucketBE09CC34": Object {
+      "Description": "S3 bucket for asset \\"1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49\\"",
+      "Type": "String",
+    },
+    "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3VersionKey82C26DDA": Object {
+      "Description": "S3 key for asset version \\"1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49\\"",
       "Type": "String",
     },
     "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658ArtifactHashA026490C": Object {
@@ -23217,7 +23217,7 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3Bucket73C0E892",
+            "Ref": "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3BucketBE09CC34",
           },
         ],
         "SourceObjectKeys": Array [
@@ -23232,7 +23232,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3VersionKey2FB0417C",
+                          "Ref": "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3VersionKey82C26DDA",
                         },
                       ],
                     },
@@ -23245,7 +23245,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3VersionKey2FB0417C",
+                          "Ref": "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3VersionKey82C26DDA",
                         },
                       ],
                     },
@@ -23973,7 +23973,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3Bucket73C0E892",
+                        "Ref": "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3BucketBE09CC34",
                       },
                     ],
                   ],
@@ -23988,7 +23988,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3Bucket73C0E892",
+                        "Ref": "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3BucketBE09CC34",
                       },
                       "/*",
                     ],
@@ -24196,18 +24196,6 @@ Object {
     },
   },
   "Parameters": Object {
-    "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213ArtifactHash683011F5": Object {
-      "Description": "Artifact hash for asset \\"13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213\\"",
-      "Type": "String",
-    },
-    "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3Bucket73C0E892": Object {
-      "Description": "S3 bucket for asset \\"13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213\\"",
-      "Type": "String",
-    },
-    "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3VersionKey2FB0417C": Object {
-      "Description": "S3 key for asset version \\"13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213\\"",
-      "Type": "String",
-    },
     "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15ArtifactHash2AA5202D": Object {
       "Description": "Artifact hash for asset \\"1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15\\"",
       "Type": "String",
@@ -24218,6 +24206,18 @@ Object {
     },
     "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35": Object {
       "Description": "S3 key for asset version \\"1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15\\"",
+      "Type": "String",
+    },
+    "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49ArtifactHashA1145632": Object {
+      "Description": "Artifact hash for asset \\"1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49\\"",
+      "Type": "String",
+    },
+    "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3BucketBE09CC34": Object {
+      "Description": "S3 bucket for asset \\"1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49\\"",
+      "Type": "String",
+    },
+    "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3VersionKey82C26DDA": Object {
+      "Description": "S3 key for asset version \\"1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49\\"",
       "Type": "String",
     },
     "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658ArtifactHashA026490C": Object {
@@ -30016,7 +30016,7 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3Bucket73C0E892",
+            "Ref": "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3BucketBE09CC34",
           },
         ],
         "SourceObjectKeys": Array [
@@ -30031,7 +30031,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3VersionKey2FB0417C",
+                          "Ref": "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3VersionKey82C26DDA",
                         },
                       ],
                     },
@@ -30044,7 +30044,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3VersionKey2FB0417C",
+                          "Ref": "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3VersionKey82C26DDA",
                         },
                       ],
                     },
@@ -30546,7 +30546,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3Bucket73C0E892",
+                        "Ref": "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3BucketBE09CC34",
                       },
                     ],
                   ],
@@ -30561,7 +30561,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3Bucket73C0E892",
+                        "Ref": "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3BucketBE09CC34",
                       },
                       "/*",
                     ],

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -33,6 +33,18 @@ Object {
     },
   },
   "Parameters": Object {
+    "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213ArtifactHash683011F5": Object {
+      "Description": "Artifact hash for asset \\"13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213\\"",
+      "Type": "String",
+    },
+    "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3Bucket73C0E892": Object {
+      "Description": "S3 bucket for asset \\"13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213\\"",
+      "Type": "String",
+    },
+    "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3VersionKey2FB0417C": Object {
+      "Description": "S3 key for asset version \\"13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213\\"",
+      "Type": "String",
+    },
     "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15ArtifactHash2AA5202D": Object {
       "Description": "Artifact hash for asset \\"1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15\\"",
       "Type": "String",
@@ -43,30 +55,6 @@ Object {
     },
     "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35": Object {
       "Description": "S3 key for asset version \\"1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15\\"",
-      "Type": "String",
-    },
-    "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49ArtifactHashA1145632": Object {
-      "Description": "Artifact hash for asset \\"1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49\\"",
-      "Type": "String",
-    },
-    "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3BucketBE09CC34": Object {
-      "Description": "S3 bucket for asset \\"1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49\\"",
-      "Type": "String",
-    },
-    "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3VersionKey82C26DDA": Object {
-      "Description": "S3 key for asset version \\"1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49\\"",
-      "Type": "String",
-    },
-    "AssetParameters2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00ArtifactHashB687F90E": Object {
-      "Description": "Artifact hash for asset \\"2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00\\"",
-      "Type": "String",
-    },
-    "AssetParameters2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00S3BucketC5860594": Object {
-      "Description": "S3 bucket for asset \\"2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00\\"",
-      "Type": "String",
-    },
-    "AssetParameters2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00S3VersionKeyCAE19CAD": Object {
-      "Description": "S3 key for asset version \\"2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00\\"",
       "Type": "String",
     },
     "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658ArtifactHashA026490C": Object {
@@ -211,6 +199,18 @@ Object {
     },
     "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3VersionKeyE415415F": Object {
       "Description": "S3 key for asset version \\"e9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68\\"",
+      "Type": "String",
+    },
+    "AssetParameterse9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5ArtifactHashBD9C8AB7": Object {
+      "Description": "Artifact hash for asset \\"e9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5\\"",
+      "Type": "String",
+    },
+    "AssetParameterse9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5S3BucketB1D1925B": Object {
+      "Description": "S3 bucket for asset \\"e9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5\\"",
+      "Type": "String",
+    },
+    "AssetParameterse9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5S3VersionKey836C4465": Object {
+      "Description": "S3 key for asset version \\"e9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5\\"",
       "Type": "String",
     },
     "AssetParametersf3d3a3cc7f26921b237eff24fc5dd7aef8f0465a1f376b8f7918eb3d4b3e8797ArtifactHashAAFCA968": Object {
@@ -6482,7 +6482,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00S3BucketC5860594",
+            "Ref": "AssetParameterse9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5S3BucketB1D1925B",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -6495,7 +6495,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00S3VersionKeyCAE19CAD",
+                          "Ref": "AssetParameterse9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5S3VersionKey836C4465",
                         },
                       ],
                     },
@@ -6508,7 +6508,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00S3VersionKeyCAE19CAD",
+                          "Ref": "AssetParameterse9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5S3VersionKey836C4465",
                         },
                       ],
                     },
@@ -7143,7 +7143,7 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3BucketBE09CC34",
+            "Ref": "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3Bucket73C0E892",
           },
         ],
         "SourceObjectKeys": Array [
@@ -7158,7 +7158,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3VersionKey82C26DDA",
+                          "Ref": "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3VersionKey2FB0417C",
                         },
                       ],
                     },
@@ -7171,7 +7171,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3VersionKey82C26DDA",
+                          "Ref": "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3VersionKey2FB0417C",
                         },
                       ],
                     },
@@ -7673,7 +7673,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3BucketBE09CC34",
+                        "Ref": "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3Bucket73C0E892",
                       },
                     ],
                   ],
@@ -7688,7 +7688,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3BucketBE09CC34",
+                        "Ref": "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3Bucket73C0E892",
                       },
                       "/*",
                     ],
@@ -7896,6 +7896,18 @@ Object {
     },
   },
   "Parameters": Object {
+    "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213ArtifactHash683011F5": Object {
+      "Description": "Artifact hash for asset \\"13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213\\"",
+      "Type": "String",
+    },
+    "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3Bucket73C0E892": Object {
+      "Description": "S3 bucket for asset \\"13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213\\"",
+      "Type": "String",
+    },
+    "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3VersionKey2FB0417C": Object {
+      "Description": "S3 key for asset version \\"13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213\\"",
+      "Type": "String",
+    },
     "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15ArtifactHash2AA5202D": Object {
       "Description": "Artifact hash for asset \\"1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15\\"",
       "Type": "String",
@@ -7906,30 +7918,6 @@ Object {
     },
     "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35": Object {
       "Description": "S3 key for asset version \\"1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15\\"",
-      "Type": "String",
-    },
-    "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49ArtifactHashA1145632": Object {
-      "Description": "Artifact hash for asset \\"1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49\\"",
-      "Type": "String",
-    },
-    "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3BucketBE09CC34": Object {
-      "Description": "S3 bucket for asset \\"1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49\\"",
-      "Type": "String",
-    },
-    "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3VersionKey82C26DDA": Object {
-      "Description": "S3 key for asset version \\"1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49\\"",
-      "Type": "String",
-    },
-    "AssetParameters2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00ArtifactHashB687F90E": Object {
-      "Description": "Artifact hash for asset \\"2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00\\"",
-      "Type": "String",
-    },
-    "AssetParameters2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00S3BucketC5860594": Object {
-      "Description": "S3 bucket for asset \\"2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00\\"",
-      "Type": "String",
-    },
-    "AssetParameters2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00S3VersionKeyCAE19CAD": Object {
-      "Description": "S3 key for asset version \\"2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00\\"",
       "Type": "String",
     },
     "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658ArtifactHashA026490C": Object {
@@ -8074,6 +8062,18 @@ Object {
     },
     "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3VersionKeyE415415F": Object {
       "Description": "S3 key for asset version \\"e9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68\\"",
+      "Type": "String",
+    },
+    "AssetParameterse9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5ArtifactHashBD9C8AB7": Object {
+      "Description": "Artifact hash for asset \\"e9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5\\"",
+      "Type": "String",
+    },
+    "AssetParameterse9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5S3BucketB1D1925B": Object {
+      "Description": "S3 bucket for asset \\"e9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5\\"",
+      "Type": "String",
+    },
+    "AssetParameterse9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5S3VersionKey836C4465": Object {
+      "Description": "S3 key for asset version \\"e9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5\\"",
       "Type": "String",
     },
     "AssetParametersf3d3a3cc7f26921b237eff24fc5dd7aef8f0465a1f376b8f7918eb3d4b3e8797ArtifactHashAAFCA968": Object {
@@ -14436,7 +14436,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00S3BucketC5860594",
+            "Ref": "AssetParameterse9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5S3BucketB1D1925B",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -14449,7 +14449,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00S3VersionKeyCAE19CAD",
+                          "Ref": "AssetParameterse9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5S3VersionKey836C4465",
                         },
                       ],
                     },
@@ -14462,7 +14462,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00S3VersionKeyCAE19CAD",
+                          "Ref": "AssetParameterse9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5S3VersionKey836C4465",
                         },
                       ],
                     },
@@ -15097,7 +15097,7 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3BucketBE09CC34",
+            "Ref": "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3Bucket73C0E892",
           },
         ],
         "SourceObjectKeys": Array [
@@ -15112,7 +15112,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3VersionKey82C26DDA",
+                          "Ref": "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3VersionKey2FB0417C",
                         },
                       ],
                     },
@@ -15125,7 +15125,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3VersionKey82C26DDA",
+                          "Ref": "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3VersionKey2FB0417C",
                         },
                       ],
                     },
@@ -15627,7 +15627,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3BucketBE09CC34",
+                        "Ref": "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3Bucket73C0E892",
                       },
                     ],
                   ],
@@ -15642,7 +15642,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3BucketBE09CC34",
+                        "Ref": "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3Bucket73C0E892",
                       },
                       "/*",
                     ],
@@ -15860,6 +15860,18 @@ Object {
     },
   },
   "Parameters": Object {
+    "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213ArtifactHash683011F5": Object {
+      "Description": "Artifact hash for asset \\"13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213\\"",
+      "Type": "String",
+    },
+    "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3Bucket73C0E892": Object {
+      "Description": "S3 bucket for asset \\"13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213\\"",
+      "Type": "String",
+    },
+    "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3VersionKey2FB0417C": Object {
+      "Description": "S3 key for asset version \\"13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213\\"",
+      "Type": "String",
+    },
     "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15ArtifactHash2AA5202D": Object {
       "Description": "Artifact hash for asset \\"1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15\\"",
       "Type": "String",
@@ -15870,30 +15882,6 @@ Object {
     },
     "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35": Object {
       "Description": "S3 key for asset version \\"1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15\\"",
-      "Type": "String",
-    },
-    "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49ArtifactHashA1145632": Object {
-      "Description": "Artifact hash for asset \\"1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49\\"",
-      "Type": "String",
-    },
-    "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3BucketBE09CC34": Object {
-      "Description": "S3 bucket for asset \\"1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49\\"",
-      "Type": "String",
-    },
-    "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3VersionKey82C26DDA": Object {
-      "Description": "S3 key for asset version \\"1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49\\"",
-      "Type": "String",
-    },
-    "AssetParameters2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00ArtifactHashB687F90E": Object {
-      "Description": "Artifact hash for asset \\"2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00\\"",
-      "Type": "String",
-    },
-    "AssetParameters2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00S3BucketC5860594": Object {
-      "Description": "S3 bucket for asset \\"2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00\\"",
-      "Type": "String",
-    },
-    "AssetParameters2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00S3VersionKeyCAE19CAD": Object {
-      "Description": "S3 key for asset version \\"2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00\\"",
       "Type": "String",
     },
     "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658ArtifactHashA026490C": Object {
@@ -16062,6 +16050,18 @@ Object {
     },
     "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3VersionKeyE415415F": Object {
       "Description": "S3 key for asset version \\"e9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68\\"",
+      "Type": "String",
+    },
+    "AssetParameterse9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5ArtifactHashBD9C8AB7": Object {
+      "Description": "Artifact hash for asset \\"e9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5\\"",
+      "Type": "String",
+    },
+    "AssetParameterse9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5S3BucketB1D1925B": Object {
+      "Description": "S3 bucket for asset \\"e9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5\\"",
+      "Type": "String",
+    },
+    "AssetParameterse9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5S3VersionKey836C4465": Object {
+      "Description": "S3 key for asset version \\"e9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5\\"",
       "Type": "String",
     },
     "AssetParametersf3d3a3cc7f26921b237eff24fc5dd7aef8f0465a1f376b8f7918eb3d4b3e8797ArtifactHashAAFCA968": Object {
@@ -22504,7 +22504,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00S3BucketC5860594",
+            "Ref": "AssetParameterse9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5S3BucketB1D1925B",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -22517,7 +22517,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00S3VersionKeyCAE19CAD",
+                          "Ref": "AssetParameterse9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5S3VersionKey836C4465",
                         },
                       ],
                     },
@@ -22530,7 +22530,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00S3VersionKeyCAE19CAD",
+                          "Ref": "AssetParameterse9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5S3VersionKey836C4465",
                         },
                       ],
                     },
@@ -23217,7 +23217,7 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3BucketBE09CC34",
+            "Ref": "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3Bucket73C0E892",
           },
         ],
         "SourceObjectKeys": Array [
@@ -23232,7 +23232,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3VersionKey82C26DDA",
+                          "Ref": "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3VersionKey2FB0417C",
                         },
                       ],
                     },
@@ -23245,7 +23245,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3VersionKey82C26DDA",
+                          "Ref": "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3VersionKey2FB0417C",
                         },
                       ],
                     },
@@ -23973,7 +23973,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3BucketBE09CC34",
+                        "Ref": "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3Bucket73C0E892",
                       },
                     ],
                   ],
@@ -23988,7 +23988,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3BucketBE09CC34",
+                        "Ref": "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3Bucket73C0E892",
                       },
                       "/*",
                     ],
@@ -24196,6 +24196,18 @@ Object {
     },
   },
   "Parameters": Object {
+    "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213ArtifactHash683011F5": Object {
+      "Description": "Artifact hash for asset \\"13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213\\"",
+      "Type": "String",
+    },
+    "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3Bucket73C0E892": Object {
+      "Description": "S3 bucket for asset \\"13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213\\"",
+      "Type": "String",
+    },
+    "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3VersionKey2FB0417C": Object {
+      "Description": "S3 key for asset version \\"13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213\\"",
+      "Type": "String",
+    },
     "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15ArtifactHash2AA5202D": Object {
       "Description": "Artifact hash for asset \\"1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15\\"",
       "Type": "String",
@@ -24206,30 +24218,6 @@ Object {
     },
     "AssetParameters1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15S3VersionKey02364A35": Object {
       "Description": "S3 key for asset version \\"1b741e40189fa4bc5e85b74360cb5c7f79e826a312c6392a0a865d36e41a4e15\\"",
-      "Type": "String",
-    },
-    "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49ArtifactHashA1145632": Object {
-      "Description": "Artifact hash for asset \\"1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49\\"",
-      "Type": "String",
-    },
-    "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3BucketBE09CC34": Object {
-      "Description": "S3 bucket for asset \\"1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49\\"",
-      "Type": "String",
-    },
-    "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3VersionKey82C26DDA": Object {
-      "Description": "S3 key for asset version \\"1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49\\"",
-      "Type": "String",
-    },
-    "AssetParameters2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00ArtifactHashB687F90E": Object {
-      "Description": "Artifact hash for asset \\"2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00\\"",
-      "Type": "String",
-    },
-    "AssetParameters2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00S3BucketC5860594": Object {
-      "Description": "S3 bucket for asset \\"2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00\\"",
-      "Type": "String",
-    },
-    "AssetParameters2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00S3VersionKeyCAE19CAD": Object {
-      "Description": "S3 key for asset version \\"2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00\\"",
       "Type": "String",
     },
     "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658ArtifactHashA026490C": Object {
@@ -24374,6 +24362,18 @@ Object {
     },
     "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3VersionKeyE415415F": Object {
       "Description": "S3 key for asset version \\"e9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68\\"",
+      "Type": "String",
+    },
+    "AssetParameterse9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5ArtifactHashBD9C8AB7": Object {
+      "Description": "Artifact hash for asset \\"e9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5\\"",
+      "Type": "String",
+    },
+    "AssetParameterse9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5S3BucketB1D1925B": Object {
+      "Description": "S3 bucket for asset \\"e9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5\\"",
+      "Type": "String",
+    },
+    "AssetParameterse9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5S3VersionKey836C4465": Object {
+      "Description": "S3 key for asset version \\"e9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5\\"",
       "Type": "String",
     },
     "AssetParametersf3d3a3cc7f26921b237eff24fc5dd7aef8f0465a1f376b8f7918eb3d4b3e8797ArtifactHashAAFCA968": Object {
@@ -29355,7 +29355,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00S3BucketC5860594",
+            "Ref": "AssetParameterse9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5S3BucketB1D1925B",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -29368,7 +29368,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00S3VersionKeyCAE19CAD",
+                          "Ref": "AssetParameterse9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5S3VersionKey836C4465",
                         },
                       ],
                     },
@@ -29381,7 +29381,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00S3VersionKeyCAE19CAD",
+                          "Ref": "AssetParameterse9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5S3VersionKey836C4465",
                         },
                       ],
                     },
@@ -30016,7 +30016,7 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3BucketBE09CC34",
+            "Ref": "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3Bucket73C0E892",
           },
         ],
         "SourceObjectKeys": Array [
@@ -30031,7 +30031,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3VersionKey82C26DDA",
+                          "Ref": "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3VersionKey2FB0417C",
                         },
                       ],
                     },
@@ -30044,7 +30044,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3VersionKey82C26DDA",
+                          "Ref": "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3VersionKey2FB0417C",
                         },
                       ],
                     },
@@ -30546,7 +30546,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3BucketBE09CC34",
+                        "Ref": "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3Bucket73C0E892",
                       },
                     ],
                   ],
@@ -30561,7 +30561,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3BucketBE09CC34",
+                        "Ref": "AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3Bucket73C0E892",
                       },
                       "/*",
                     ],

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -4066,7 +4066,7 @@ Resources:
           - CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536
           - Arn
       SourceBucketNames:
-        - Ref: AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3Bucket73C0E892
+        - Ref: AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3BucketBE09CC34
       SourceObjectKeys:
         - Fn::Join:
             - ""
@@ -4074,12 +4074,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3VersionKey2FB0417C
+                      - Ref: AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3VersionKey82C26DDA
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3VersionKey2FB0417C
+                      - Ref: AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3VersionKey82C26DDA
       DestinationBucketName:
         Ref: ConstructHubWebAppWebsiteBucket4B2B9DB2
       Prune: true
@@ -4237,13 +4237,13 @@ Resources:
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3Bucket73C0E892
+                    - Ref: AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3BucketBE09CC34
               - Fn::Join:
                   - ""
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3Bucket73C0E892
+                    - Ref: AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3BucketBE09CC34
                     - /*
           - Action:
               - s3:GetObject*
@@ -4722,18 +4722,18 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "7ee6e37c4f89b09a6b3c50e513093daf23a858809daed5a6703095d14955c9b2"
-  AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3Bucket73C0E892:
+  AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3BucketBE09CC34:
     Type: String
     Description: S3 bucket for asset
-      "13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213"
-  AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3VersionKey2FB0417C:
+      "1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49"
+  AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3VersionKey82C26DDA:
     Type: String
     Description: S3 key for asset version
-      "13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213"
-  AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213ArtifactHash683011F5:
+      "1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49"
+  AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49ArtifactHashA1145632:
     Type: String
     Description: Artifact hash for asset
-      "13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213"
+      "1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49"
   AssetParametersd5594c96e8d8bc8ce1cd238fb011bd3e1a5c69dada29b4366e17e735f7617fa3S3Bucket5045DB1E:
     Type: String
     Description: S3 bucket for asset

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -3393,7 +3393,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00S3BucketC5860594
+          Ref: AssetParameterse9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5S3BucketB1D1925B
         S3Key:
           Fn::Join:
             - ""
@@ -3401,12 +3401,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00S3VersionKeyCAE19CAD
+                      - Ref: AssetParameterse9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5S3VersionKey836C4465
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00S3VersionKeyCAE19CAD
+                      - Ref: AssetParameterse9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5S3VersionKey836C4465
       Role:
         Fn::GetAtt:
           - ConstructHubSourcesNpmJsServiceRoleAC3F7AA6
@@ -4066,7 +4066,7 @@ Resources:
           - CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536
           - Arn
       SourceBucketNames:
-        - Ref: AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3BucketBE09CC34
+        - Ref: AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3Bucket73C0E892
       SourceObjectKeys:
         - Fn::Join:
             - ""
@@ -4074,12 +4074,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3VersionKey82C26DDA
+                      - Ref: AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3VersionKey2FB0417C
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3VersionKey82C26DDA
+                      - Ref: AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3VersionKey2FB0417C
       DestinationBucketName:
         Ref: ConstructHubWebAppWebsiteBucket4B2B9DB2
       Prune: true
@@ -4237,13 +4237,13 @@ Resources:
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3BucketBE09CC34
+                    - Ref: AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3Bucket73C0E892
               - Fn::Join:
                   - ""
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3BucketBE09CC34
+                    - Ref: AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3Bucket73C0E892
                     - /*
           - Action:
               - s3:GetObject*
@@ -4698,18 +4698,18 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "9a32117ab2cc975756f8900271d48775c9395ac8d34470e8af4ed1b943abbe4b"
-  AssetParameters2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00S3BucketC5860594:
+  AssetParameterse9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5S3BucketB1D1925B:
     Type: String
     Description: S3 bucket for asset
-      "2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00"
-  AssetParameters2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00S3VersionKeyCAE19CAD:
+      "e9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5"
+  AssetParameterse9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5S3VersionKey836C4465:
     Type: String
     Description: S3 key for asset version
-      "2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00"
-  AssetParameters2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00ArtifactHashB687F90E:
+      "e9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5"
+  AssetParameterse9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5ArtifactHashBD9C8AB7:
     Type: String
     Description: Artifact hash for asset
-      "2821e9a03f5c8acf8da1616ef4b5f44bfa5867557dbcc64cca51242892942a00"
+      "e9d6b27a275f0d2a1e19344b7e41d3de824aa511d7e95f956e0000e83796ffa5"
   AssetParameters7ee6e37c4f89b09a6b3c50e513093daf23a858809daed5a6703095d14955c9b2S3BucketF2BF2B22:
     Type: String
     Description: S3 bucket for asset
@@ -4722,18 +4722,18 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "7ee6e37c4f89b09a6b3c50e513093daf23a858809daed5a6703095d14955c9b2"
-  AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3BucketBE09CC34:
+  AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3Bucket73C0E892:
     Type: String
     Description: S3 bucket for asset
-      "1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49"
-  AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49S3VersionKey82C26DDA:
+      "13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213"
+  AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213S3VersionKey2FB0417C:
     Type: String
     Description: S3 key for asset version
-      "1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49"
-  AssetParameters1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49ArtifactHashA1145632:
+      "13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213"
+  AssetParameters13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213ArtifactHash683011F5:
     Type: String
     Description: Artifact hash for asset
-      "1face777440a6c91597c02624e93afe39145a62da02fc17053f5f95c46a6bb49"
+      "13f36c2c74e91703d26de326e1f031b812541d0ff9d4a791e156f99fb58c0213"
   AssetParametersd5594c96e8d8bc8ce1cd238fb011bd3e1a5c69dada29b4366e17e735f7617fa3S3Bucket5045DB1E:
     Type: String
     Description: S3 bucket for asset

--- a/src/package-sources/npmjs/npm-js-follower.lambda.ts
+++ b/src/package-sources/npmjs/npm-js-follower.lambda.ts
@@ -243,7 +243,7 @@ export async function handler(event: ScheduledEvent, context: Context) {
     return new Promise<Buffer>((ok, ko) => {
       https.get(url, (response) => {
         if (response.statusCode !== 200) {
-          throw new Error(`Unsuccessful GET: ${response.statusCode} - ${response.statusMessage}`);
+          ko(new Error(`Unsuccessful GET: ${response.statusCode} - ${response.statusMessage}`));
         }
 
         let body = Buffer.alloc(0);


### PR DESCRIPTION
A thrown error in the `httpGet` function within the npm js follower
lambda causes the entire function to fail instead of just logging the
individual package that it is unable to access.

Changed the error handling block to invoke the catch branch of the
promise returned.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
