### PR TITLE
fix: CloudWatch logs buffer saturating in inventory function

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -141,6 +141,18 @@ Object {
       "Description": "S3 key for asset version \\"3cc7fc9fb662480244296e4d3eb332ea8d84404a8d083239d5df9406e94ac790\\"",
       "Type": "String",
     },
+    "AssetParameters3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3eArtifactHash4D80EC28": Object {
+      "Description": "Artifact hash for asset \\"3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3e\\"",
+      "Type": "String",
+    },
+    "AssetParameters3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3eS3Bucket873095AF": Object {
+      "Description": "S3 bucket for asset \\"3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3e\\"",
+      "Type": "String",
+    },
+    "AssetParameters3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3eS3VersionKeyD785B973": Object {
+      "Description": "S3 key for asset version \\"3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3e\\"",
+      "Type": "String",
+    },
     "AssetParameters4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbcArtifactHashF236251A": Object {
       "Description": "Artifact hash for asset \\"4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbc\\"",
       "Type": "String",
@@ -199,18 +211,6 @@ Object {
     },
     "AssetParameters8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064S3VersionKey5B081B37": Object {
       "Description": "S3 key for asset version \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
-      "Type": "String",
-    },
-    "AssetParameters9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4ArtifactHashF33B02A6": Object {
-      "Description": "Artifact hash for asset \\"9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4\\"",
-      "Type": "String",
-    },
-    "AssetParameters9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4S3Bucket56727124": Object {
-      "Description": "S3 bucket for asset \\"9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4\\"",
-      "Type": "String",
-    },
-    "AssetParameters9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4S3VersionKey8520F957": Object {
-      "Description": "S3 key for asset version \\"9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4\\"",
       "Type": "String",
     },
     "AssetParametersa9c1126f433d4d7214e1150e73f618dcbf66cfface99922057bbad43792f8baaArtifactHash8FB5D501": Object {
@@ -2208,7 +2208,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4S3Bucket56727124",
+            "Ref": "AssetParameters3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3eS3Bucket873095AF",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -2221,7 +2221,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4S3VersionKey8520F957",
+                          "Ref": "AssetParameters3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3eS3VersionKeyD785B973",
                         },
                       ],
                     },
@@ -2234,7 +2234,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4S3VersionKey8520F957",
+                          "Ref": "AssetParameters3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3eS3VersionKeyD785B973",
                         },
                       ],
                     },
@@ -8307,6 +8307,18 @@ Object {
       "Description": "S3 key for asset version \\"3cc7fc9fb662480244296e4d3eb332ea8d84404a8d083239d5df9406e94ac790\\"",
       "Type": "String",
     },
+    "AssetParameters3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3eArtifactHash4D80EC28": Object {
+      "Description": "Artifact hash for asset \\"3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3e\\"",
+      "Type": "String",
+    },
+    "AssetParameters3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3eS3Bucket873095AF": Object {
+      "Description": "S3 bucket for asset \\"3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3e\\"",
+      "Type": "String",
+    },
+    "AssetParameters3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3eS3VersionKeyD785B973": Object {
+      "Description": "S3 key for asset version \\"3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3e\\"",
+      "Type": "String",
+    },
     "AssetParameters4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbcArtifactHashF236251A": Object {
       "Description": "Artifact hash for asset \\"4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbc\\"",
       "Type": "String",
@@ -8365,18 +8377,6 @@ Object {
     },
     "AssetParameters8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064S3VersionKey5B081B37": Object {
       "Description": "S3 key for asset version \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
-      "Type": "String",
-    },
-    "AssetParameters9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4ArtifactHashF33B02A6": Object {
-      "Description": "Artifact hash for asset \\"9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4\\"",
-      "Type": "String",
-    },
-    "AssetParameters9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4S3Bucket56727124": Object {
-      "Description": "S3 bucket for asset \\"9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4\\"",
-      "Type": "String",
-    },
-    "AssetParameters9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4S3VersionKey8520F957": Object {
-      "Description": "S3 key for asset version \\"9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4\\"",
       "Type": "String",
     },
     "AssetParametersa9c1126f433d4d7214e1150e73f618dcbf66cfface99922057bbad43792f8baaArtifactHash8FB5D501": Object {
@@ -10381,7 +10381,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4S3Bucket56727124",
+            "Ref": "AssetParameters3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3eS3Bucket873095AF",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -10394,7 +10394,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4S3VersionKey8520F957",
+                          "Ref": "AssetParameters3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3eS3VersionKeyD785B973",
                         },
                       ],
                     },
@@ -10407,7 +10407,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4S3VersionKey8520F957",
+                          "Ref": "AssetParameters3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3eS3VersionKeyD785B973",
                         },
                       ],
                     },
@@ -16518,6 +16518,18 @@ Object {
       "Description": "S3 key for asset version \\"3cc7fc9fb662480244296e4d3eb332ea8d84404a8d083239d5df9406e94ac790\\"",
       "Type": "String",
     },
+    "AssetParameters3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3eArtifactHash4D80EC28": Object {
+      "Description": "Artifact hash for asset \\"3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3e\\"",
+      "Type": "String",
+    },
+    "AssetParameters3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3eS3Bucket873095AF": Object {
+      "Description": "S3 bucket for asset \\"3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3e\\"",
+      "Type": "String",
+    },
+    "AssetParameters3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3eS3VersionKeyD785B973": Object {
+      "Description": "S3 key for asset version \\"3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3e\\"",
+      "Type": "String",
+    },
     "AssetParameters4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbcArtifactHashF236251A": Object {
       "Description": "Artifact hash for asset \\"4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbc\\"",
       "Type": "String",
@@ -16600,18 +16612,6 @@ Object {
     },
     "AssetParameters8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064S3VersionKey5B081B37": Object {
       "Description": "S3 key for asset version \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
-      "Type": "String",
-    },
-    "AssetParameters9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4ArtifactHashF33B02A6": Object {
-      "Description": "Artifact hash for asset \\"9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4\\"",
-      "Type": "String",
-    },
-    "AssetParameters9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4S3Bucket56727124": Object {
-      "Description": "S3 bucket for asset \\"9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4\\"",
-      "Type": "String",
-    },
-    "AssetParameters9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4S3VersionKey8520F957": Object {
-      "Description": "S3 key for asset version \\"9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4\\"",
       "Type": "String",
     },
     "AssetParametersa9c1126f433d4d7214e1150e73f618dcbf66cfface99922057bbad43792f8baaArtifactHash8FB5D501": Object {
@@ -18758,7 +18758,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4S3Bucket56727124",
+            "Ref": "AssetParameters3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3eS3Bucket873095AF",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -18771,7 +18771,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4S3VersionKey8520F957",
+                          "Ref": "AssetParameters3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3eS3VersionKeyD785B973",
                         },
                       ],
                     },
@@ -18784,7 +18784,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4S3VersionKey8520F957",
+                          "Ref": "AssetParameters3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3eS3VersionKeyD785B973",
                         },
                       ],
                     },
@@ -25158,6 +25158,18 @@ Object {
       "Description": "S3 key for asset version \\"3cc7fc9fb662480244296e4d3eb332ea8d84404a8d083239d5df9406e94ac790\\"",
       "Type": "String",
     },
+    "AssetParameters3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3eArtifactHash4D80EC28": Object {
+      "Description": "Artifact hash for asset \\"3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3e\\"",
+      "Type": "String",
+    },
+    "AssetParameters3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3eS3Bucket873095AF": Object {
+      "Description": "S3 bucket for asset \\"3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3e\\"",
+      "Type": "String",
+    },
+    "AssetParameters3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3eS3VersionKeyD785B973": Object {
+      "Description": "S3 key for asset version \\"3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3e\\"",
+      "Type": "String",
+    },
     "AssetParameters4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbcArtifactHashF236251A": Object {
       "Description": "Artifact hash for asset \\"4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbc\\"",
       "Type": "String",
@@ -25216,18 +25228,6 @@ Object {
     },
     "AssetParameters8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064S3VersionKey5B081B37": Object {
       "Description": "S3 key for asset version \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
-      "Type": "String",
-    },
-    "AssetParameters9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4ArtifactHashF33B02A6": Object {
-      "Description": "Artifact hash for asset \\"9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4\\"",
-      "Type": "String",
-    },
-    "AssetParameters9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4S3Bucket56727124": Object {
-      "Description": "S3 bucket for asset \\"9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4\\"",
-      "Type": "String",
-    },
-    "AssetParameters9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4S3VersionKey8520F957": Object {
-      "Description": "S3 key for asset version \\"9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4\\"",
       "Type": "String",
     },
     "AssetParametersa9c1126f433d4d7214e1150e73f618dcbf66cfface99922057bbad43792f8baaArtifactHash8FB5D501": Object {
@@ -27160,7 +27160,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4S3Bucket56727124",
+            "Ref": "AssetParameters3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3eS3Bucket873095AF",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -27173,7 +27173,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4S3VersionKey8520F957",
+                          "Ref": "AssetParameters3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3eS3VersionKeyD785B973",
                         },
                       ],
                     },
@@ -27186,7 +27186,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4S3VersionKey8520F957",
+                          "Ref": "AssetParameters3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3eS3VersionKeyD785B973",
                         },
                       ],
                     },

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -3499,7 +3499,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4S3Bucket56727124
+          Ref: AssetParameters3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3eS3Bucket873095AF
         S3Key:
           Fn::Join:
             - ""
@@ -3507,12 +3507,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4S3VersionKey8520F957
+                      - Ref: AssetParameters3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3eS3VersionKeyD785B973
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4S3VersionKey8520F957
+                      - Ref: AssetParameters3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3eS3VersionKeyD785B973
       Role:
         Fn::GetAtt:
           - ConstructHubInventoryCanaryServiceRole7684EDDE
@@ -4907,18 +4907,18 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "41af655bf242608677fb1b76a2fc7928bf1be45ab323eacd1bd5002412949214"
-  AssetParameters9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4S3Bucket56727124:
+  AssetParameters3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3eS3Bucket873095AF:
     Type: String
     Description: S3 bucket for asset
-      "9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4"
-  AssetParameters9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4S3VersionKey8520F957:
+      "3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3e"
+  AssetParameters3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3eS3VersionKeyD785B973:
     Type: String
     Description: S3 key for asset version
-      "9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4"
-  AssetParameters9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4ArtifactHashF33B02A6:
+      "3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3e"
+  AssetParameters3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3eArtifactHash4D80EC28:
     Type: String
     Description: Artifact hash for asset
-      "9f90a1d26064edf8a2a7508b7d8f2bd02933eaeab73bfb7a570512566c26c5e4"
+      "3da8b81a6f8cf12a6f74eee62e85d82f28e229ca16017abcb564a22f908c4d3e"
   AssetParametersa9c1126f433d4d7214e1150e73f618dcbf66cfface99922057bbad43792f8baaS3Bucket1390AE13:
     Type: String
     Description: S3 bucket for asset


### PR DESCRIPTION
The inventory function is producing lines that exceed the maximum size
of the CloudWatch logs agent buffer, resulting in dropped metrics as it
catchs it's breath.

Reducing the length of logged lines ensures metrics are properly
produced.

Additionally, stopped outputting unsupported & supported packages, only
outputting the list of missing (i.e: problematic) packages.

Fixes https://github.com/cdklabs/construct-hub-internal/issues/50

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*