### PR TITLE
fix: NpmJS follower times out / appears to hang

### DIFF
--- a/src/package-sources/npmjs/couch-changes.lambda-shared.ts
+++ b/src/package-sources/npmjs/couch-changes.lambda-shared.ts
@@ -1,8 +1,27 @@
+import * as buffer from 'buffer';
 import { EventEmitter } from 'events';
 import { OutgoingHttpHeaders } from 'http';
 import { Agent, request } from 'https';
 import { URL } from 'url';
 import { gunzipSync } from 'zlib';
+
+/**
+ * The maximum length of a response body we can accept that we will be able to
+ * successfully parse out. There is a limit in node on how big a string instance
+ * can be, and `JSON.parse` only operates on string instances. If we get too
+ * many unicode code-points, we will simply not be able to parse the result out,
+ * and will thow an error with an appropriate error message.
+ */
+const MAX_DATA_LENGTH = Math.min(
+  // NOTE: MAX_STRING_LENGTH is expressed in UTF-16 code units. We expect to receive JSON
+  // which ultimately is UTF-8-encoded text. An UTF-16 code unit is 32 bits, but this
+  // maps to between 8 and 32 bits in UTF-8... Consequently, we can't allow more than
+  // MAX_StRING_LENGTH / 4 if we want to be certain we can stringify the buffer.
+  Math.floor(buffer.constants.MAX_STRING_LENGTH / 4),
+  // This is the maximum length of a Buffer instance. We cannot technically accept any
+  // more data than this... so we won't even be trying to.
+  buffer.constants.MAX_LENGTH,
+);
 
 /**
  * A utility class that helps with traversing CouchDB database changes streams
@@ -43,16 +62,31 @@ export class CouchChanges extends EventEmitter {
    *
    * @returns a page of changes.
    */
-  public async changes(since: string | number, { batchSize = 100 }: { readonly batchSize?: number } = {}): Promise<DatabaseChanges> {
+  public async changes(since: string | number, opts?: { readonly batchSize?: number }): Promise<DatabaseChanges> {
+    const batchSize = opts?.batchSize ?? 100;
+
     const changesUrl = new URL('_changes', this.baseUrl);
-    changesUrl.searchParams.set('limit', batchSize.toFixed());
     changesUrl.searchParams.set('include_docs', 'true');
+    changesUrl.searchParams.set('limit', batchSize.toFixed());
     changesUrl.searchParams.set('selector', '_filter');
+    changesUrl.searchParams.set('seq_interval', batchSize.toFixed());
     changesUrl.searchParams.set('since', since.toString());
+    changesUrl.searchParams.set('timeout', '20000' /* ms */);
 
     const filter = { name: { $gt: null } };
 
-    return await this.https('post', changesUrl, filter) as any;
+    try {
+      return await this.https('post', changesUrl, filter) as any;
+    } catch (err) {
+      if (err instanceof ResponseTooLargeError && batchSize > 1) {
+        // The response was too large, try again, but with a smaller batch size
+        const smallerBatchSize = Math.max(1, Math.floor(batchSize / 2));
+        console.log(`Batch of ${batchSize} from ${since} was too large... Trying again with batch size of ${smallerBatchSize}`);
+        return this.changes(since, { ...opts, batchSize: smallerBatchSize });
+      }
+      // Else simply forward the error out again...
+      return Promise.reject(err);
+    }
   }
 
   /**
@@ -74,7 +108,7 @@ export class CouchChanges extends EventEmitter {
     return new Promise((ok, ko) => {
       const retry = () => setTimeout(
         () => {
-          console.log(`Retrying ${method.toUpperCase()} ${url.toString()}`);
+          console.log(`Retrying ${method.toUpperCase()} ${url}`);
           this.https(method, url, body, attempt + 1).then(ok, ko);
         },
         Math.min(500 * attempt, 5_000),
@@ -87,6 +121,7 @@ export class CouchChanges extends EventEmitter {
       if (body) {
         headers['Content-Type'] = 'application/json';
       }
+      console.log(`Request: ${method.toUpperCase()} ${url}`);
       const req = request(
         url,
         {
@@ -98,52 +133,70 @@ export class CouchChanges extends EventEmitter {
         },
         (res) => {
           if (res.statusCode == null) {
-            const error = new Error(`[FATAL] Request failed: ${method.toUpperCase()} ${url.toString()}`);
+            const error = new Error(`[FATAL] Request failed: ${method.toUpperCase()} ${url}`);
             Error.captureStackTrace(error);
             return ko(error);
           }
+
+          console.log(`Response: ${method.toUpperCase()} ${url} => HTTP ${res.statusCode} (${res.statusMessage})`);
+
           // Transient (server) errors:
           if (res.statusCode >= 500 && res.statusCode < 600) {
-            console.error(`[RETRYABLE] HTTP ${res.statusCode} (${res.statusMessage}) - ${method.toUpperCase()} ${url.toString()}`);
+            console.error(`[RETRYABLE] HTTP ${res.statusCode} (${res.statusMessage}) - ${method.toUpperCase()} ${url}`);
             // Call again after a short back-off
             return retry();
           }
           // Permanent (client) errors:
           if (res.statusCode >= 400 && res.statusCode < 500) {
-            const error = new Error(`[FATAL] HTTP ${res.statusCode} (${res.statusMessage}) - ${method.toUpperCase()} ${url.toString()}`);
+            const error = new Error(`[FATAL] HTTP ${res.statusCode} (${res.statusMessage}) - ${method.toUpperCase()} ${url}`);
             Error.captureStackTrace(error);
             return ko(error);
           }
 
-          let data = Buffer.alloc(
-            typeof res.headers['content-length'] === 'string'
-              ? Number.parseInt(res.headers['content-length'])
-              : 4_096,
-          );
-          let dataLength = 0;
-
           res.once('error', (err: Error & { code?: string }) => {
+            // Don't call the `close` handler - we are reporting failure or retrying in a new request here...
+            res.removeAllListeners('close');
             if (err.code === 'ECONNRESET') {
               // Transient networking problem?
-              console.error(`[RETRYABLE] ${err.code} - ${method.toUpperCase()} ${url.toString()}`);
-              res.removeAllListeners('close');
+              console.error(`[RETRYABLE] ${err.code} - ${method.toUpperCase()} ${url}`);
               retry();
             } else {
-              debugger;
               ko(err);
             }
           });
+
+          // We'll increase the buffer size by at least this much if the buffer we currently have is
+          // not large enough. CouchDB typically sends response in `chunked` encoding, so we don't
+          // know the full length of the response in advance... We hence try to avoid doing too many
+          // expensive copies if the response is very large (it can be!).
+          const bufferIncrements = 1_048_576; /* 1MiB */
+          let data = Buffer.alloc(
+            typeof res.headers['content-length'] === 'string'
+              ? Number.parseInt(res.headers['content-length'])
+              : bufferIncrements,
+          );
+          let dataLength = 0;
           res.on('data', (chunk) => {
-            const buffer = chunk = Buffer.from(chunk);
-            if (dataLength + buffer.length > data.length) {
+            const chunkBuffer = chunk = Buffer.from(chunk);
+            // Check if we still have capacity to accept that data without going too large to parse...
+            if (dataLength + chunkBuffer.length > MAX_DATA_LENGTH) {
+              console.log(`Response too large (> ${MAX_DATA_LENGTH}), aborting: ${method.toUpperCase()} ${url}`);
+              // We won't be able to stringify this... no point in continuing. Calling destroy with
+              // an error will cause the `error` event to be emitted, then the `close` event will be
+              // emitted. Any outstanding data will be dropped, the socket will be destroyed.
+              req.destroy(new ResponseTooLargeError(method, url));
+              return;
+            }
+            if (dataLength + chunkBuffer.length > data.length) {
               // Buffer is not large enough, extend it to fit new data...
               const existing = data;
-              data = Buffer.alloc(data.length + Math.max(buffer.length, 4_096));
+              data = Buffer.alloc(Math.min(data.length + Math.max(chunkBuffer.length, bufferIncrements), buffer.constants.MAX_LENGTH));
               existing.copy(data);
             }
-            buffer.copy(data, dataLength);
-            dataLength += buffer.length;
+            chunkBuffer.copy(data, dataLength);
+            dataLength += chunkBuffer.length;
           });
+
           res.once('close', () => {
             // Ensure buffer is trimmed to correct length.
             data = data.subarray(0, dataLength);
@@ -151,14 +204,22 @@ export class CouchChanges extends EventEmitter {
               if (res.headers['content-encoding'] === 'gzip') {
                 data = gunzipSync(data);
               }
-              ok(JSON.parse(data.toString('utf-8')));
+              console.log(`Response: ${method.toUpperCase()} ${url} => ${dataLength} bytes`);
+              try {
+                ok(JSON.parse(data.toString('utf-8')));
+              } catch (err) {
+                if (err.code === 'ERR_STRING_TOO_LONG') {
+                  ko(new ResponseTooLargeError(method, url, err));
+                } else {
+                  ko(err);
+                }
+              }
             } catch (error) {
               if ((error as Error & { code?: string }).code === 'Z_BUF_ERROR') {
                 // Truncated payload... Connection cut too early?
-                console.error(`[RETRYABLE] Z_BUF_ERROR (${error.message}) - ${method.toUpperCase()} ${url.toString()}`);
+                console.error(`[RETRYABLE] Z_BUF_ERROR (${error.message}) - ${method.toUpperCase()} ${url}`);
                 retry();
               } else {
-                debugger;
                 ko(error);
               }
             }
@@ -202,9 +263,10 @@ export interface DatabaseChange {
   readonly id: string;
 
   /**
-   * The sequence ID for this change in the stream.
+   * The sequence ID for this change in the stream. It may not be present for
+   * all (or any) entries in the result.
    */
-  readonly seq: string | number;
+  readonly seq?: string | number;
 
   /**
    * Whether this change corresponds to this document being deleted.
@@ -230,4 +292,13 @@ export interface DatabaseInfos {
     readonly file: number;
   };
   readonly update_seq: string | number;
+}
+
+class ResponseTooLargeError extends Error {
+  public readonly name = ResponseTooLargeError.name;
+
+  public constructor(method: string, url: URL, public readonly cause?: any) {
+    super(`The response to ${method.toUpperCase()} ${url} is too large, and cannot be JSON.parse'd.`);
+    Error.captureStackTrace(this, ResponseTooLargeError);
+  }
 }

--- a/src/package-sources/npmjs/npm-js-follower.lambda.ts
+++ b/src/package-sources/npmjs/npm-js-follower.lambda.ts
@@ -123,7 +123,7 @@ export async function handler(event: ScheduledEvent, context: Context) {
               integrity: infos.dist.shasum,
               modified: modified.toISOString(),
               name: infos.name,
-              seq: seq.toString(),
+              seq: seq?.toString(),
               tarballUrl: infos.dist.tarball,
               version: infos.version,
             };
@@ -456,7 +456,7 @@ interface UpdatedVersion {
   /**
    * The CouchDB transaction number for the update.
    */
-  readonly seq: string | number;
+  readonly seq?: string | number;
 }
 
 interface Document {
@@ -485,8 +485,5 @@ interface Document {
 }
 
 interface Change extends DatabaseChange {
-  readonly seq: string;
   readonly doc: Document;
-  readonly id: string;
-  readonly deleted: boolean;
 }

--- a/src/package-sources/npmjs/stage-and-notify.lambda.ts
+++ b/src/package-sources/npmjs/stage-and-notify.lambda.ts
@@ -56,7 +56,8 @@ export async function handler(event: PackageVersion | SQSEvent, context: Context
       'Modified-At': event.modified,
       'Origin-Integrity': event.integrity,
       'Origin-URI': event.tarballUrl,
-      'Sequence': event.seq,
+      // Seq might not be present... so skip it if absent...
+      ...(event.seq ? { Sequence: event.seq } : {}),
     },
   }).promise();
 
@@ -68,7 +69,8 @@ export async function handler(event: PackageVersion | SQSEvent, context: Context
         dist: event.tarballUrl,
         integrity: event.integrity,
         modified: event.modified,
-        seq: event.seq,
+        // Seq might not be present... so skip it if absent...
+        ...(event.seq ? { seq: event.seq } : { }),
       },
       time: event.modified,
     },
@@ -96,7 +98,7 @@ export interface PackageVersion {
   readonly tarballUrl: string;
   readonly integrity: string;
 
-  readonly seq: string;
+  readonly seq?: string;
 }
 
 /**


### PR DESCRIPTION
The NpmJS follower is requesting batches of 100 changes by default, but
this can result in excessively large response payloads. There is a limit
in how long a string can be when created from a `Buffer` instance, and
`JSON.parse` only operates on `string` instances.

Consequently, we aim to detect when the response has grown larger than
what we can stringify, and throw a dedicated error in case this happens.
The `changes` endpoint detects this particular error condition and
retries with a batch size reduced by half until the batch size is equal
to 1, at which point it will let the error bubble up to the client.

The follower appeared to hang because the `close` event of the HTTP
message was crashing without ever calling the `resolve` nor `reject`
handlers of the `Promise`, because it was throwing an error before
getting there.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*