### PR TITLE
chore: update github token

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       pull-requests: write
     if: contains(github.event.pull_request.labels.*.name, 'auto-approve') &&
-      (github.event.pull_request.user.login == 'aws-cdk-automation')
+      (github.event.pull_request.user.login == 'cdklabs-automation')
     steps:
       - uses: hmarr/auto-approve-action@v2.1.0
         with:

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -62,7 +62,7 @@ jobs:
         id: create-pr
         uses: peter-evans/create-pull-request@v3
         with:
-          token: ${{ secrets.CDK_AUTOMATION_GITHUB_TOKEN }}
+          token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: >-
             chore(deps): upgrade dependencies
 

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -89,7 +89,7 @@ const project = new JsiiProject({
     '*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*',
   ],
 
-  projenUpgradeSecret: 'CDK_AUTOMATION_GITHUB_TOKEN',
+  projenUpgradeSecret: 'PROJEN_GITHUB_TOKEN',
 
   releaseToNpm: true,
 
@@ -121,7 +121,7 @@ const project = new JsiiProject({
   // Exclude handler images from TypeScript compier path
   excludeTypescript: ['resources/**'],
   autoApproveOptions: {
-    allowedUsernames: ['aws-cdk-automation'],
+    allowedUsernames: ['cdklabs-automation'],
     secret: 'GITHUB_TOKEN',
   },
   autoApproveUpgrades: true,
@@ -130,7 +130,7 @@ const project = new JsiiProject({
     ignoreProjen: false,
     workflowOptions: {
       labels: ['auto-approve'],
-      secret: 'CDK_AUTOMATION_GITHUB_TOKEN',
+      secret: 'PROJEN_GITHUB_TOKEN',
       container: {
         image: 'jsii/superchain',
       },


### PR DESCRIPTION
Use `PROJEN_GITHUB_TOKEN` to align with all projen projects

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*