### PR TITLE
fix(ingestion): CA publish failures cause ingestion failures

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -105,6 +105,18 @@ Object {
       "Description": "S3 key for asset version \\"4251843552ca3ae129a06633a70fa27fc92b47ab849687033c3ad1e7fce03130\\"",
       "Type": "String",
     },
+    "AssetParameters488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12ArtifactHash794BC30F": Object {
+      "Description": "Artifact hash for asset \\"488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12\\"",
+      "Type": "String",
+    },
+    "AssetParameters488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12S3BucketC21384F6": Object {
+      "Description": "S3 bucket for asset \\"488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12\\"",
+      "Type": "String",
+    },
+    "AssetParameters488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12S3VersionKey2E24D57B": Object {
+      "Description": "S3 key for asset version \\"488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12\\"",
+      "Type": "String",
+    },
     "AssetParameters663fcf0912a43161b04556b6e82be6ae6e1f55c7b06466d6939c51a53a7c4be3ArtifactHashDE1DA343": Object {
       "Description": "Artifact hash for asset \\"663fcf0912a43161b04556b6e82be6ae6e1f55c7b06466d6939c51a53a7c4be3\\"",
       "Type": "String",
@@ -175,18 +187,6 @@ Object {
     },
     "AssetParametersb120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827S3VersionKeyB95D17C3": Object {
       "Description": "S3 key for asset version \\"b120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827\\"",
-      "Type": "String",
-    },
-    "AssetParametersc01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87ArtifactHashDC72D8F7": Object {
-      "Description": "Artifact hash for asset \\"c01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87\\"",
-      "Type": "String",
-    },
-    "AssetParametersc01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87S3Bucket51FB6AD9": Object {
-      "Description": "S3 bucket for asset \\"c01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87\\"",
-      "Type": "String",
-    },
-    "AssetParametersc01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87S3VersionKeyA8F1A8B1": Object {
-      "Description": "S3 key for asset version \\"c01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87\\"",
       "Type": "String",
     },
     "AssetParametersc5ed3506ccf141325c557e0e0c7990b8436c834222d75edcc64d8220f0e46245ArtifactHashEBD3FED7": Object {
@@ -2026,7 +2026,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87S3Bucket51FB6AD9",
+            "Ref": "AssetParameters488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12S3BucketC21384F6",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -2039,7 +2039,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87S3VersionKeyA8F1A8B1",
+                          "Ref": "AssetParameters488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12S3VersionKey2E24D57B",
                         },
                       ],
                     },
@@ -2052,7 +2052,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87S3VersionKeyA8F1A8B1",
+                          "Ref": "AssetParameters488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12S3VersionKey2E24D57B",
                         },
                       ],
                     },
@@ -10418,6 +10418,18 @@ Object {
       "Description": "S3 key for asset version \\"4251843552ca3ae129a06633a70fa27fc92b47ab849687033c3ad1e7fce03130\\"",
       "Type": "String",
     },
+    "AssetParameters488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12ArtifactHash794BC30F": Object {
+      "Description": "Artifact hash for asset \\"488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12\\"",
+      "Type": "String",
+    },
+    "AssetParameters488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12S3BucketC21384F6": Object {
+      "Description": "S3 bucket for asset \\"488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12\\"",
+      "Type": "String",
+    },
+    "AssetParameters488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12S3VersionKey2E24D57B": Object {
+      "Description": "S3 key for asset version \\"488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12\\"",
+      "Type": "String",
+    },
     "AssetParameters663fcf0912a43161b04556b6e82be6ae6e1f55c7b06466d6939c51a53a7c4be3ArtifactHashDE1DA343": Object {
       "Description": "Artifact hash for asset \\"663fcf0912a43161b04556b6e82be6ae6e1f55c7b06466d6939c51a53a7c4be3\\"",
       "Type": "String",
@@ -10488,18 +10500,6 @@ Object {
     },
     "AssetParametersb120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827S3VersionKeyB95D17C3": Object {
       "Description": "S3 key for asset version \\"b120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827\\"",
-      "Type": "String",
-    },
-    "AssetParametersc01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87ArtifactHashDC72D8F7": Object {
-      "Description": "Artifact hash for asset \\"c01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87\\"",
-      "Type": "String",
-    },
-    "AssetParametersc01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87S3Bucket51FB6AD9": Object {
-      "Description": "S3 bucket for asset \\"c01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87\\"",
-      "Type": "String",
-    },
-    "AssetParametersc01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87S3VersionKeyA8F1A8B1": Object {
-      "Description": "S3 key for asset version \\"c01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87\\"",
       "Type": "String",
     },
     "AssetParametersc5ed3506ccf141325c557e0e0c7990b8436c834222d75edcc64d8220f0e46245ArtifactHashEBD3FED7": Object {
@@ -12292,7 +12292,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87S3Bucket51FB6AD9",
+            "Ref": "AssetParameters488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12S3BucketC21384F6",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -12305,7 +12305,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87S3VersionKeyA8F1A8B1",
+                          "Ref": "AssetParameters488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12S3VersionKey2E24D57B",
                         },
                       ],
                     },
@@ -12318,7 +12318,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87S3VersionKeyA8F1A8B1",
+                          "Ref": "AssetParameters488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12S3VersionKey2E24D57B",
                         },
                       ],
                     },
@@ -20717,6 +20717,18 @@ Object {
       "Description": "S3 key for asset version \\"4251843552ca3ae129a06633a70fa27fc92b47ab849687033c3ad1e7fce03130\\"",
       "Type": "String",
     },
+    "AssetParameters488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12ArtifactHash794BC30F": Object {
+      "Description": "Artifact hash for asset \\"488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12\\"",
+      "Type": "String",
+    },
+    "AssetParameters488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12S3BucketC21384F6": Object {
+      "Description": "S3 bucket for asset \\"488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12\\"",
+      "Type": "String",
+    },
+    "AssetParameters488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12S3VersionKey2E24D57B": Object {
+      "Description": "S3 key for asset version \\"488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12\\"",
+      "Type": "String",
+    },
     "AssetParameters5465af3e563838faf87f189369af003b61ed4608e6c6423cf21af7189e21abafArtifactHash1E43F8AF": Object {
       "Description": "Artifact hash for asset \\"5465af3e563838faf87f189369af003b61ed4608e6c6423cf21af7189e21abaf\\"",
       "Type": "String",
@@ -20811,18 +20823,6 @@ Object {
     },
     "AssetParametersb120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827S3VersionKeyB95D17C3": Object {
       "Description": "S3 key for asset version \\"b120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827\\"",
-      "Type": "String",
-    },
-    "AssetParametersc01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87ArtifactHashDC72D8F7": Object {
-      "Description": "Artifact hash for asset \\"c01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87\\"",
-      "Type": "String",
-    },
-    "AssetParametersc01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87S3Bucket51FB6AD9": Object {
-      "Description": "S3 bucket for asset \\"c01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87\\"",
-      "Type": "String",
-    },
-    "AssetParametersc01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87S3VersionKeyA8F1A8B1": Object {
-      "Description": "S3 key for asset version \\"c01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87\\"",
       "Type": "String",
     },
     "AssetParametersc5ed3506ccf141325c557e0e0c7990b8436c834222d75edcc64d8220f0e46245ArtifactHashEBD3FED7": Object {
@@ -22811,7 +22811,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87S3Bucket51FB6AD9",
+            "Ref": "AssetParameters488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12S3BucketC21384F6",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -22824,7 +22824,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87S3VersionKeyA8F1A8B1",
+                          "Ref": "AssetParameters488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12S3VersionKey2E24D57B",
                         },
                       ],
                     },
@@ -22837,7 +22837,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87S3VersionKeyA8F1A8B1",
+                          "Ref": "AssetParameters488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12S3VersionKey2E24D57B",
                         },
                       ],
                     },
@@ -31504,6 +31504,18 @@ Object {
       "Description": "S3 key for asset version \\"4251843552ca3ae129a06633a70fa27fc92b47ab849687033c3ad1e7fce03130\\"",
       "Type": "String",
     },
+    "AssetParameters488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12ArtifactHash794BC30F": Object {
+      "Description": "Artifact hash for asset \\"488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12\\"",
+      "Type": "String",
+    },
+    "AssetParameters488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12S3BucketC21384F6": Object {
+      "Description": "S3 bucket for asset \\"488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12\\"",
+      "Type": "String",
+    },
+    "AssetParameters488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12S3VersionKey2E24D57B": Object {
+      "Description": "S3 key for asset version \\"488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12\\"",
+      "Type": "String",
+    },
     "AssetParameters663fcf0912a43161b04556b6e82be6ae6e1f55c7b06466d6939c51a53a7c4be3ArtifactHashDE1DA343": Object {
       "Description": "Artifact hash for asset \\"663fcf0912a43161b04556b6e82be6ae6e1f55c7b06466d6939c51a53a7c4be3\\"",
       "Type": "String",
@@ -31574,18 +31586,6 @@ Object {
     },
     "AssetParametersb120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827S3VersionKeyB95D17C3": Object {
       "Description": "S3 key for asset version \\"b120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827\\"",
-      "Type": "String",
-    },
-    "AssetParametersc01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87ArtifactHashDC72D8F7": Object {
-      "Description": "Artifact hash for asset \\"c01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87\\"",
-      "Type": "String",
-    },
-    "AssetParametersc01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87S3Bucket51FB6AD9": Object {
-      "Description": "S3 bucket for asset \\"c01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87\\"",
-      "Type": "String",
-    },
-    "AssetParametersc01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87S3VersionKeyA8F1A8B1": Object {
-      "Description": "S3 key for asset version \\"c01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87\\"",
       "Type": "String",
     },
     "AssetParametersc5ed3506ccf141325c557e0e0c7990b8436c834222d75edcc64d8220f0e46245ArtifactHashEBD3FED7": Object {
@@ -33360,7 +33360,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87S3Bucket51FB6AD9",
+            "Ref": "AssetParameters488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12S3BucketC21384F6",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -33373,7 +33373,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87S3VersionKeyA8F1A8B1",
+                          "Ref": "AssetParameters488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12S3VersionKey2E24D57B",
                         },
                       ],
                     },
@@ -33386,7 +33386,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87S3VersionKeyA8F1A8B1",
+                          "Ref": "AssetParameters488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12S3VersionKey2E24D57B",
                         },
                       ],
                     },

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -3582,7 +3582,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParametersc01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87S3Bucket51FB6AD9
+          Ref: AssetParameters488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12S3BucketC21384F6
         S3Key:
           Fn::Join:
             - ""
@@ -3590,12 +3590,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersc01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87S3VersionKeyA8F1A8B1
+                      - Ref: AssetParameters488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12S3VersionKey2E24D57B
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersc01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87S3VersionKeyA8F1A8B1
+                      - Ref: AssetParameters488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12S3VersionKey2E24D57B
       Role:
         Fn::GetAtt:
           - ConstructHubIngestionServiceRole6380BAB6
@@ -6125,18 +6125,18 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "b69f8e77829ba765ee3a37c088671f56d5982ab8e2a57c2f3103bea15181e67b"
-  AssetParametersc01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87S3Bucket51FB6AD9:
+  AssetParameters488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12S3BucketC21384F6:
     Type: String
     Description: S3 bucket for asset
-      "c01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87"
-  AssetParametersc01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87S3VersionKeyA8F1A8B1:
+      "488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12"
+  AssetParameters488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12S3VersionKey2E24D57B:
     Type: String
     Description: S3 key for asset version
-      "c01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87"
-  AssetParametersc01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87ArtifactHashDC72D8F7:
+      "488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12"
+  AssetParameters488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12ArtifactHash794BC30F:
     Type: String
     Description: Artifact hash for asset
-      "c01b74c1df38f6bac865f829f18aa303717cde9c9e48f663b23b22b187c95c87"
+      "488118c1e72eb3881cfd4bfa51da1546da5aa3a3aedf24dcf687a1474f57dc12"
   AssetParametersfff521bba8a9184b9c645defabf10d457dc2397bd06b224a579d433ea650ca4cS3Bucket1AA1CD5B:
     Type: String
     Description: S3 bucket for asset

--- a/src/backend/ingestion/ingestion.lambda.ts
+++ b/src/backend/ingestion/ingestion.lambda.ts
@@ -180,13 +180,11 @@ export const handler = metricScope(
       if (codeArtifactProps) {
         console.log('Publishing to the internal CodeArtifact...');
         try {
-          const tarballBuff = Buffer.from(tarball.Body!);
-          const { packageJson } = await extractObjects(tarballBuff, { packageJson: { path: 'package/package.json', required: true } });
-          const { publishConfig } = JSON.parse(packageJson.toString('utf-8'));
+          const { publishConfig } = packageJsonObj;
           if (publishConfig) {
-            console.log(`Not publishing to CodeArtifact due to the presence of publishConfig in package.json: `, publishConfig);
+            console.log('Not publishing to CodeArtifact due to the presence of publishConfig in package.json: ', publishConfig);
           } else {
-            await codeArtifactPublishPackage(tarballBuff, codeArtifactProps);
+            await codeArtifactPublishPackage(Buffer.from(tarball.Body!), codeArtifactProps);
           }
         } catch (err) {
           console.error('Failed publishing to CodeArtifact: ', err);

--- a/src/backend/ingestion/ingestion.lambda.ts
+++ b/src/backend/ingestion/ingestion.lambda.ts
@@ -179,7 +179,18 @@ export const handler = metricScope(
 
       if (codeArtifactProps) {
         console.log('Publishing to the internal CodeArtifact...');
-        await codeArtifactPublishPackage(Buffer.from(tarball.Body!), codeArtifactProps);
+        try {
+          const tarballBuff = Buffer.from(tarball.Body!);
+          const { packageJson } = await extractObjects(tarballBuff, { packageJson: { path: 'package/package.json', required: true } });
+          const { publishConfig } = JSON.parse(packageJson.toString('utf-8'));
+          if (publishConfig) {
+            console.log(`Not publishing to CodeArtifact due to the presence of publishConfig in package.json: `, publishConfig);
+          } else {
+            await codeArtifactPublishPackage(tarballBuff, codeArtifactProps);
+          }
+        } catch (err) {
+          console.error('Failed publishing to CodeArtifact: ', err);
+        }
       }
 
       const metadata = {


### PR DESCRIPTION
CodeArtifact publishing is a best-effort attempt, and should not
normally be necessary. Changes the code path so that:

1. It is not attempted if there is `publishConfig` in the package.json
   file, as this would override the configrued registry;
2. Failures are simpluy logged and ignored


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*