### PR TITLE
chore: set embedded metrics environment to "Local"

### DIFF
--- a/.projenrc.js
+++ b/.projenrc.js
@@ -446,7 +446,7 @@ function newEcsTask(entrypoint) {
   df.line();
   // Install node 14+ the regular way...
   df.line('RUN curl -sL https://rpm.nodesource.com/setup_14.x | bash - \\');
-  df.line(' && yum install -y nodejs \\');
+  df.line(' && yum install -y git nodejs \\');
   // The entry point requires aws-sdk to be available, so we install it locally.
   df.line(' && npm install --no-save aws-sdk@^2.957.0 \\');
   // Clean up the yum cache in the interest of image size

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -33,6 +33,18 @@ Object {
     },
   },
   "Parameters": Object {
+    "AssetParameters0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bcArtifactHashE5D04645": Object {
+      "Description": "Artifact hash for asset \\"0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bc\\"",
+      "Type": "String",
+    },
+    "AssetParameters0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bcS3Bucket6D44F554": Object {
+      "Description": "S3 bucket for asset \\"0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bc\\"",
+      "Type": "String",
+    },
+    "AssetParameters0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bcS3VersionKey462DE115": Object {
+      "Description": "S3 key for asset version \\"0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bc\\"",
+      "Type": "String",
+    },
     "AssetParameters0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9ArtifactHashB9E3BF29": Object {
       "Description": "Artifact hash for asset \\"0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9\\"",
       "Type": "String",
@@ -43,18 +55,6 @@ Object {
     },
     "AssetParameters0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9S3VersionKeyE9957876": Object {
       "Description": "S3 key for asset version \\"0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9\\"",
-      "Type": "String",
-    },
-    "AssetParameters193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0eArtifactHash65707448": Object {
-      "Description": "Artifact hash for asset \\"193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0e\\"",
-      "Type": "String",
-    },
-    "AssetParameters193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0eS3BucketBEF7922D": Object {
-      "Description": "S3 bucket for asset \\"193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0e\\"",
-      "Type": "String",
-    },
-    "AssetParameters193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0eS3VersionKey5FE096DC": Object {
-      "Description": "S3 key for asset version \\"193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0e\\"",
       "Type": "String",
     },
     "AssetParameters1f6de40da10b415b255c07df709f791e772ffb9f7bdd14ad81fb75643aad24eaArtifactHash3943F7F3": Object {
@@ -141,16 +141,28 @@ Object {
       "Description": "S3 key for asset version \\"67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24\\"",
       "Type": "String",
     },
-    "AssetParameters68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3ArtifactHash23D97CE9": Object {
-      "Description": "Artifact hash for asset \\"68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3\\"",
+    "AssetParameters684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1ArtifactHashF9F3B2D5": Object {
+      "Description": "Artifact hash for asset \\"684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1\\"",
       "Type": "String",
     },
-    "AssetParameters68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3S3Bucket3950C0EE": Object {
-      "Description": "S3 bucket for asset \\"68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3\\"",
+    "AssetParameters684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1S3BucketFB2F9F6D": Object {
+      "Description": "S3 bucket for asset \\"684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1\\"",
       "Type": "String",
     },
-    "AssetParameters68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3S3VersionKey2164070C": Object {
-      "Description": "S3 key for asset version \\"68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3\\"",
+    "AssetParameters684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1S3VersionKey174E0E8E": Object {
+      "Description": "S3 key for asset version \\"684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1\\"",
+      "Type": "String",
+    },
+    "AssetParameters6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ffArtifactHash54E50C4E": Object {
+      "Description": "Artifact hash for asset \\"6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ff\\"",
+      "Type": "String",
+    },
+    "AssetParameters6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ffS3BucketB7466FA6": Object {
+      "Description": "S3 bucket for asset \\"6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ff\\"",
+      "Type": "String",
+    },
+    "AssetParameters6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ffS3VersionKey00EDB7CB": Object {
+      "Description": "S3 key for asset version \\"6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ff\\"",
       "Type": "String",
     },
     "AssetParameters79d754d99b9d767ed507972d3a7bf52f926d53c913120b6103a82fa3c894267cArtifactHash79122D66": Object {
@@ -177,6 +189,18 @@ Object {
       "Description": "S3 key for asset version \\"82c1d259a49fa7db5212bdfb1fa8779ba3ddabda7261502187e61e5d39d819ca\\"",
       "Type": "String",
     },
+    "AssetParameters8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946aArtifactHash7BAE68F3": Object {
+      "Description": "Artifact hash for asset \\"8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946a\\"",
+      "Type": "String",
+    },
+    "AssetParameters8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946aS3Bucket2E9327D6": Object {
+      "Description": "S3 bucket for asset \\"8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946a\\"",
+      "Type": "String",
+    },
+    "AssetParameters8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946aS3VersionKey949D5568": Object {
+      "Description": "S3 key for asset version \\"8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946a\\"",
+      "Type": "String",
+    },
     "AssetParameters8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064ArtifactHashEA963870": Object {
       "Description": "Artifact hash for asset \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
@@ -189,18 +213,6 @@ Object {
       "Description": "S3 key for asset version \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
     },
-    "AssetParametersd2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2ArtifactHash8AA4097C": Object {
-      "Description": "Artifact hash for asset \\"d2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2\\"",
-      "Type": "String",
-    },
-    "AssetParametersd2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2S3Bucket2E449B72": Object {
-      "Description": "S3 bucket for asset \\"d2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2\\"",
-      "Type": "String",
-    },
-    "AssetParametersd2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2S3VersionKeyA2DCB0B4": Object {
-      "Description": "S3 key for asset version \\"d2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2\\"",
-      "Type": "String",
-    },
     "AssetParametersd6c90ce78d9c7f3b1a2d776b282631be6333d6a8bde28cfd5f17a13074c058f2ArtifactHash4C0A13FA": Object {
       "Description": "Artifact hash for asset \\"d6c90ce78d9c7f3b1a2d776b282631be6333d6a8bde28cfd5f17a13074c058f2\\"",
       "Type": "String",
@@ -211,18 +223,6 @@ Object {
     },
     "AssetParametersd6c90ce78d9c7f3b1a2d776b282631be6333d6a8bde28cfd5f17a13074c058f2S3VersionKey42B55070": Object {
       "Description": "S3 key for asset version \\"d6c90ce78d9c7f3b1a2d776b282631be6333d6a8bde28cfd5f17a13074c058f2\\"",
-      "Type": "String",
-    },
-    "AssetParametersd74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ffArtifactHash22400483": Object {
-      "Description": "Artifact hash for asset \\"d74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ff\\"",
-      "Type": "String",
-    },
-    "AssetParametersd74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ffS3Bucket0CDB3F85": Object {
-      "Description": "S3 bucket for asset \\"d74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ff\\"",
-      "Type": "String",
-    },
-    "AssetParametersd74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ffS3VersionKeyFE91DA6F": Object {
-      "Description": "S3 key for asset version \\"d74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ff\\"",
       "Type": "String",
     },
     "AssetParametersdd50dda049e1844e3956054b7db78813a17ac8e0c3a87d6a369562130a9c8924ArtifactHash44A8CEEC": Object {
@@ -1389,7 +1389,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersd2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2S3Bucket2E449B72",
+            "Ref": "AssetParameters8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946aS3Bucket2E9327D6",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -1402,7 +1402,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersd2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2S3VersionKeyA2DCB0B4",
+                          "Ref": "AssetParameters8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946aS3VersionKey949D5568",
                         },
                       ],
                     },
@@ -1415,7 +1415,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersd2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2S3VersionKeyA2DCB0B4",
+                          "Ref": "AssetParameters8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946aS3VersionKey949D5568",
                         },
                       ],
                     },
@@ -1757,7 +1757,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3S3Bucket3950C0EE",
+            "Ref": "AssetParameters0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bcS3Bucket6D44F554",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -1770,7 +1770,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3S3VersionKey2164070C",
+                          "Ref": "AssetParameters0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bcS3VersionKey462DE115",
                         },
                       ],
                     },
@@ -1783,7 +1783,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3S3VersionKey2164070C",
+                          "Ref": "AssetParameters0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bcS3VersionKey462DE115",
                         },
                       ],
                     },
@@ -1796,6 +1796,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": Object {
           "Variables": Object {
+            "AWS_EMF_ENVIRONMENT": "Local",
             "BUCKET_NAME": Object {
               "Ref": "ConstructHubPackageDataDC5EF35E",
             },
@@ -2203,7 +2204,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0eS3BucketBEF7922D",
+            "Ref": "AssetParameters684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1S3BucketFB2F9F6D",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -2216,7 +2217,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0eS3VersionKey5FE096DC",
+                          "Ref": "AssetParameters684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1S3VersionKey174E0E8E",
                         },
                       ],
                     },
@@ -2229,7 +2230,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0eS3VersionKey5FE096DC",
+                          "Ref": "AssetParameters684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1S3VersionKey174E0E8E",
                         },
                       ],
                     },
@@ -2242,6 +2243,7 @@ Direct link to the function: /lambda/home#/functions/",
         "Description": "[ConstructHub/Inventory] A canary that periodically inspects the list of indexed packages",
         "Environment": Object {
           "Variables": Object {
+            "AWS_EMF_ENVIRONMENT": "Local",
             "BUCKET_NAME": Object {
               "Ref": "ConstructHubPackageDataDC5EF35E",
             },
@@ -4815,6 +4817,7 @@ Direct link to function: /lambda/home#/functions/",
         },
         "Environment": Object {
           "Variables": Object {
+            "AWS_EMF_ENVIRONMENT": "Local",
             "BUCKET_NAME": Object {
               "Ref": "ConstructHubPackageDataDC5EF35E",
             },
@@ -5816,7 +5819,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                   Object {
                     "Ref": "AWS::URLSuffix",
                   },
-                  "/aws-cdk/assets:1d526c8b8a7d0b21c6e2dba8c620d6979757d6d37ca50404dc84c93fcf4d4bbf",
+                  "/aws-cdk/assets:71b8b086f1590e35f6c1d7078eb089c83fc9d4b30486eaf3bf62f733f069b88e",
                 ],
               ],
             },
@@ -6603,7 +6606,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersd74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ffS3Bucket0CDB3F85",
+            "Ref": "AssetParameters6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ffS3BucketB7466FA6",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -6616,7 +6619,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersd74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ffS3VersionKeyFE91DA6F",
+                          "Ref": "AssetParameters6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ffS3VersionKey00EDB7CB",
                         },
                       ],
                     },
@@ -6629,7 +6632,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersd74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ffS3VersionKeyFE91DA6F",
+                          "Ref": "AssetParameters6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ffS3VersionKey00EDB7CB",
                         },
                       ],
                     },
@@ -6642,6 +6645,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": Object {
           "Variables": Object {
+            "AWS_EMF_ENVIRONMENT": "Local",
             "BUCKET_NAME": Object {
               "Ref": "ConstructHubSourcesNpmJsStagingBucketB286F0E6",
             },
@@ -8162,6 +8166,18 @@ Object {
     },
   },
   "Parameters": Object {
+    "AssetParameters0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bcArtifactHashE5D04645": Object {
+      "Description": "Artifact hash for asset \\"0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bc\\"",
+      "Type": "String",
+    },
+    "AssetParameters0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bcS3Bucket6D44F554": Object {
+      "Description": "S3 bucket for asset \\"0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bc\\"",
+      "Type": "String",
+    },
+    "AssetParameters0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bcS3VersionKey462DE115": Object {
+      "Description": "S3 key for asset version \\"0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bc\\"",
+      "Type": "String",
+    },
     "AssetParameters0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9ArtifactHashB9E3BF29": Object {
       "Description": "Artifact hash for asset \\"0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9\\"",
       "Type": "String",
@@ -8172,18 +8188,6 @@ Object {
     },
     "AssetParameters0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9S3VersionKeyE9957876": Object {
       "Description": "S3 key for asset version \\"0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9\\"",
-      "Type": "String",
-    },
-    "AssetParameters193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0eArtifactHash65707448": Object {
-      "Description": "Artifact hash for asset \\"193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0e\\"",
-      "Type": "String",
-    },
-    "AssetParameters193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0eS3BucketBEF7922D": Object {
-      "Description": "S3 bucket for asset \\"193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0e\\"",
-      "Type": "String",
-    },
-    "AssetParameters193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0eS3VersionKey5FE096DC": Object {
-      "Description": "S3 key for asset version \\"193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0e\\"",
       "Type": "String",
     },
     "AssetParameters1f6de40da10b415b255c07df709f791e772ffb9f7bdd14ad81fb75643aad24eaArtifactHash3943F7F3": Object {
@@ -8270,16 +8274,28 @@ Object {
       "Description": "S3 key for asset version \\"67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24\\"",
       "Type": "String",
     },
-    "AssetParameters68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3ArtifactHash23D97CE9": Object {
-      "Description": "Artifact hash for asset \\"68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3\\"",
+    "AssetParameters684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1ArtifactHashF9F3B2D5": Object {
+      "Description": "Artifact hash for asset \\"684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1\\"",
       "Type": "String",
     },
-    "AssetParameters68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3S3Bucket3950C0EE": Object {
-      "Description": "S3 bucket for asset \\"68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3\\"",
+    "AssetParameters684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1S3BucketFB2F9F6D": Object {
+      "Description": "S3 bucket for asset \\"684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1\\"",
       "Type": "String",
     },
-    "AssetParameters68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3S3VersionKey2164070C": Object {
-      "Description": "S3 key for asset version \\"68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3\\"",
+    "AssetParameters684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1S3VersionKey174E0E8E": Object {
+      "Description": "S3 key for asset version \\"684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1\\"",
+      "Type": "String",
+    },
+    "AssetParameters6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ffArtifactHash54E50C4E": Object {
+      "Description": "Artifact hash for asset \\"6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ff\\"",
+      "Type": "String",
+    },
+    "AssetParameters6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ffS3BucketB7466FA6": Object {
+      "Description": "S3 bucket for asset \\"6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ff\\"",
+      "Type": "String",
+    },
+    "AssetParameters6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ffS3VersionKey00EDB7CB": Object {
+      "Description": "S3 key for asset version \\"6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ff\\"",
       "Type": "String",
     },
     "AssetParameters79d754d99b9d767ed507972d3a7bf52f926d53c913120b6103a82fa3c894267cArtifactHash79122D66": Object {
@@ -8306,6 +8322,18 @@ Object {
       "Description": "S3 key for asset version \\"82c1d259a49fa7db5212bdfb1fa8779ba3ddabda7261502187e61e5d39d819ca\\"",
       "Type": "String",
     },
+    "AssetParameters8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946aArtifactHash7BAE68F3": Object {
+      "Description": "Artifact hash for asset \\"8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946a\\"",
+      "Type": "String",
+    },
+    "AssetParameters8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946aS3Bucket2E9327D6": Object {
+      "Description": "S3 bucket for asset \\"8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946a\\"",
+      "Type": "String",
+    },
+    "AssetParameters8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946aS3VersionKey949D5568": Object {
+      "Description": "S3 key for asset version \\"8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946a\\"",
+      "Type": "String",
+    },
     "AssetParameters8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064ArtifactHashEA963870": Object {
       "Description": "Artifact hash for asset \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
@@ -8318,18 +8346,6 @@ Object {
       "Description": "S3 key for asset version \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
     },
-    "AssetParametersd2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2ArtifactHash8AA4097C": Object {
-      "Description": "Artifact hash for asset \\"d2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2\\"",
-      "Type": "String",
-    },
-    "AssetParametersd2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2S3Bucket2E449B72": Object {
-      "Description": "S3 bucket for asset \\"d2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2\\"",
-      "Type": "String",
-    },
-    "AssetParametersd2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2S3VersionKeyA2DCB0B4": Object {
-      "Description": "S3 key for asset version \\"d2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2\\"",
-      "Type": "String",
-    },
     "AssetParametersd6c90ce78d9c7f3b1a2d776b282631be6333d6a8bde28cfd5f17a13074c058f2ArtifactHash4C0A13FA": Object {
       "Description": "Artifact hash for asset \\"d6c90ce78d9c7f3b1a2d776b282631be6333d6a8bde28cfd5f17a13074c058f2\\"",
       "Type": "String",
@@ -8340,18 +8356,6 @@ Object {
     },
     "AssetParametersd6c90ce78d9c7f3b1a2d776b282631be6333d6a8bde28cfd5f17a13074c058f2S3VersionKey42B55070": Object {
       "Description": "S3 key for asset version \\"d6c90ce78d9c7f3b1a2d776b282631be6333d6a8bde28cfd5f17a13074c058f2\\"",
-      "Type": "String",
-    },
-    "AssetParametersd74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ffArtifactHash22400483": Object {
-      "Description": "Artifact hash for asset \\"d74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ff\\"",
-      "Type": "String",
-    },
-    "AssetParametersd74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ffS3Bucket0CDB3F85": Object {
-      "Description": "S3 bucket for asset \\"d74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ff\\"",
-      "Type": "String",
-    },
-    "AssetParametersd74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ffS3VersionKeyFE91DA6F": Object {
-      "Description": "S3 key for asset version \\"d74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ff\\"",
       "Type": "String",
     },
     "AssetParametersdd50dda049e1844e3956054b7db78813a17ac8e0c3a87d6a369562130a9c8924ArtifactHash44A8CEEC": Object {
@@ -9525,7 +9529,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersd2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2S3Bucket2E449B72",
+            "Ref": "AssetParameters8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946aS3Bucket2E9327D6",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -9538,7 +9542,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersd2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2S3VersionKeyA2DCB0B4",
+                          "Ref": "AssetParameters8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946aS3VersionKey949D5568",
                         },
                       ],
                     },
@@ -9551,7 +9555,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersd2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2S3VersionKeyA2DCB0B4",
+                          "Ref": "AssetParameters8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946aS3VersionKey949D5568",
                         },
                       ],
                     },
@@ -9893,7 +9897,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3S3Bucket3950C0EE",
+            "Ref": "AssetParameters0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bcS3Bucket6D44F554",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -9906,7 +9910,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3S3VersionKey2164070C",
+                          "Ref": "AssetParameters0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bcS3VersionKey462DE115",
                         },
                       ],
                     },
@@ -9919,7 +9923,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3S3VersionKey2164070C",
+                          "Ref": "AssetParameters0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bcS3VersionKey462DE115",
                         },
                       ],
                     },
@@ -9932,6 +9936,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": Object {
           "Variables": Object {
+            "AWS_EMF_ENVIRONMENT": "Local",
             "BUCKET_NAME": Object {
               "Ref": "ConstructHubPackageDataDC5EF35E",
             },
@@ -10339,7 +10344,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0eS3BucketBEF7922D",
+            "Ref": "AssetParameters684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1S3BucketFB2F9F6D",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -10352,7 +10357,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0eS3VersionKey5FE096DC",
+                          "Ref": "AssetParameters684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1S3VersionKey174E0E8E",
                         },
                       ],
                     },
@@ -10365,7 +10370,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0eS3VersionKey5FE096DC",
+                          "Ref": "AssetParameters684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1S3VersionKey174E0E8E",
                         },
                       ],
                     },
@@ -10378,6 +10383,7 @@ Direct link to the function: /lambda/home#/functions/",
         "Description": "[ConstructHub/Inventory] A canary that periodically inspects the list of indexed packages",
         "Environment": Object {
           "Variables": Object {
+            "AWS_EMF_ENVIRONMENT": "Local",
             "BUCKET_NAME": Object {
               "Ref": "ConstructHubPackageDataDC5EF35E",
             },
@@ -12965,6 +12971,7 @@ Direct link to function: /lambda/home#/functions/",
         },
         "Environment": Object {
           "Variables": Object {
+            "AWS_EMF_ENVIRONMENT": "Local",
             "BUCKET_NAME": Object {
               "Ref": "ConstructHubPackageDataDC5EF35E",
             },
@@ -13966,7 +13973,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                   Object {
                     "Ref": "AWS::URLSuffix",
                   },
-                  "/aws-cdk/assets:1d526c8b8a7d0b21c6e2dba8c620d6979757d6d37ca50404dc84c93fcf4d4bbf",
+                  "/aws-cdk/assets:71b8b086f1590e35f6c1d7078eb089c83fc9d4b30486eaf3bf62f733f069b88e",
                 ],
               ],
             },
@@ -14767,7 +14774,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersd74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ffS3Bucket0CDB3F85",
+            "Ref": "AssetParameters6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ffS3BucketB7466FA6",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -14780,7 +14787,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersd74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ffS3VersionKeyFE91DA6F",
+                          "Ref": "AssetParameters6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ffS3VersionKey00EDB7CB",
                         },
                       ],
                     },
@@ -14793,7 +14800,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersd74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ffS3VersionKeyFE91DA6F",
+                          "Ref": "AssetParameters6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ffS3VersionKey00EDB7CB",
                         },
                       ],
                     },
@@ -14806,6 +14813,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": Object {
           "Variables": Object {
+            "AWS_EMF_ENVIRONMENT": "Local",
             "BUCKET_NAME": Object {
               "Ref": "ConstructHubSourcesNpmJsStagingBucketB286F0E6",
             },
@@ -16336,6 +16344,18 @@ Object {
     },
   },
   "Parameters": Object {
+    "AssetParameters0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bcArtifactHashE5D04645": Object {
+      "Description": "Artifact hash for asset \\"0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bc\\"",
+      "Type": "String",
+    },
+    "AssetParameters0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bcS3Bucket6D44F554": Object {
+      "Description": "S3 bucket for asset \\"0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bc\\"",
+      "Type": "String",
+    },
+    "AssetParameters0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bcS3VersionKey462DE115": Object {
+      "Description": "S3 key for asset version \\"0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bc\\"",
+      "Type": "String",
+    },
     "AssetParameters0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9ArtifactHashB9E3BF29": Object {
       "Description": "Artifact hash for asset \\"0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9\\"",
       "Type": "String",
@@ -16346,18 +16366,6 @@ Object {
     },
     "AssetParameters0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9S3VersionKeyE9957876": Object {
       "Description": "S3 key for asset version \\"0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9\\"",
-      "Type": "String",
-    },
-    "AssetParameters193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0eArtifactHash65707448": Object {
-      "Description": "Artifact hash for asset \\"193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0e\\"",
-      "Type": "String",
-    },
-    "AssetParameters193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0eS3BucketBEF7922D": Object {
-      "Description": "S3 bucket for asset \\"193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0e\\"",
-      "Type": "String",
-    },
-    "AssetParameters193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0eS3VersionKey5FE096DC": Object {
-      "Description": "S3 key for asset version \\"193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0e\\"",
       "Type": "String",
     },
     "AssetParameters1f6de40da10b415b255c07df709f791e772ffb9f7bdd14ad81fb75643aad24eaArtifactHash3943F7F3": Object {
@@ -16444,16 +16452,16 @@ Object {
       "Description": "S3 key for asset version \\"67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24\\"",
       "Type": "String",
     },
-    "AssetParameters68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3ArtifactHash23D97CE9": Object {
-      "Description": "Artifact hash for asset \\"68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3\\"",
+    "AssetParameters684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1ArtifactHashF9F3B2D5": Object {
+      "Description": "Artifact hash for asset \\"684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1\\"",
       "Type": "String",
     },
-    "AssetParameters68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3S3Bucket3950C0EE": Object {
-      "Description": "S3 bucket for asset \\"68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3\\"",
+    "AssetParameters684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1S3BucketFB2F9F6D": Object {
+      "Description": "S3 bucket for asset \\"684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1\\"",
       "Type": "String",
     },
-    "AssetParameters68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3S3VersionKey2164070C": Object {
-      "Description": "S3 key for asset version \\"68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3\\"",
+    "AssetParameters684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1S3VersionKey174E0E8E": Object {
+      "Description": "S3 key for asset version \\"684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1\\"",
       "Type": "String",
     },
     "AssetParameters6d776a0ecdabbe5b6a50988cf945a1d46bce6cc9cc107ef065837a533bc0d113ArtifactHashABB8AF21": Object {
@@ -16466,6 +16474,18 @@ Object {
     },
     "AssetParameters6d776a0ecdabbe5b6a50988cf945a1d46bce6cc9cc107ef065837a533bc0d113S3VersionKeyBC64C42B": Object {
       "Description": "S3 key for asset version \\"6d776a0ecdabbe5b6a50988cf945a1d46bce6cc9cc107ef065837a533bc0d113\\"",
+      "Type": "String",
+    },
+    "AssetParameters6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ffArtifactHash54E50C4E": Object {
+      "Description": "Artifact hash for asset \\"6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ff\\"",
+      "Type": "String",
+    },
+    "AssetParameters6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ffS3BucketB7466FA6": Object {
+      "Description": "S3 bucket for asset \\"6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ff\\"",
+      "Type": "String",
+    },
+    "AssetParameters6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ffS3VersionKey00EDB7CB": Object {
+      "Description": "S3 key for asset version \\"6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ff\\"",
       "Type": "String",
     },
     "AssetParameters79d754d99b9d767ed507972d3a7bf52f926d53c913120b6103a82fa3c894267cArtifactHash79122D66": Object {
@@ -16504,6 +16524,18 @@ Object {
       "Description": "S3 key for asset version \\"82c1d259a49fa7db5212bdfb1fa8779ba3ddabda7261502187e61e5d39d819ca\\"",
       "Type": "String",
     },
+    "AssetParameters8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946aArtifactHash7BAE68F3": Object {
+      "Description": "Artifact hash for asset \\"8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946a\\"",
+      "Type": "String",
+    },
+    "AssetParameters8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946aS3Bucket2E9327D6": Object {
+      "Description": "S3 bucket for asset \\"8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946a\\"",
+      "Type": "String",
+    },
+    "AssetParameters8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946aS3VersionKey949D5568": Object {
+      "Description": "S3 key for asset version \\"8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946a\\"",
+      "Type": "String",
+    },
     "AssetParameters8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064ArtifactHashEA963870": Object {
       "Description": "Artifact hash for asset \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
@@ -16516,18 +16548,6 @@ Object {
       "Description": "S3 key for asset version \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
     },
-    "AssetParametersd2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2ArtifactHash8AA4097C": Object {
-      "Description": "Artifact hash for asset \\"d2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2\\"",
-      "Type": "String",
-    },
-    "AssetParametersd2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2S3Bucket2E449B72": Object {
-      "Description": "S3 bucket for asset \\"d2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2\\"",
-      "Type": "String",
-    },
-    "AssetParametersd2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2S3VersionKeyA2DCB0B4": Object {
-      "Description": "S3 key for asset version \\"d2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2\\"",
-      "Type": "String",
-    },
     "AssetParametersd6c90ce78d9c7f3b1a2d776b282631be6333d6a8bde28cfd5f17a13074c058f2ArtifactHash4C0A13FA": Object {
       "Description": "Artifact hash for asset \\"d6c90ce78d9c7f3b1a2d776b282631be6333d6a8bde28cfd5f17a13074c058f2\\"",
       "Type": "String",
@@ -16538,18 +16558,6 @@ Object {
     },
     "AssetParametersd6c90ce78d9c7f3b1a2d776b282631be6333d6a8bde28cfd5f17a13074c058f2S3VersionKey42B55070": Object {
       "Description": "S3 key for asset version \\"d6c90ce78d9c7f3b1a2d776b282631be6333d6a8bde28cfd5f17a13074c058f2\\"",
-      "Type": "String",
-    },
-    "AssetParametersd74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ffArtifactHash22400483": Object {
-      "Description": "Artifact hash for asset \\"d74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ff\\"",
-      "Type": "String",
-    },
-    "AssetParametersd74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ffS3Bucket0CDB3F85": Object {
-      "Description": "S3 bucket for asset \\"d74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ff\\"",
-      "Type": "String",
-    },
-    "AssetParametersd74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ffS3VersionKeyFE91DA6F": Object {
-      "Description": "S3 key for asset version \\"d74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ff\\"",
       "Type": "String",
     },
     "AssetParametersdd50dda049e1844e3956054b7db78813a17ac8e0c3a87d6a369562130a9c8924ArtifactHash44A8CEEC": Object {
@@ -17865,7 +17873,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersd2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2S3Bucket2E449B72",
+            "Ref": "AssetParameters8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946aS3Bucket2E9327D6",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -17878,7 +17886,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersd2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2S3VersionKeyA2DCB0B4",
+                          "Ref": "AssetParameters8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946aS3VersionKey949D5568",
                         },
                       ],
                     },
@@ -17891,7 +17899,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersd2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2S3VersionKeyA2DCB0B4",
+                          "Ref": "AssetParameters8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946aS3VersionKey949D5568",
                         },
                       ],
                     },
@@ -18233,7 +18241,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3S3Bucket3950C0EE",
+            "Ref": "AssetParameters0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bcS3Bucket6D44F554",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -18246,7 +18254,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3S3VersionKey2164070C",
+                          "Ref": "AssetParameters0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bcS3VersionKey462DE115",
                         },
                       ],
                     },
@@ -18259,7 +18267,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3S3VersionKey2164070C",
+                          "Ref": "AssetParameters0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bcS3VersionKey462DE115",
                         },
                       ],
                     },
@@ -18272,6 +18280,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": Object {
           "Variables": Object {
+            "AWS_EMF_ENVIRONMENT": "Local",
             "BUCKET_NAME": Object {
               "Ref": "ConstructHubPackageDataDC5EF35E",
             },
@@ -18679,7 +18688,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0eS3BucketBEF7922D",
+            "Ref": "AssetParameters684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1S3BucketFB2F9F6D",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -18692,7 +18701,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0eS3VersionKey5FE096DC",
+                          "Ref": "AssetParameters684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1S3VersionKey174E0E8E",
                         },
                       ],
                     },
@@ -18705,7 +18714,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0eS3VersionKey5FE096DC",
+                          "Ref": "AssetParameters684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1S3VersionKey174E0E8E",
                         },
                       ],
                     },
@@ -18718,6 +18727,7 @@ Direct link to the function: /lambda/home#/functions/",
         "Description": "[ConstructHub/Inventory] A canary that periodically inspects the list of indexed packages",
         "Environment": Object {
           "Variables": Object {
+            "AWS_EMF_ENVIRONMENT": "Local",
             "BUCKET_NAME": Object {
               "Ref": "ConstructHubPackageDataDC5EF35E",
             },
@@ -21313,6 +21323,7 @@ Direct link to function: /lambda/home#/functions/",
         },
         "Environment": Object {
           "Variables": Object {
+            "AWS_EMF_ENVIRONMENT": "Local",
             "BUCKET_NAME": Object {
               "Ref": "ConstructHubPackageDataDC5EF35E",
             },
@@ -22314,7 +22325,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                   Object {
                     "Ref": "AWS::URLSuffix",
                   },
-                  "/aws-cdk/assets:1d526c8b8a7d0b21c6e2dba8c620d6979757d6d37ca50404dc84c93fcf4d4bbf",
+                  "/aws-cdk/assets:71b8b086f1590e35f6c1d7078eb089c83fc9d4b30486eaf3bf62f733f069b88e",
                 ],
               ],
             },
@@ -23101,7 +23112,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersd74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ffS3Bucket0CDB3F85",
+            "Ref": "AssetParameters6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ffS3BucketB7466FA6",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -23114,7 +23125,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersd74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ffS3VersionKeyFE91DA6F",
+                          "Ref": "AssetParameters6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ffS3VersionKey00EDB7CB",
                         },
                       ],
                     },
@@ -23127,7 +23138,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersd74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ffS3VersionKeyFE91DA6F",
+                          "Ref": "AssetParameters6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ffS3VersionKey00EDB7CB",
                         },
                       ],
                     },
@@ -23140,6 +23151,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": Object {
           "Variables": Object {
+            "AWS_EMF_ENVIRONMENT": "Local",
             "BUCKET_NAME": Object {
               "Ref": "ConstructHubSourcesNpmJsStagingBucketB286F0E6",
             },
@@ -24201,6 +24213,7 @@ function handler(event) {
         "Description": "Monitors the days to expiry of the certificate used to serve my.construct.hub",
         "Environment": Object {
           "Variables": Object {
+            "AWS_EMF_ENVIRONMENT": "Local",
             "HTTPS_ENDPOINT": "my.construct.hub",
             "METRIC_NAME": "DaysToExpiry",
             "METRIC_NAMESPACE": "Test",
@@ -24938,6 +24951,18 @@ Object {
     },
   },
   "Parameters": Object {
+    "AssetParameters0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bcArtifactHashE5D04645": Object {
+      "Description": "Artifact hash for asset \\"0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bc\\"",
+      "Type": "String",
+    },
+    "AssetParameters0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bcS3Bucket6D44F554": Object {
+      "Description": "S3 bucket for asset \\"0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bc\\"",
+      "Type": "String",
+    },
+    "AssetParameters0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bcS3VersionKey462DE115": Object {
+      "Description": "S3 key for asset version \\"0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bc\\"",
+      "Type": "String",
+    },
     "AssetParameters0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9ArtifactHashB9E3BF29": Object {
       "Description": "Artifact hash for asset \\"0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9\\"",
       "Type": "String",
@@ -24948,18 +24973,6 @@ Object {
     },
     "AssetParameters0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9S3VersionKeyE9957876": Object {
       "Description": "S3 key for asset version \\"0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9\\"",
-      "Type": "String",
-    },
-    "AssetParameters193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0eArtifactHash65707448": Object {
-      "Description": "Artifact hash for asset \\"193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0e\\"",
-      "Type": "String",
-    },
-    "AssetParameters193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0eS3BucketBEF7922D": Object {
-      "Description": "S3 bucket for asset \\"193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0e\\"",
-      "Type": "String",
-    },
-    "AssetParameters193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0eS3VersionKey5FE096DC": Object {
-      "Description": "S3 key for asset version \\"193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0e\\"",
       "Type": "String",
     },
     "AssetParameters1f6de40da10b415b255c07df709f791e772ffb9f7bdd14ad81fb75643aad24eaArtifactHash3943F7F3": Object {
@@ -25046,16 +25059,28 @@ Object {
       "Description": "S3 key for asset version \\"67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24\\"",
       "Type": "String",
     },
-    "AssetParameters68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3ArtifactHash23D97CE9": Object {
-      "Description": "Artifact hash for asset \\"68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3\\"",
+    "AssetParameters684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1ArtifactHashF9F3B2D5": Object {
+      "Description": "Artifact hash for asset \\"684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1\\"",
       "Type": "String",
     },
-    "AssetParameters68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3S3Bucket3950C0EE": Object {
-      "Description": "S3 bucket for asset \\"68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3\\"",
+    "AssetParameters684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1S3BucketFB2F9F6D": Object {
+      "Description": "S3 bucket for asset \\"684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1\\"",
       "Type": "String",
     },
-    "AssetParameters68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3S3VersionKey2164070C": Object {
-      "Description": "S3 key for asset version \\"68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3\\"",
+    "AssetParameters684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1S3VersionKey174E0E8E": Object {
+      "Description": "S3 key for asset version \\"684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1\\"",
+      "Type": "String",
+    },
+    "AssetParameters6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ffArtifactHash54E50C4E": Object {
+      "Description": "Artifact hash for asset \\"6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ff\\"",
+      "Type": "String",
+    },
+    "AssetParameters6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ffS3BucketB7466FA6": Object {
+      "Description": "S3 bucket for asset \\"6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ff\\"",
+      "Type": "String",
+    },
+    "AssetParameters6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ffS3VersionKey00EDB7CB": Object {
+      "Description": "S3 key for asset version \\"6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ff\\"",
       "Type": "String",
     },
     "AssetParameters79d754d99b9d767ed507972d3a7bf52f926d53c913120b6103a82fa3c894267cArtifactHash79122D66": Object {
@@ -25082,6 +25107,18 @@ Object {
       "Description": "S3 key for asset version \\"82c1d259a49fa7db5212bdfb1fa8779ba3ddabda7261502187e61e5d39d819ca\\"",
       "Type": "String",
     },
+    "AssetParameters8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946aArtifactHash7BAE68F3": Object {
+      "Description": "Artifact hash for asset \\"8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946a\\"",
+      "Type": "String",
+    },
+    "AssetParameters8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946aS3Bucket2E9327D6": Object {
+      "Description": "S3 bucket for asset \\"8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946a\\"",
+      "Type": "String",
+    },
+    "AssetParameters8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946aS3VersionKey949D5568": Object {
+      "Description": "S3 key for asset version \\"8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946a\\"",
+      "Type": "String",
+    },
     "AssetParameters8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064ArtifactHashEA963870": Object {
       "Description": "Artifact hash for asset \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
@@ -25094,18 +25131,6 @@ Object {
       "Description": "S3 key for asset version \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
     },
-    "AssetParametersd2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2ArtifactHash8AA4097C": Object {
-      "Description": "Artifact hash for asset \\"d2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2\\"",
-      "Type": "String",
-    },
-    "AssetParametersd2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2S3Bucket2E449B72": Object {
-      "Description": "S3 bucket for asset \\"d2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2\\"",
-      "Type": "String",
-    },
-    "AssetParametersd2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2S3VersionKeyA2DCB0B4": Object {
-      "Description": "S3 key for asset version \\"d2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2\\"",
-      "Type": "String",
-    },
     "AssetParametersd6c90ce78d9c7f3b1a2d776b282631be6333d6a8bde28cfd5f17a13074c058f2ArtifactHash4C0A13FA": Object {
       "Description": "Artifact hash for asset \\"d6c90ce78d9c7f3b1a2d776b282631be6333d6a8bde28cfd5f17a13074c058f2\\"",
       "Type": "String",
@@ -25116,18 +25141,6 @@ Object {
     },
     "AssetParametersd6c90ce78d9c7f3b1a2d776b282631be6333d6a8bde28cfd5f17a13074c058f2S3VersionKey42B55070": Object {
       "Description": "S3 key for asset version \\"d6c90ce78d9c7f3b1a2d776b282631be6333d6a8bde28cfd5f17a13074c058f2\\"",
-      "Type": "String",
-    },
-    "AssetParametersd74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ffArtifactHash22400483": Object {
-      "Description": "Artifact hash for asset \\"d74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ff\\"",
-      "Type": "String",
-    },
-    "AssetParametersd74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ffS3Bucket0CDB3F85": Object {
-      "Description": "S3 bucket for asset \\"d74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ff\\"",
-      "Type": "String",
-    },
-    "AssetParametersd74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ffS3VersionKeyFE91DA6F": Object {
-      "Description": "S3 key for asset version \\"d74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ff\\"",
       "Type": "String",
     },
     "AssetParametersdd50dda049e1844e3956054b7db78813a17ac8e0c3a87d6a369562130a9c8924ArtifactHash44A8CEEC": Object {
@@ -26229,7 +26242,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersd2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2S3Bucket2E449B72",
+            "Ref": "AssetParameters8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946aS3Bucket2E9327D6",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -26242,7 +26255,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersd2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2S3VersionKeyA2DCB0B4",
+                          "Ref": "AssetParameters8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946aS3VersionKey949D5568",
                         },
                       ],
                     },
@@ -26255,7 +26268,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersd2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2S3VersionKeyA2DCB0B4",
+                          "Ref": "AssetParameters8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946aS3VersionKey949D5568",
                         },
                       ],
                     },
@@ -26597,7 +26610,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3S3Bucket3950C0EE",
+            "Ref": "AssetParameters0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bcS3Bucket6D44F554",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -26610,7 +26623,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3S3VersionKey2164070C",
+                          "Ref": "AssetParameters0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bcS3VersionKey462DE115",
                         },
                       ],
                     },
@@ -26623,7 +26636,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3S3VersionKey2164070C",
+                          "Ref": "AssetParameters0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bcS3VersionKey462DE115",
                         },
                       ],
                     },
@@ -26636,6 +26649,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": Object {
           "Variables": Object {
+            "AWS_EMF_ENVIRONMENT": "Local",
             "BUCKET_NAME": Object {
               "Ref": "ConstructHubPackageDataDC5EF35E",
             },
@@ -27043,7 +27057,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0eS3BucketBEF7922D",
+            "Ref": "AssetParameters684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1S3BucketFB2F9F6D",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -27056,7 +27070,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0eS3VersionKey5FE096DC",
+                          "Ref": "AssetParameters684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1S3VersionKey174E0E8E",
                         },
                       ],
                     },
@@ -27069,7 +27083,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0eS3VersionKey5FE096DC",
+                          "Ref": "AssetParameters684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1S3VersionKey174E0E8E",
                         },
                       ],
                     },
@@ -27082,6 +27096,7 @@ Direct link to the function: /lambda/home#/functions/",
         "Description": "[ConstructHub/Inventory] A canary that periodically inspects the list of indexed packages",
         "Environment": Object {
           "Variables": Object {
+            "AWS_EMF_ENVIRONMENT": "Local",
             "BUCKET_NAME": Object {
               "Ref": "ConstructHubPackageDataDC5EF35E",
             },
@@ -28247,6 +28262,7 @@ Direct link to function: /lambda/home#/functions/",
         },
         "Environment": Object {
           "Variables": Object {
+            "AWS_EMF_ENVIRONMENT": "Local",
             "BUCKET_NAME": Object {
               "Ref": "ConstructHubPackageDataDC5EF35E",
             },
@@ -29601,7 +29617,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                   Object {
                     "Ref": "AWS::URLSuffix",
                   },
-                  "/aws-cdk/assets:1d526c8b8a7d0b21c6e2dba8c620d6979757d6d37ca50404dc84c93fcf4d4bbf",
+                  "/aws-cdk/assets:71b8b086f1590e35f6c1d7078eb089c83fc9d4b30486eaf3bf62f733f069b88e",
                 ],
               ],
             },
@@ -30388,7 +30404,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersd74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ffS3Bucket0CDB3F85",
+            "Ref": "AssetParameters6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ffS3BucketB7466FA6",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -30401,7 +30417,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersd74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ffS3VersionKeyFE91DA6F",
+                          "Ref": "AssetParameters6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ffS3VersionKey00EDB7CB",
                         },
                       ],
                     },
@@ -30414,7 +30430,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersd74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ffS3VersionKeyFE91DA6F",
+                          "Ref": "AssetParameters6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ffS3VersionKey00EDB7CB",
                         },
                       ],
                     },
@@ -30427,6 +30443,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": Object {
           "Variables": Object {
+            "AWS_EMF_ENVIRONMENT": "Local",
             "BUCKET_NAME": Object {
               "Ref": "ConstructHubSourcesNpmJsStagingBucketB286F0E6",
             },

--- a/src/__tests__/backend/deny-list/__snapshots__/deny-list.test.ts.snap
+++ b/src/__tests__/backend/deny-list/__snapshots__/deny-list.test.ts.snap
@@ -58,6 +58,18 @@ Object {
       "Description": "S3 key for asset version \\"669caa28bc9d5dda98cda5a48a7a005ebcc4da14e2c3de1f4d10803f28a90bb7\\"",
       "Type": "String",
     },
+    "AssetParameters8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946aArtifactHash7BAE68F3": Object {
+      "Description": "Artifact hash for asset \\"8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946a\\"",
+      "Type": "String",
+    },
+    "AssetParameters8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946aS3Bucket2E9327D6": Object {
+      "Description": "S3 bucket for asset \\"8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946a\\"",
+      "Type": "String",
+    },
+    "AssetParameters8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946aS3VersionKey949D5568": Object {
+      "Description": "S3 key for asset version \\"8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946a\\"",
+      "Type": "String",
+    },
     "AssetParameters8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064ArtifactHashEA963870": Object {
       "Description": "Artifact hash for asset \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
@@ -68,18 +80,6 @@ Object {
     },
     "AssetParameters8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064S3VersionKey5B081B37": Object {
       "Description": "S3 key for asset version \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
-      "Type": "String",
-    },
-    "AssetParametersd2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2ArtifactHash8AA4097C": Object {
-      "Description": "Artifact hash for asset \\"d2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2\\"",
-      "Type": "String",
-    },
-    "AssetParametersd2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2S3Bucket2E449B72": Object {
-      "Description": "S3 bucket for asset \\"d2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2\\"",
-      "Type": "String",
-    },
-    "AssetParametersd2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2S3VersionKeyA2DCB0B4": Object {
-      "Description": "S3 key for asset version \\"d2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2\\"",
       "Type": "String",
     },
     "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68ArtifactHashD9A515C3": Object {
@@ -838,7 +838,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersd2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2S3Bucket2E449B72",
+            "Ref": "AssetParameters8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946aS3Bucket2E9327D6",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -851,7 +851,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersd2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2S3VersionKeyA2DCB0B4",
+                          "Ref": "AssetParameters8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946aS3VersionKey949D5568",
                         },
                       ],
                     },
@@ -864,7 +864,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersd2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2S3VersionKeyA2DCB0B4",
+                          "Ref": "AssetParameters8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946aS3VersionKey949D5568",
                         },
                       ],
                     },

--- a/src/__tests__/backend/deny-list/integ/deny-list.integ.cdkout/TestDenyList.template.json
+++ b/src/__tests__/backend/deny-list/integ/deny-list.integ.cdkout/TestDenyList.template.json
@@ -1268,7 +1268,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": {
-            "Ref": "AssetParametersd2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2S3Bucket2E449B72"
+            "Ref": "AssetParameters8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946aS3Bucket2E9327D6"
           },
           "S3Key": {
             "Fn::Join": [
@@ -1281,7 +1281,7 @@
                       "Fn::Split": [
                         "||",
                         {
-                          "Ref": "AssetParametersd2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2S3VersionKeyA2DCB0B4"
+                          "Ref": "AssetParameters8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946aS3VersionKey949D5568"
                         }
                       ]
                     }
@@ -1294,7 +1294,7 @@
                       "Fn::Split": [
                         "||",
                         {
-                          "Ref": "AssetParametersd2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2S3VersionKeyA2DCB0B4"
+                          "Ref": "AssetParameters8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946aS3VersionKey949D5568"
                         }
                       ]
                     }
@@ -1342,7 +1342,7 @@
       ],
       "Metadata": {
         "aws:cdk:path": "TestDenyList/DenyList/Prune/PruneHandler/Resource",
-        "aws:asset:path": "asset.d2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2.bundle",
+        "aws:asset:path": "asset.8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946a.bundle",
         "aws:asset:property": "Code"
       }
     },
@@ -2310,17 +2310,17 @@
       "Type": "String",
       "Description": "Artifact hash for asset \"7b06823bbcc72a4d3141d044a898d5e4c5daf481a313ff067160af1e936d04e8\""
     },
-    "AssetParametersd2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2S3Bucket2E449B72": {
+    "AssetParameters8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946aS3Bucket2E9327D6": {
       "Type": "String",
-      "Description": "S3 bucket for asset \"d2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2\""
+      "Description": "S3 bucket for asset \"8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946a\""
     },
-    "AssetParametersd2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2S3VersionKeyA2DCB0B4": {
+    "AssetParameters8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946aS3VersionKey949D5568": {
       "Type": "String",
-      "Description": "S3 key for asset version \"d2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2\""
+      "Description": "S3 key for asset version \"8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946a\""
     },
-    "AssetParametersd2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2ArtifactHash8AA4097C": {
+    "AssetParameters8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946aArtifactHash7BAE68F3": {
       "Type": "String",
-      "Description": "Artifact hash for asset \"d2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2\""
+      "Description": "Artifact hash for asset \"8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946a\""
     },
     "AssetParameters61d4c1bc1f52c5393c891a125157599d7eba7414b40d068abb4c07ae433e0b37S3Bucket71D3A47B": {
       "Type": "String",

--- a/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
+++ b/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
@@ -159,7 +159,7 @@ Object {
                   Object {
                     "Ref": "AWS::URLSuffix",
                   },
-                  "/aws-cdk/assets:1d526c8b8a7d0b21c6e2dba8c620d6979757d6d37ca50404dc84c93fcf4d4bbf",
+                  "/aws-cdk/assets:71b8b086f1590e35f6c1d7078eb089c83fc9d4b30486eaf3bf62f733f069b88e",
                 ],
               ],
             },
@@ -812,7 +812,7 @@ Object {
                   Object {
                     "Ref": "AWS::URLSuffix",
                   },
-                  "/aws-cdk/assets:1d526c8b8a7d0b21c6e2dba8c620d6979757d6d37ca50404dc84c93fcf4d4bbf",
+                  "/aws-cdk/assets:71b8b086f1590e35f6c1d7078eb089c83fc9d4b30486eaf3bf62f733f069b88e",
                 ],
               ],
             },
@@ -1584,7 +1584,7 @@ Object {
                   Object {
                     "Ref": "AWS::URLSuffix",
                   },
-                  "/aws-cdk/assets:1d526c8b8a7d0b21c6e2dba8c620d6979757d6d37ca50404dc84c93fcf4d4bbf",
+                  "/aws-cdk/assets:71b8b086f1590e35f6c1d7078eb089c83fc9d4b30486eaf3bf62f733f069b88e",
                 ],
               ],
             },
@@ -2233,7 +2233,7 @@ Object {
                   Object {
                     "Ref": "AWS::URLSuffix",
                   },
-                  "/aws-cdk/assets:1d526c8b8a7d0b21c6e2dba8c620d6979757d6d37ca50404dc84c93fcf4d4bbf",
+                  "/aws-cdk/assets:71b8b086f1590e35f6c1d7078eb089c83fc9d4b30486eaf3bf62f733f069b88e",
                 ],
               ],
             },

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -1580,7 +1580,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParametersd2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2S3Bucket2E449B72
+          Ref: AssetParameters8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946aS3Bucket2E9327D6
         S3Key:
           Fn::Join:
             - ""
@@ -1588,12 +1588,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersd2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2S3VersionKeyA2DCB0B4
+                      - Ref: AssetParameters8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946aS3VersionKey949D5568
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersd2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2S3VersionKeyA2DCB0B4
+                      - Ref: AssetParameters8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946aS3VersionKey949D5568
       Role:
         Fn::GetAtt:
           - ConstructHubDenyListPrunePruneHandlerServiceRole58BDE1FE
@@ -1894,6 +1894,7 @@ Resources:
         Variables:
           BUCKET_NAME:
             Ref: ConstructHubPackageDataDC5EF35E
+          AWS_EMF_ENVIRONMENT: Local
           DENY_LIST_BUCKET_NAME:
             Ref: ConstructHubDenyListBucket1B3C2C2E
           DENY_LIST_OBJECT_KEY: deny-list.json
@@ -2221,7 +2222,7 @@ Resources:
                 - Ref: AWS::Region
                 - .
                 - Ref: AWS::URLSuffix
-                - /aws-cdk/assets:1d526c8b8a7d0b21c6e2dba8c620d6979757d6d37ca50404dc84c93fcf4d4bbf
+                - /aws-cdk/assets:71b8b086f1590e35f6c1d7078eb089c83fc9d4b30486eaf3bf62f733f069b88e
           LogConfiguration:
             LogDriver: awslogs
             Options:
@@ -2907,7 +2908,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3S3Bucket3950C0EE
+          Ref: AssetParameters0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bcS3Bucket6D44F554
         S3Key:
           Fn::Join:
             - ""
@@ -2915,12 +2916,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3S3VersionKey2164070C
+                      - Ref: AssetParameters0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bcS3VersionKey462DE115
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3S3VersionKey2164070C
+                      - Ref: AssetParameters0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bcS3VersionKey462DE115
       Role:
         Fn::GetAtt:
           - ConstructHubIngestionServiceRole6380BAB6
@@ -2929,12 +2930,13 @@ Resources:
         Construct Hub"
       Environment:
         Variables:
+          AWS_EMF_ENVIRONMENT: Local
           BUCKET_NAME:
             Ref: ConstructHubPackageDataDC5EF35E
-          STATE_MACHINE_ARN:
-            Ref: ConstructHubOrchestration39161A46
           PACKAGE_LINKS: "[]"
           PACKAGE_TAGS: "[]"
+          STATE_MACHINE_ARN:
+            Ref: ConstructHubOrchestration39161A46
       Handler: index.handler
       MemorySize: 10240
       Runtime: nodejs14.x
@@ -3294,7 +3296,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParametersd74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ffS3Bucket0CDB3F85
+          Ref: AssetParameters6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ffS3BucketB7466FA6
         S3Key:
           Fn::Join:
             - ""
@@ -3302,12 +3304,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersd74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ffS3VersionKeyFE91DA6F
+                      - Ref: AssetParameters6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ffS3VersionKey00EDB7CB
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersd74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ffS3VersionKeyFE91DA6F
+                      - Ref: AssetParameters6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ffS3VersionKey00EDB7CB
       Role:
         Fn::GetAtt:
           - ConstructHubSourcesNpmJsServiceRoleAC3F7AA6
@@ -3316,6 +3318,7 @@ Resources:
         index for new packages"
       Environment:
         Variables:
+          AWS_EMF_ENVIRONMENT: Local
           BUCKET_NAME:
             Ref: ConstructHubSourcesNpmJsStagingBucketB286F0E6
           QUEUE_URL:
@@ -3471,7 +3474,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0eS3BucketBEF7922D
+          Ref: AssetParameters684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1S3BucketFB2F9F6D
         S3Key:
           Fn::Join:
             - ""
@@ -3479,12 +3482,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0eS3VersionKey5FE096DC
+                      - Ref: AssetParameters684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1S3VersionKey174E0E8E
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0eS3VersionKey5FE096DC
+                      - Ref: AssetParameters684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1S3VersionKey174E0E8E
       Role:
         Fn::GetAtt:
           - ConstructHubInventoryCanaryServiceRole7684EDDE
@@ -3493,6 +3496,7 @@ Resources:
         list of indexed packages"
       Environment:
         Variables:
+          AWS_EMF_ENVIRONMENT: Local
           BUCKET_NAME:
             Ref: ConstructHubPackageDataDC5EF35E
       Handler: index.handler
@@ -4765,18 +4769,18 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "6f1f07e70de63d5afdbcab762f8f867a2aedb494b30cd360d5deb518d3914263"
-  AssetParametersd2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2S3Bucket2E449B72:
+  AssetParameters8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946aS3Bucket2E9327D6:
     Type: String
     Description: S3 bucket for asset
-      "d2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2"
-  AssetParametersd2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2S3VersionKeyA2DCB0B4:
+      "8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946a"
+  AssetParameters8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946aS3VersionKey949D5568:
     Type: String
     Description: S3 key for asset version
-      "d2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2"
-  AssetParametersd2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2ArtifactHash8AA4097C:
+      "8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946a"
+  AssetParameters8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946aArtifactHash7BAE68F3:
     Type: String
     Description: Artifact hash for asset
-      "d2f9e85e5c4cb9855e1d36340a245ea6326317a222fef71c6ff7b17c887ff9b2"
+      "8adf71535c3f5bf41f33d9a43ecf1b8a7eaac0f2b3e5f7fa2ffaaa428c12946a"
   AssetParameters61d4c1bc1f52c5393c891a125157599d7eba7414b40d068abb4c07ae433e0b37S3Bucket71D3A47B:
     Type: String
     Description: S3 bucket for asset
@@ -4837,18 +4841,18 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "292b98a8dbac7057e18cb0a4c131464260f79de144be40905cc44eb06b73700f"
-  AssetParameters68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3S3Bucket3950C0EE:
+  AssetParameters0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bcS3Bucket6D44F554:
     Type: String
     Description: S3 bucket for asset
-      "68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3"
-  AssetParameters68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3S3VersionKey2164070C:
+      "0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bc"
+  AssetParameters0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bcS3VersionKey462DE115:
     Type: String
     Description: S3 key for asset version
-      "68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3"
-  AssetParameters68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3ArtifactHash23D97CE9:
+      "0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bc"
+  AssetParameters0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bcArtifactHashE5D04645:
     Type: String
     Description: Artifact hash for asset
-      "68d8714c84382c791df916885106edb377b4d52799b500174197640f5fd345d3"
+      "0394430ea816e135bdd397ed564f544a8fe78aced8913a7537f6e81f42d401bc"
   AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3BucketF36A877E:
     Type: String
     Description: S3 bucket for asset
@@ -4861,30 +4865,30 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658"
-  AssetParametersd74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ffS3Bucket0CDB3F85:
+  AssetParameters6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ffS3BucketB7466FA6:
     Type: String
     Description: S3 bucket for asset
-      "d74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ff"
-  AssetParametersd74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ffS3VersionKeyFE91DA6F:
+      "6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ff"
+  AssetParameters6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ffS3VersionKey00EDB7CB:
     Type: String
     Description: S3 key for asset version
-      "d74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ff"
-  AssetParametersd74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ffArtifactHash22400483:
+      "6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ff"
+  AssetParameters6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ffArtifactHash54E50C4E:
     Type: String
     Description: Artifact hash for asset
-      "d74a6177f9f11dff0fa4ca2a923268ff47b532c8f2ac37bfcbe7f127e6b384ff"
-  AssetParameters193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0eS3BucketBEF7922D:
+      "6f8f47ab2551cd03944399fbd488c889457817deff8ed6012344ec6198ee88ff"
+  AssetParameters684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1S3BucketFB2F9F6D:
     Type: String
     Description: S3 bucket for asset
-      "193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0e"
-  AssetParameters193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0eS3VersionKey5FE096DC:
+      "684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1"
+  AssetParameters684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1S3VersionKey174E0E8E:
     Type: String
     Description: S3 key for asset version
-      "193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0e"
-  AssetParameters193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0eArtifactHash65707448:
+      "684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1"
+  AssetParameters684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1ArtifactHashF9F3B2D5:
     Type: String
     Description: Artifact hash for asset
-      "193ab3d682298348f4722520b56200dd384854c5cb4fc35be0206421579c7d0e"
+      "684ad395ae5954ed850c03419d424bd8ce45476b4b1994d5a662ae24b3682fe1"
   AssetParameters52923bc19f53f9913f4071d1ded9e7d425e9ea0feaf543b4b3835db7fc4265ccS3BucketC2B2D2E0:
     Type: String
     Description: S3 bucket for asset

--- a/src/__tests__/package-sources/__snapshots__/code-artifact.test.ts.snap
+++ b/src/__tests__/package-sources/__snapshots__/code-artifact.test.ts.snap
@@ -3,16 +3,16 @@
 exports[`default configuration 1`] = `
 Object {
   "Parameters": Object {
-    "AssetParametersbcf72a082d6d90ba6c3db7db3fab9b0d857323ae031116e1012d11c0f2c5d861ArtifactHashA621B135": Object {
-      "Description": "Artifact hash for asset \\"bcf72a082d6d90ba6c3db7db3fab9b0d857323ae031116e1012d11c0f2c5d861\\"",
+    "AssetParameters7874e74ba540e98105efab45daec6b8b81149067d50c688956762f12a10932ecArtifactHashF10285F8": Object {
+      "Description": "Artifact hash for asset \\"7874e74ba540e98105efab45daec6b8b81149067d50c688956762f12a10932ec\\"",
       "Type": "String",
     },
-    "AssetParametersbcf72a082d6d90ba6c3db7db3fab9b0d857323ae031116e1012d11c0f2c5d861S3Bucket364D1EED": Object {
-      "Description": "S3 bucket for asset \\"bcf72a082d6d90ba6c3db7db3fab9b0d857323ae031116e1012d11c0f2c5d861\\"",
+    "AssetParameters7874e74ba540e98105efab45daec6b8b81149067d50c688956762f12a10932ecS3BucketAD59102C": Object {
+      "Description": "S3 bucket for asset \\"7874e74ba540e98105efab45daec6b8b81149067d50c688956762f12a10932ec\\"",
       "Type": "String",
     },
-    "AssetParametersbcf72a082d6d90ba6c3db7db3fab9b0d857323ae031116e1012d11c0f2c5d861S3VersionKey123FFEAF": Object {
-      "Description": "S3 key for asset version \\"bcf72a082d6d90ba6c3db7db3fab9b0d857323ae031116e1012d11c0f2c5d861\\"",
+    "AssetParameters7874e74ba540e98105efab45daec6b8b81149067d50c688956762f12a10932ecS3VersionKey98948FF7": Object {
+      "Description": "S3 key for asset version \\"7874e74ba540e98105efab45daec6b8b81149067d50c688956762f12a10932ec\\"",
       "Type": "String",
     },
   },
@@ -143,7 +143,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersbcf72a082d6d90ba6c3db7db3fab9b0d857323ae031116e1012d11c0f2c5d861S3Bucket364D1EED",
+            "Ref": "AssetParameters7874e74ba540e98105efab45daec6b8b81149067d50c688956762f12a10932ecS3BucketAD59102C",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -156,7 +156,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersbcf72a082d6d90ba6c3db7db3fab9b0d857323ae031116e1012d11c0f2c5d861S3VersionKey123FFEAF",
+                          "Ref": "AssetParameters7874e74ba540e98105efab45daec6b8b81149067d50c688956762f12a10932ecS3VersionKey98948FF7",
                         },
                       ],
                     },
@@ -169,7 +169,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersbcf72a082d6d90ba6c3db7db3fab9b0d857323ae031116e1012d11c0f2c5d861S3VersionKey123FFEAF",
+                          "Ref": "AssetParameters7874e74ba540e98105efab45daec6b8b81149067d50c688956762f12a10932ecS3VersionKey98948FF7",
                         },
                       ],
                     },
@@ -190,6 +190,7 @@ Object {
         "Description": "[Test/CodeArtifact/123456789012:mock-domain-name/mock-repository-name] Handle CodeArtifact EventBridge events",
         "Environment": Object {
           "Variables": Object {
+            "AWS_EMF_ENVIRONMENT": "Local",
             "BUCKET_NAME": Object {
               "Ref": "fakepathtorepositoryStagingBucketF571B2BA",
             },
@@ -532,16 +533,16 @@ Link to the lambda function: /lambda/home#/functions/",
 exports[`user-provided staging bucket 1`] = `
 Object {
   "Parameters": Object {
-    "AssetParametersbcf72a082d6d90ba6c3db7db3fab9b0d857323ae031116e1012d11c0f2c5d861ArtifactHashA621B135": Object {
-      "Description": "Artifact hash for asset \\"bcf72a082d6d90ba6c3db7db3fab9b0d857323ae031116e1012d11c0f2c5d861\\"",
+    "AssetParameters7874e74ba540e98105efab45daec6b8b81149067d50c688956762f12a10932ecArtifactHashF10285F8": Object {
+      "Description": "Artifact hash for asset \\"7874e74ba540e98105efab45daec6b8b81149067d50c688956762f12a10932ec\\"",
       "Type": "String",
     },
-    "AssetParametersbcf72a082d6d90ba6c3db7db3fab9b0d857323ae031116e1012d11c0f2c5d861S3Bucket364D1EED": Object {
-      "Description": "S3 bucket for asset \\"bcf72a082d6d90ba6c3db7db3fab9b0d857323ae031116e1012d11c0f2c5d861\\"",
+    "AssetParameters7874e74ba540e98105efab45daec6b8b81149067d50c688956762f12a10932ecS3BucketAD59102C": Object {
+      "Description": "S3 bucket for asset \\"7874e74ba540e98105efab45daec6b8b81149067d50c688956762f12a10932ec\\"",
       "Type": "String",
     },
-    "AssetParametersbcf72a082d6d90ba6c3db7db3fab9b0d857323ae031116e1012d11c0f2c5d861S3VersionKey123FFEAF": Object {
-      "Description": "S3 key for asset version \\"bcf72a082d6d90ba6c3db7db3fab9b0d857323ae031116e1012d11c0f2c5d861\\"",
+    "AssetParameters7874e74ba540e98105efab45daec6b8b81149067d50c688956762f12a10932ecS3VersionKey98948FF7": Object {
+      "Description": "S3 key for asset version \\"7874e74ba540e98105efab45daec6b8b81149067d50c688956762f12a10932ec\\"",
       "Type": "String",
     },
   },
@@ -623,7 +624,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersbcf72a082d6d90ba6c3db7db3fab9b0d857323ae031116e1012d11c0f2c5d861S3Bucket364D1EED",
+            "Ref": "AssetParameters7874e74ba540e98105efab45daec6b8b81149067d50c688956762f12a10932ecS3BucketAD59102C",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -636,7 +637,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersbcf72a082d6d90ba6c3db7db3fab9b0d857323ae031116e1012d11c0f2c5d861S3VersionKey123FFEAF",
+                          "Ref": "AssetParameters7874e74ba540e98105efab45daec6b8b81149067d50c688956762f12a10932ecS3VersionKey98948FF7",
                         },
                       ],
                     },
@@ -649,7 +650,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersbcf72a082d6d90ba6c3db7db3fab9b0d857323ae031116e1012d11c0f2c5d861S3VersionKey123FFEAF",
+                          "Ref": "AssetParameters7874e74ba540e98105efab45daec6b8b81149067d50c688956762f12a10932ecS3VersionKey98948FF7",
                         },
                       ],
                     },
@@ -670,6 +671,7 @@ Object {
         "Description": "[Test/CodeArtifact/123456789012:mock-domain-name/mock-repository-name] Handle CodeArtifact EventBridge events",
         "Environment": Object {
           "Variables": Object {
+            "AWS_EMF_ENVIRONMENT": "Local",
             "BUCKET_NAME": "mock-bucket",
             "QUEUE_URL": "https://fake-queue-url/phony",
           },

--- a/src/backend/catalog-builder/index.ts
+++ b/src/backend/catalog-builder/index.ts
@@ -44,6 +44,7 @@ export class CatalogBuilder extends Construct {
       description: `Creates the catalog.json object in ${props.bucket.bucketName}`,
       environment: {
         BUCKET_NAME: props.bucket.bucketName,
+        AWS_EMF_ENVIRONMENT: 'Local',
       },
       logRetention: props.logRetention ?? RetentionDays.TEN_YEARS,
       memorySize: 10_240, // Currently the maximum possible setting

--- a/src/backend/deny-list/prune-handler.lambda.ts
+++ b/src/backend/deny-list/prune-handler.lambda.ts
@@ -1,5 +1,4 @@
 import { Configuration, metricScope, Unit } from 'aws-embedded-metrics';
-import Environments from 'aws-embedded-metrics/lib/environment/Environments';
 import * as AWS from 'aws-sdk';
 import * as clients from '../shared/aws.lambda-shared';
 import { requireEnv } from '../shared/env.lambda-shared';
@@ -11,7 +10,6 @@ const sqs = clients.sqs();
 const lambda = clients.lambda();
 
 // Configure embedded metrics format
-Configuration.environmentOverride = Environments.Lambda;
 Configuration.namespace = METRICS_NAMESPACE;
 
 export async function handler(event: unknown) {

--- a/src/backend/ingestion/index.ts
+++ b/src/backend/ingestion/index.ts
@@ -98,10 +98,11 @@ export class Ingestion extends Construct implements IGrantable {
     const handler = new Handler(this, 'Default', {
       description: '[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub',
       environment: {
+        AWS_EMF_ENVIRONMENT: 'Local',
         BUCKET_NAME: props.bucket.bucketName,
-        STATE_MACHINE_ARN: props.orchestration.stateMachine.stateMachineArn,
         PACKAGE_LINKS: JSON.stringify(props.packageLinks ?? []),
         PACKAGE_TAGS: JSON.stringify(props.packageTags ?? []),
+        STATE_MACHINE_ARN: props.orchestration.stateMachine.stateMachineArn,
       },
       logRetention: props.logRetention ?? RetentionDays.TEN_YEARS,
       memorySize: 10_240, // Currently the maximum possible setting

--- a/src/backend/ingestion/ingestion.lambda.ts
+++ b/src/backend/ingestion/ingestion.lambda.ts
@@ -4,7 +4,6 @@ import { URL } from 'url';
 
 import { Assembly, validateAssembly } from '@jsii/spec';
 import { metricScope, Configuration, Unit } from 'aws-embedded-metrics';
-import Environments from 'aws-embedded-metrics/lib/environment/Environments';
 import type { Context, SQSEvent } from 'aws-lambda';
 import { SemVer } from 'semver';
 import type { PackageTagConfig } from '../../package-tag';
@@ -19,7 +18,6 @@ import { isTagApplicable } from '../shared/tags';
 import { extractObjects } from '../shared/tarball.lambda-shared';
 import { MetricName, METRICS_NAMESPACE } from './constants';
 
-Configuration.environmentOverride = Environments.Lambda;
 Configuration.namespace = METRICS_NAMESPACE;
 
 export const handler = metricScope(

--- a/src/backend/inventory/canary.lambda.ts
+++ b/src/backend/inventory/canary.lambda.ts
@@ -1,5 +1,4 @@
 import { metricScope, Configuration, Unit } from 'aws-embedded-metrics';
-import Environments from 'aws-embedded-metrics/lib/environment/Environments';
 import type { Context, ScheduledEvent } from 'aws-lambda';
 import { SemVer } from 'semver';
 import * as aws from '../shared/aws.lambda-shared';
@@ -8,7 +7,6 @@ import { requireEnv } from '../shared/env.lambda-shared';
 import { DocumentationLanguage } from '../shared/language';
 import { METRICS_NAMESPACE, MetricName, LANGUAGE_DIMENSION } from './constants';
 
-Configuration.environmentOverride = Environments.Lambda;
 Configuration.namespace = METRICS_NAMESPACE;
 
 export async function handler(event: ScheduledEvent, _context: Context) {

--- a/src/backend/inventory/index.ts
+++ b/src/backend/inventory/index.ts
@@ -50,7 +50,10 @@ export class Inventory extends Construct {
 
     this.canary = new Canary(this, 'Resource', {
       description: '[ConstructHub/Inventory] A canary that periodically inspects the list of indexed packages',
-      environment: { BUCKET_NAME: props.bucket.bucketName },
+      environment: {
+        AWS_EMF_ENVIRONMENT: 'Local',
+        BUCKET_NAME: props.bucket.bucketName,
+      },
       logRetention: props.logRetention,
       memorySize: 10_240,
       timeout: rate,

--- a/src/monitored-certificate/index.ts
+++ b/src/monitored-certificate/index.ts
@@ -68,9 +68,10 @@ export class MonitoredCertificate extends Construct {
     const dynamicMonitor = new CertificateMonitor(this, 'Monitor', {
       description: `Monitors the days to expiry of the certificate used to serve ${props.domainName}`,
       environment: {
+        AWS_EMF_ENVIRONMENT: 'Local',
         HTTPS_ENDPOINT: props.domainName,
-        METRIC_NAMESPACE: this.endpointMetricNamespace,
         METRIC_NAME: this.endpointMetricName,
+        METRIC_NAMESPACE: this.endpointMetricNamespace,
       },
       memorySize: 1_024,
       timeout: Duration.minutes(5),

--- a/src/package-sources/code-artifact.ts
+++ b/src/package-sources/code-artifact.ts
@@ -54,6 +54,7 @@ export class CodeArtifact implements IPackageSource {
       deadLetterQueue: dlq,
       description: `[${scope.node.path}/CodeArtifact/${repositoryId}] Handle CodeArtifact EventBridge events`,
       environment: {
+        AWS_EMF_ENVIRONMENT: 'Local',
         BUCKET_NAME: bucket.bucketName,
         QUEUE_URL: queue.queueUrl,
       },

--- a/src/package-sources/codeartifact/code-artifact-forwarder.lambda.ts
+++ b/src/package-sources/codeartifact/code-artifact-forwarder.lambda.ts
@@ -1,5 +1,4 @@
-import { Configuration, metricScope, Unit } from 'aws-embedded-metrics';
-import Environments from 'aws-embedded-metrics/lib/environment/Environments';
+import { metricScope, Unit } from 'aws-embedded-metrics';
 import type { Context, EventBridgeEvent } from 'aws-lambda';
 
 import { DenyListClient } from '../../backend/deny-list/client.lambda-shared';
@@ -12,8 +11,6 @@ import { extractObjects } from '../../backend/shared/tarball.lambda-shared';
 import { METRICS_NAMESPACE, MetricName, DOMAIN_OWNER_DIMENSION, DOMAIN_NAME_DIMENSION, REPOSITORY_NAME_DIMENSION } from './constants.lambda-shared';
 
 const DETAIL_TYPE = 'CodeArtifact Package Version State Change' as const;
-
-Configuration.environmentOverride = Environments.Lambda;
 
 export const handler = metricScope((metrics) => async (event: EventBridgeEvent<typeof DETAIL_TYPE, CodeArtifactDetail>, context: Context) => {
   console.log(`Event: ${JSON.stringify(event, null, 2)}`);

--- a/src/package-sources/npmjs.ts
+++ b/src/package-sources/npmjs.ts
@@ -43,6 +43,7 @@ export class NpmJs implements IPackageSource {
     const follower = new NpmJsFollower(scope, 'NpmJs', {
       description: `[${scope.node.path}/NpmJs] Periodically query npmjs.com index for new packages`,
       environment: {
+        AWS_EMF_ENVIRONMENT: 'Local',
         BUCKET_NAME: bucket.bucketName,
         QUEUE_URL: queue.queueUrl,
       },

--- a/src/package-sources/npmjs/npm-js-follower.lambda.ts
+++ b/src/package-sources/npmjs/npm-js-follower.lambda.ts
@@ -3,7 +3,6 @@ import * as https from 'https';
 import { URL } from 'url';
 
 import { metricScope, Configuration, MetricsLogger, Unit } from 'aws-embedded-metrics';
-import Environments from 'aws-embedded-metrics/lib/environment/Environments';
 import type { Context, ScheduledEvent } from 'aws-lambda';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import Nano = require('nano');
@@ -22,7 +21,6 @@ const CONSTRUCT_KEYWORDS: ReadonlySet<string> = new Set(['cdk', 'aws-cdk', 'awsc
 const NPM_REPLICA_REGISTRY_URL = 'https://replicate.npmjs.com/';
 
 // Configure embedded metrics format
-Configuration.environmentOverride = Environments.Lambda;
 Configuration.namespace = METRICS_NAMESPACE;
 
 /**


### PR DESCRIPTION
This disables all automated decoration (i.e: dimensions), which we are
not using anyway, and ensures metrics are flushed out to STDOUT. This is
done by setting an environment variable on Lambda functions that
controls the default behavior of the `aws-embedded-metrics` library.

Locally, this has the effect of correctly emitting the metrics within
the canary lambda function, which stopped working in production a couple
of days/weeks ago for an unknown reason.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*