### PR TITLE
fix: command `integ:deny-list:destroy` changes snapshot by mistake

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -557,7 +557,7 @@
       "description": "destroy integration test __tests__/backend/deny-list/integ/deny-list.integ.ts",
       "steps": [
         {
-          "exec": "cdk destroy --app src/__tests__/backend/deny-list/integ/deny-list.integ.cdkout"
+          "exec": "cdk destroy --app src/__tests__/backend/deny-list/integ/deny-list.integ.cdkout --no-version-reporting"
         }
       ]
     },

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -214,7 +214,7 @@ function discoverIntegrationTests() {
 
     const destroy = project.addTask(`integ:${name}:destroy`, {
       description: `destroy integration test ${entry}`,
-      exec: `cdk destroy --app ${snapshotdir}`,
+      exec: `cdk destroy --app ${snapshotdir} --no-version-reporting`,
     });
 
     deploy.spawn(destroy);


### PR DESCRIPTION
Add option ` --no-version-reporting` to command `cdk destroy` in integration tests.

Without this option, command `integ:deny-list:destroy` will change the snapshot used for integration tests. In this case, further test executions will fail.

Fixes #338.

@eladb 

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*