### PR TITLE
feat: option to skip docgen after re-ingesting packages

### DIFF
--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -525,10 +525,12 @@ Two workflows are available for bulk-reprocessing:
 
 1. The "re-ingest everything" workflow can be used to re-process packages
    through the entire pipeline, including re-generating the `metadata.json`
-   object. This is usually not necessary, unless an issue has been identified
-   with many indexed packages (incorrect or missing `metadata.json`, incorrectly
-   identfied construct framework package, etc...). In most cases, re-generating
-   the documentation is sufficient.
+   object and re-generating all docs. This is usually not necessary, unless an
+   issue has been identified with many indexed packages (incorrect or missing
+   `metadata.json`, incorrectly identfied construct framework package, etc...).
+   In most cases, re-generating the documentation is sufficient. To skip
+   regenerating docs, you can initiate the workflow with the
+   `"skipDocgen": true` option.
 1. The "re-generate all documentation" workflow re-runs all indexed packages
    through the documentation-generation process. This is useful when a new
    language is added to ConstructHub, or the rendered documentation has

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -93,18 +93,6 @@ Object {
       "Description": "S3 key for asset version \\"4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbc\\"",
       "Type": "String",
     },
-    "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181ArtifactHash428CD1A0": Object {
-      "Description": "Artifact hash for asset \\"4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181\\"",
-      "Type": "String",
-    },
-    "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3BucketAEB068B9": Object {
-      "Description": "S3 bucket for asset \\"4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181\\"",
-      "Type": "String",
-    },
-    "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3VersionKey00947D36": Object {
-      "Description": "S3 key for asset version \\"4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181\\"",
-      "Type": "String",
-    },
     "AssetParameters51e6101c826732d4e632b2ee6a67e76518b05cea28bb0a00d6c5c697c83d89baArtifactHash102D0396": Object {
       "Description": "Artifact hash for asset \\"51e6101c826732d4e632b2ee6a67e76518b05cea28bb0a00d6c5c697c83d89ba\\"",
       "Type": "String",
@@ -211,6 +199,18 @@ Object {
     },
     "AssetParametersb120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827S3VersionKeyB95D17C3": Object {
       "Description": "S3 key for asset version \\"b120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827\\"",
+      "Type": "String",
+    },
+    "AssetParametersbe9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5ArtifactHashE0B34747": Object {
+      "Description": "Artifact hash for asset \\"be9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5\\"",
+      "Type": "String",
+    },
+    "AssetParametersbe9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5S3Bucket0F67E5C9": Object {
+      "Description": "S3 bucket for asset \\"be9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5\\"",
+      "Type": "String",
+    },
+    "AssetParametersbe9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5S3VersionKeyC402DD84": Object {
+      "Description": "S3 key for asset version \\"be9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5\\"",
       "Type": "String",
     },
     "AssetParametersc1f9f7fee97e2df480da35de932afbbb65f72ae5b9a0ed8e71a5ac9e2ab57054ArtifactHash1B78EE65": Object {
@@ -2508,7 +2508,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3BucketAEB068B9",
+            "Ref": "AssetParametersbe9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5S3Bucket0F67E5C9",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -2521,7 +2521,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3VersionKey00947D36",
+                          "Ref": "AssetParametersbe9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5S3VersionKeyC402DD84",
                         },
                       ],
                     },
@@ -2534,7 +2534,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3VersionKey00947D36",
+                          "Ref": "AssetParametersbe9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5S3VersionKeyC402DD84",
                         },
                       ],
                     },
@@ -2564,7 +2564,7 @@ Direct link to the function: /lambda/home#/functions/",
           ],
         },
         "Runtime": "nodejs14.x",
-        "Timeout": 180,
+        "Timeout": 60,
         "TracingConfig": Object {
           "Mode": "Active",
         },
@@ -10758,18 +10758,6 @@ Object {
       "Description": "S3 key for asset version \\"4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbc\\"",
       "Type": "String",
     },
-    "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181ArtifactHash428CD1A0": Object {
-      "Description": "Artifact hash for asset \\"4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181\\"",
-      "Type": "String",
-    },
-    "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3BucketAEB068B9": Object {
-      "Description": "S3 bucket for asset \\"4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181\\"",
-      "Type": "String",
-    },
-    "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3VersionKey00947D36": Object {
-      "Description": "S3 key for asset version \\"4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181\\"",
-      "Type": "String",
-    },
     "AssetParameters51e6101c826732d4e632b2ee6a67e76518b05cea28bb0a00d6c5c697c83d89baArtifactHash102D0396": Object {
       "Description": "Artifact hash for asset \\"51e6101c826732d4e632b2ee6a67e76518b05cea28bb0a00d6c5c697c83d89ba\\"",
       "Type": "String",
@@ -10876,6 +10864,18 @@ Object {
     },
     "AssetParametersb120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827S3VersionKeyB95D17C3": Object {
       "Description": "S3 key for asset version \\"b120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827\\"",
+      "Type": "String",
+    },
+    "AssetParametersbe9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5ArtifactHashE0B34747": Object {
+      "Description": "Artifact hash for asset \\"be9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5\\"",
+      "Type": "String",
+    },
+    "AssetParametersbe9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5S3Bucket0F67E5C9": Object {
+      "Description": "S3 bucket for asset \\"be9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5\\"",
+      "Type": "String",
+    },
+    "AssetParametersbe9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5S3VersionKeyC402DD84": Object {
+      "Description": "S3 key for asset version \\"be9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5\\"",
       "Type": "String",
     },
     "AssetParametersc1f9f7fee97e2df480da35de932afbbb65f72ae5b9a0ed8e71a5ac9e2ab57054ArtifactHash1B78EE65": Object {
@@ -13126,7 +13126,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3BucketAEB068B9",
+            "Ref": "AssetParametersbe9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5S3Bucket0F67E5C9",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -13139,7 +13139,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3VersionKey00947D36",
+                          "Ref": "AssetParametersbe9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5S3VersionKeyC402DD84",
                         },
                       ],
                     },
@@ -13152,7 +13152,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3VersionKey00947D36",
+                          "Ref": "AssetParametersbe9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5S3VersionKeyC402DD84",
                         },
                       ],
                     },
@@ -13182,7 +13182,7 @@ Direct link to the function: /lambda/home#/functions/",
           ],
         },
         "Runtime": "nodejs14.x",
-        "Timeout": 180,
+        "Timeout": 60,
         "TracingConfig": Object {
           "Mode": "Active",
         },
@@ -21409,18 +21409,6 @@ Object {
       "Description": "S3 key for asset version \\"4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbc\\"",
       "Type": "String",
     },
-    "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181ArtifactHash428CD1A0": Object {
-      "Description": "Artifact hash for asset \\"4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181\\"",
-      "Type": "String",
-    },
-    "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3BucketAEB068B9": Object {
-      "Description": "S3 bucket for asset \\"4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181\\"",
-      "Type": "String",
-    },
-    "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3VersionKey00947D36": Object {
-      "Description": "S3 key for asset version \\"4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181\\"",
-      "Type": "String",
-    },
     "AssetParameters51e6101c826732d4e632b2ee6a67e76518b05cea28bb0a00d6c5c697c83d89baArtifactHash102D0396": Object {
       "Description": "Artifact hash for asset \\"51e6101c826732d4e632b2ee6a67e76518b05cea28bb0a00d6c5c697c83d89ba\\"",
       "Type": "String",
@@ -21551,6 +21539,18 @@ Object {
     },
     "AssetParametersb120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827S3VersionKeyB95D17C3": Object {
       "Description": "S3 key for asset version \\"b120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827\\"",
+      "Type": "String",
+    },
+    "AssetParametersbe9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5ArtifactHashE0B34747": Object {
+      "Description": "Artifact hash for asset \\"be9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5\\"",
+      "Type": "String",
+    },
+    "AssetParametersbe9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5S3Bucket0F67E5C9": Object {
+      "Description": "S3 bucket for asset \\"be9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5\\"",
+      "Type": "String",
+    },
+    "AssetParametersbe9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5S3VersionKeyC402DD84": Object {
+      "Description": "S3 key for asset version \\"be9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5\\"",
       "Type": "String",
     },
     "AssetParametersc1f9f7fee97e2df480da35de932afbbb65f72ae5b9a0ed8e71a5ac9e2ab57054ArtifactHash1B78EE65": Object {
@@ -23997,7 +23997,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3BucketAEB068B9",
+            "Ref": "AssetParametersbe9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5S3Bucket0F67E5C9",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -24010,7 +24010,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3VersionKey00947D36",
+                          "Ref": "AssetParametersbe9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5S3VersionKeyC402DD84",
                         },
                       ],
                     },
@@ -24023,7 +24023,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3VersionKey00947D36",
+                          "Ref": "AssetParametersbe9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5S3VersionKeyC402DD84",
                         },
                       ],
                     },
@@ -24053,7 +24053,7 @@ Direct link to the function: /lambda/home#/functions/",
           ],
         },
         "Runtime": "nodejs14.x",
-        "Timeout": 180,
+        "Timeout": 60,
         "TracingConfig": Object {
           "Mode": "Active",
         },
@@ -32548,18 +32548,6 @@ Object {
       "Description": "S3 key for asset version \\"4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbc\\"",
       "Type": "String",
     },
-    "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181ArtifactHash428CD1A0": Object {
-      "Description": "Artifact hash for asset \\"4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181\\"",
-      "Type": "String",
-    },
-    "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3BucketAEB068B9": Object {
-      "Description": "S3 bucket for asset \\"4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181\\"",
-      "Type": "String",
-    },
-    "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3VersionKey00947D36": Object {
-      "Description": "S3 key for asset version \\"4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181\\"",
-      "Type": "String",
-    },
     "AssetParameters51e6101c826732d4e632b2ee6a67e76518b05cea28bb0a00d6c5c697c83d89baArtifactHash102D0396": Object {
       "Description": "Artifact hash for asset \\"51e6101c826732d4e632b2ee6a67e76518b05cea28bb0a00d6c5c697c83d89ba\\"",
       "Type": "String",
@@ -32666,6 +32654,18 @@ Object {
     },
     "AssetParametersb120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827S3VersionKeyB95D17C3": Object {
       "Description": "S3 key for asset version \\"b120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827\\"",
+      "Type": "String",
+    },
+    "AssetParametersbe9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5ArtifactHashE0B34747": Object {
+      "Description": "Artifact hash for asset \\"be9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5\\"",
+      "Type": "String",
+    },
+    "AssetParametersbe9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5S3Bucket0F67E5C9": Object {
+      "Description": "S3 bucket for asset \\"be9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5\\"",
+      "Type": "String",
+    },
+    "AssetParametersbe9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5S3VersionKeyC402DD84": Object {
+      "Description": "S3 key for asset version \\"be9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5\\"",
       "Type": "String",
     },
     "AssetParametersc1f9f7fee97e2df480da35de932afbbb65f72ae5b9a0ed8e71a5ac9e2ab57054ArtifactHash1B78EE65": Object {
@@ -34898,7 +34898,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3BucketAEB068B9",
+            "Ref": "AssetParametersbe9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5S3Bucket0F67E5C9",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -34911,7 +34911,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3VersionKey00947D36",
+                          "Ref": "AssetParametersbe9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5S3VersionKeyC402DD84",
                         },
                       ],
                     },
@@ -34924,7 +34924,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3VersionKey00947D36",
+                          "Ref": "AssetParametersbe9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5S3VersionKeyC402DD84",
                         },
                       ],
                     },
@@ -34954,7 +34954,7 @@ Direct link to the function: /lambda/home#/functions/",
           ],
         },
         "Runtime": "nodejs14.x",
-        "Timeout": 180,
+        "Timeout": 60,
         "TracingConfig": Object {
           "Mode": "Active",
         },

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -33,16 +33,16 @@ Object {
     },
   },
   "Parameters": Object {
-    "AssetParameters0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2ArtifactHash0B2B7704": Object {
-      "Description": "Artifact hash for asset \\"0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2\\"",
+    "AssetParameters0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547afArtifactHashBF1388E8": Object {
+      "Description": "Artifact hash for asset \\"0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547af\\"",
       "Type": "String",
     },
-    "AssetParameters0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2S3BucketF895C157": Object {
-      "Description": "S3 bucket for asset \\"0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2\\"",
+    "AssetParameters0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547afS3Bucket0C55E91B": Object {
+      "Description": "S3 bucket for asset \\"0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547af\\"",
       "Type": "String",
     },
-    "AssetParameters0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2S3VersionKey5A51414E": Object {
-      "Description": "S3 key for asset version \\"0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2\\"",
+    "AssetParameters0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547afS3VersionKeyFDBDFFC2": Object {
+      "Description": "S3 key for asset version \\"0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547af\\"",
       "Type": "String",
     },
     "AssetParameters0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9ArtifactHashB9E3BF29": Object {
@@ -81,18 +81,6 @@ Object {
       "Description": "S3 key for asset version \\"2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658\\"",
       "Type": "String",
     },
-    "AssetParameters375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727ArtifactHash117D71AA": Object {
-      "Description": "Artifact hash for asset \\"375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727\\"",
-      "Type": "String",
-    },
-    "AssetParameters375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727S3Bucket927BFE5C": Object {
-      "Description": "S3 bucket for asset \\"375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727\\"",
-      "Type": "String",
-    },
-    "AssetParameters375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727S3VersionKey80769D0D": Object {
-      "Description": "S3 key for asset version \\"375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727\\"",
-      "Type": "String",
-    },
     "AssetParameters4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbcArtifactHashF236251A": Object {
       "Description": "Artifact hash for asset \\"4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbc\\"",
       "Type": "String",
@@ -103,6 +91,18 @@ Object {
     },
     "AssetParameters4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbcS3VersionKey547E84F8": Object {
       "Description": "S3 key for asset version \\"4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbc\\"",
+      "Type": "String",
+    },
+    "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181ArtifactHash428CD1A0": Object {
+      "Description": "Artifact hash for asset \\"4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181\\"",
+      "Type": "String",
+    },
+    "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3BucketAEB068B9": Object {
+      "Description": "S3 bucket for asset \\"4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181\\"",
+      "Type": "String",
+    },
+    "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3VersionKey00947D36": Object {
+      "Description": "S3 key for asset version \\"4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181\\"",
       "Type": "String",
     },
     "AssetParameters51e6101c826732d4e632b2ee6a67e76518b05cea28bb0a00d6c5c697c83d89baArtifactHash102D0396": Object {
@@ -153,16 +153,16 @@ Object {
       "Description": "S3 key for asset version \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
     },
-    "AssetParameters945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17ArtifactHash3E3A0986": Object {
-      "Description": "Artifact hash for asset \\"945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17\\"",
+    "AssetParameters9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5fArtifactHash26A7736C": Object {
+      "Description": "Artifact hash for asset \\"9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5f\\"",
       "Type": "String",
     },
-    "AssetParameters945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17S3Bucket6A002A15": Object {
-      "Description": "S3 bucket for asset \\"945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17\\"",
+    "AssetParameters9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5fS3Bucket932E68D6": Object {
+      "Description": "S3 bucket for asset \\"9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5f\\"",
       "Type": "String",
     },
-    "AssetParameters945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17S3VersionKeyAC01152C": Object {
-      "Description": "S3 key for asset version \\"945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17\\"",
+    "AssetParameters9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5fS3VersionKey1EF690AA": Object {
+      "Description": "S3 key for asset version \\"9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5f\\"",
       "Type": "String",
     },
     "AssetParametersa01d4ca81a4167a5f4a8084ccd5b7f926995c222c590c70973b3ee2c7087b534ArtifactHash1057C76B": Object {
@@ -2046,7 +2046,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17S3Bucket6A002A15",
+            "Ref": "AssetParameters9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5fS3Bucket932E68D6",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -2059,7 +2059,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17S3VersionKeyAC01152C",
+                          "Ref": "AssetParameters9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5fS3VersionKey1EF690AA",
                         },
                       ],
                     },
@@ -2072,7 +2072,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17S3VersionKeyAC01152C",
+                          "Ref": "AssetParameters9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5fS3VersionKey1EF690AA",
                         },
                       ],
                     },
@@ -2508,7 +2508,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2S3BucketF895C157",
+            "Ref": "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3BucketAEB068B9",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -2521,7 +2521,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2S3VersionKey5A51414E",
+                          "Ref": "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3VersionKey00947D36",
                         },
                       ],
                     },
@@ -2534,7 +2534,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2S3VersionKey5A51414E",
+                          "Ref": "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3VersionKey00947D36",
                         },
                       ],
                     },
@@ -2564,7 +2564,7 @@ Direct link to the function: /lambda/home#/functions/",
           ],
         },
         "Runtime": "nodejs14.x",
-        "Timeout": 60,
+        "Timeout": 180,
         "TracingConfig": Object {
           "Mode": "Active",
         },
@@ -2710,7 +2710,7 @@ Direct link to the function: /lambda/home#/functions/",
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"StartAt\\":\\"Has a ContinuationToken?\\",\\"States\\":{\\"Has a ContinuationToken?\\":{\\"Type\\":\\"Choice\\",\\"Choices\\":[{\\"Variable\\":\\"$.ContinuationToken\\",\\"IsPresent\\":true,\\"Next\\":\\"S3.ListObjectsV2(NextPage)\\"}],\\"Default\\":\\"S3.ListObjectsV2(FirstPage)\\"},\\"S3.ListObjectsV2(FirstPage)\\":{\\"Next\\":\\"Is there more?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"S3.SdkClientException\\"]}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.response\\",\\"Resource\\":\\"arn:",
+              "{\\"StartAt\\":\\"Move input into $.params\\",\\"States\\":{\\"Move input into $.params\\":{\\"Type\\":\\"Pass\\",\\"Parameters\\":{\\"params.$\\":\\"$\\"},\\"Next\\":\\"Has a ContinuationToken?\\"},\\"Has a ContinuationToken?\\":{\\"Type\\":\\"Choice\\",\\"Choices\\":[{\\"Variable\\":\\"$.ContinuationToken\\",\\"IsPresent\\":true,\\"Next\\":\\"S3.ListObjectsV2(NextPage)\\"}],\\"Default\\":\\"S3.ListObjectsV2(FirstPage)\\"},\\"S3.ListObjectsV2(FirstPage)\\":{\\"Next\\":\\"Is there more?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"S3.SdkClientException\\"]}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.response\\",\\"Resource\\":\\"arn:",
               Object {
                 "Ref": "AWS::Partition",
               },
@@ -2726,7 +2726,7 @@ Direct link to the function: /lambda/home#/functions/",
               Object {
                 "Ref": "ConstructHubPackageDataDC5EF35E",
               },
-              "\\",\\"ContinuationToken.$\\":\\"$.ContinuationToken\\",\\"Prefix\\":\\"data/\\"}},\\"Process Result\\":{\\"Type\\":\\"Map\\",\\"ResultPath\\":null,\\"End\\":true,\\"Iterator\\":{\\"StartAt\\":\\"Is metadata object?\\",\\"States\\":{\\"Is metadata object?\\":{\\"Type\\":\\"Choice\\",\\"Choices\\":[{\\"Variable\\":\\"$.Key\\",\\"StringMatches\\":\\"*/metadata.json\\",\\"Next\\":\\"Send for reprocessing\\"}],\\"Default\\":\\"Nothing to do\\"},\\"Nothing to do\\":{\\"Type\\":\\"Succeed\\"},\\"Send for reprocessing\\":{\\"End\\":true,\\"Retry\\":[{\\"ErrorEquals\\":[\\"Lambda.ServiceException\\",\\"Lambda.AWSLambdaException\\",\\"Lambda.SdkClientException\\"],\\"IntervalSeconds\\":2,\\"MaxAttempts\\":6,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":30,\\"BackoffRate\\":1.1}],\\"Type\\":\\"Task\\",\\"Resource\\":\\"arn:",
+              "\\",\\"ContinuationToken.$\\":\\"$.ContinuationToken\\",\\"Prefix\\":\\"data/\\"}},\\"Process Result\\":{\\"Type\\":\\"Map\\",\\"ResultPath\\":null,\\"End\\":true,\\"Parameters\\":{\\"s3Object.$\\":\\"$$.Map.Item.Value\\",\\"params.$\\":\\"$.params\\"},\\"Iterator\\":{\\"StartAt\\":\\"Is metadata object?\\",\\"States\\":{\\"Is metadata object?\\":{\\"Type\\":\\"Choice\\",\\"Choices\\":[{\\"Variable\\":\\"$.s3Object.Key\\",\\"StringMatches\\":\\"*/metadata.json\\",\\"Next\\":\\"Send for reprocessing\\"}],\\"Default\\":\\"Nothing to do\\"},\\"Nothing to do\\":{\\"Type\\":\\"Succeed\\"},\\"Send for reprocessing\\":{\\"End\\":true,\\"Retry\\":[{\\"ErrorEquals\\":[\\"Lambda.ServiceException\\",\\"Lambda.AWSLambdaException\\",\\"Lambda.SdkClientException\\"],\\"IntervalSeconds\\":2,\\"MaxAttempts\\":6,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":30,\\"BackoffRate\\":1.1}],\\"Type\\":\\"Task\\",\\"Resource\\":\\"arn:",
               Object {
                 "Ref": "AWS::Partition",
               },
@@ -6443,7 +6443,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727S3Bucket927BFE5C",
+            "Ref": "AssetParameters0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547afS3Bucket0C55E91B",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -6456,7 +6456,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727S3VersionKey80769D0D",
+                          "Ref": "AssetParameters0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547afS3VersionKeyFDBDFFC2",
                         },
                       ],
                     },
@@ -6469,7 +6469,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727S3VersionKey80769D0D",
+                          "Ref": "AssetParameters0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547afS3VersionKeyFDBDFFC2",
                         },
                       ],
                     },
@@ -10698,16 +10698,16 @@ Object {
     },
   },
   "Parameters": Object {
-    "AssetParameters0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2ArtifactHash0B2B7704": Object {
-      "Description": "Artifact hash for asset \\"0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2\\"",
+    "AssetParameters0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547afArtifactHashBF1388E8": Object {
+      "Description": "Artifact hash for asset \\"0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547af\\"",
       "Type": "String",
     },
-    "AssetParameters0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2S3BucketF895C157": Object {
-      "Description": "S3 bucket for asset \\"0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2\\"",
+    "AssetParameters0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547afS3Bucket0C55E91B": Object {
+      "Description": "S3 bucket for asset \\"0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547af\\"",
       "Type": "String",
     },
-    "AssetParameters0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2S3VersionKey5A51414E": Object {
-      "Description": "S3 key for asset version \\"0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2\\"",
+    "AssetParameters0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547afS3VersionKeyFDBDFFC2": Object {
+      "Description": "S3 key for asset version \\"0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547af\\"",
       "Type": "String",
     },
     "AssetParameters0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9ArtifactHashB9E3BF29": Object {
@@ -10746,18 +10746,6 @@ Object {
       "Description": "S3 key for asset version \\"2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658\\"",
       "Type": "String",
     },
-    "AssetParameters375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727ArtifactHash117D71AA": Object {
-      "Description": "Artifact hash for asset \\"375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727\\"",
-      "Type": "String",
-    },
-    "AssetParameters375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727S3Bucket927BFE5C": Object {
-      "Description": "S3 bucket for asset \\"375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727\\"",
-      "Type": "String",
-    },
-    "AssetParameters375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727S3VersionKey80769D0D": Object {
-      "Description": "S3 key for asset version \\"375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727\\"",
-      "Type": "String",
-    },
     "AssetParameters4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbcArtifactHashF236251A": Object {
       "Description": "Artifact hash for asset \\"4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbc\\"",
       "Type": "String",
@@ -10768,6 +10756,18 @@ Object {
     },
     "AssetParameters4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbcS3VersionKey547E84F8": Object {
       "Description": "S3 key for asset version \\"4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbc\\"",
+      "Type": "String",
+    },
+    "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181ArtifactHash428CD1A0": Object {
+      "Description": "Artifact hash for asset \\"4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181\\"",
+      "Type": "String",
+    },
+    "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3BucketAEB068B9": Object {
+      "Description": "S3 bucket for asset \\"4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181\\"",
+      "Type": "String",
+    },
+    "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3VersionKey00947D36": Object {
+      "Description": "S3 key for asset version \\"4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181\\"",
       "Type": "String",
     },
     "AssetParameters51e6101c826732d4e632b2ee6a67e76518b05cea28bb0a00d6c5c697c83d89baArtifactHash102D0396": Object {
@@ -10818,16 +10818,16 @@ Object {
       "Description": "S3 key for asset version \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
     },
-    "AssetParameters945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17ArtifactHash3E3A0986": Object {
-      "Description": "Artifact hash for asset \\"945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17\\"",
+    "AssetParameters9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5fArtifactHash26A7736C": Object {
+      "Description": "Artifact hash for asset \\"9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5f\\"",
       "Type": "String",
     },
-    "AssetParameters945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17S3Bucket6A002A15": Object {
-      "Description": "S3 bucket for asset \\"945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17\\"",
+    "AssetParameters9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5fS3Bucket932E68D6": Object {
+      "Description": "S3 bucket for asset \\"9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5f\\"",
       "Type": "String",
     },
-    "AssetParameters945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17S3VersionKeyAC01152C": Object {
-      "Description": "S3 key for asset version \\"945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17\\"",
+    "AssetParameters9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5fS3VersionKey1EF690AA": Object {
+      "Description": "S3 key for asset version \\"9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5f\\"",
       "Type": "String",
     },
     "AssetParametersa01d4ca81a4167a5f4a8084ccd5b7f926995c222c590c70973b3ee2c7087b534ArtifactHash1057C76B": Object {
@@ -12664,7 +12664,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17S3Bucket6A002A15",
+            "Ref": "AssetParameters9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5fS3Bucket932E68D6",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -12677,7 +12677,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17S3VersionKeyAC01152C",
+                          "Ref": "AssetParameters9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5fS3VersionKey1EF690AA",
                         },
                       ],
                     },
@@ -12690,7 +12690,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17S3VersionKeyAC01152C",
+                          "Ref": "AssetParameters9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5fS3VersionKey1EF690AA",
                         },
                       ],
                     },
@@ -13126,7 +13126,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2S3BucketF895C157",
+            "Ref": "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3BucketAEB068B9",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -13139,7 +13139,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2S3VersionKey5A51414E",
+                          "Ref": "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3VersionKey00947D36",
                         },
                       ],
                     },
@@ -13152,7 +13152,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2S3VersionKey5A51414E",
+                          "Ref": "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3VersionKey00947D36",
                         },
                       ],
                     },
@@ -13182,7 +13182,7 @@ Direct link to the function: /lambda/home#/functions/",
           ],
         },
         "Runtime": "nodejs14.x",
-        "Timeout": 60,
+        "Timeout": 180,
         "TracingConfig": Object {
           "Mode": "Active",
         },
@@ -13328,7 +13328,7 @@ Direct link to the function: /lambda/home#/functions/",
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"StartAt\\":\\"Has a ContinuationToken?\\",\\"States\\":{\\"Has a ContinuationToken?\\":{\\"Type\\":\\"Choice\\",\\"Choices\\":[{\\"Variable\\":\\"$.ContinuationToken\\",\\"IsPresent\\":true,\\"Next\\":\\"S3.ListObjectsV2(NextPage)\\"}],\\"Default\\":\\"S3.ListObjectsV2(FirstPage)\\"},\\"S3.ListObjectsV2(FirstPage)\\":{\\"Next\\":\\"Is there more?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"S3.SdkClientException\\"]}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.response\\",\\"Resource\\":\\"arn:",
+              "{\\"StartAt\\":\\"Move input into $.params\\",\\"States\\":{\\"Move input into $.params\\":{\\"Type\\":\\"Pass\\",\\"Parameters\\":{\\"params.$\\":\\"$\\"},\\"Next\\":\\"Has a ContinuationToken?\\"},\\"Has a ContinuationToken?\\":{\\"Type\\":\\"Choice\\",\\"Choices\\":[{\\"Variable\\":\\"$.ContinuationToken\\",\\"IsPresent\\":true,\\"Next\\":\\"S3.ListObjectsV2(NextPage)\\"}],\\"Default\\":\\"S3.ListObjectsV2(FirstPage)\\"},\\"S3.ListObjectsV2(FirstPage)\\":{\\"Next\\":\\"Is there more?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"S3.SdkClientException\\"]}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.response\\",\\"Resource\\":\\"arn:",
               Object {
                 "Ref": "AWS::Partition",
               },
@@ -13344,7 +13344,7 @@ Direct link to the function: /lambda/home#/functions/",
               Object {
                 "Ref": "ConstructHubPackageDataDC5EF35E",
               },
-              "\\",\\"ContinuationToken.$\\":\\"$.ContinuationToken\\",\\"Prefix\\":\\"data/\\"}},\\"Process Result\\":{\\"Type\\":\\"Map\\",\\"ResultPath\\":null,\\"End\\":true,\\"Iterator\\":{\\"StartAt\\":\\"Is metadata object?\\",\\"States\\":{\\"Is metadata object?\\":{\\"Type\\":\\"Choice\\",\\"Choices\\":[{\\"Variable\\":\\"$.Key\\",\\"StringMatches\\":\\"*/metadata.json\\",\\"Next\\":\\"Send for reprocessing\\"}],\\"Default\\":\\"Nothing to do\\"},\\"Nothing to do\\":{\\"Type\\":\\"Succeed\\"},\\"Send for reprocessing\\":{\\"End\\":true,\\"Retry\\":[{\\"ErrorEquals\\":[\\"Lambda.ServiceException\\",\\"Lambda.AWSLambdaException\\",\\"Lambda.SdkClientException\\"],\\"IntervalSeconds\\":2,\\"MaxAttempts\\":6,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":30,\\"BackoffRate\\":1.1}],\\"Type\\":\\"Task\\",\\"Resource\\":\\"arn:",
+              "\\",\\"ContinuationToken.$\\":\\"$.ContinuationToken\\",\\"Prefix\\":\\"data/\\"}},\\"Process Result\\":{\\"Type\\":\\"Map\\",\\"ResultPath\\":null,\\"End\\":true,\\"Parameters\\":{\\"s3Object.$\\":\\"$$.Map.Item.Value\\",\\"params.$\\":\\"$.params\\"},\\"Iterator\\":{\\"StartAt\\":\\"Is metadata object?\\",\\"States\\":{\\"Is metadata object?\\":{\\"Type\\":\\"Choice\\",\\"Choices\\":[{\\"Variable\\":\\"$.s3Object.Key\\",\\"StringMatches\\":\\"*/metadata.json\\",\\"Next\\":\\"Send for reprocessing\\"}],\\"Default\\":\\"Nothing to do\\"},\\"Nothing to do\\":{\\"Type\\":\\"Succeed\\"},\\"Send for reprocessing\\":{\\"End\\":true,\\"Retry\\":[{\\"ErrorEquals\\":[\\"Lambda.ServiceException\\",\\"Lambda.AWSLambdaException\\",\\"Lambda.SdkClientException\\"],\\"IntervalSeconds\\":2,\\"MaxAttempts\\":6,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":30,\\"BackoffRate\\":1.1}],\\"Type\\":\\"Task\\",\\"Resource\\":\\"arn:",
               Object {
                 "Ref": "AWS::Partition",
               },
@@ -17076,7 +17076,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727S3Bucket927BFE5C",
+            "Ref": "AssetParameters0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547afS3Bucket0C55E91B",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -17089,7 +17089,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727S3VersionKey80769D0D",
+                          "Ref": "AssetParameters0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547afS3VersionKeyFDBDFFC2",
                         },
                       ],
                     },
@@ -17102,7 +17102,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727S3VersionKey80769D0D",
+                          "Ref": "AssetParameters0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547afS3VersionKeyFDBDFFC2",
                         },
                       ],
                     },
@@ -21349,16 +21349,16 @@ Object {
     },
   },
   "Parameters": Object {
-    "AssetParameters0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2ArtifactHash0B2B7704": Object {
-      "Description": "Artifact hash for asset \\"0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2\\"",
+    "AssetParameters0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547afArtifactHashBF1388E8": Object {
+      "Description": "Artifact hash for asset \\"0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547af\\"",
       "Type": "String",
     },
-    "AssetParameters0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2S3BucketF895C157": Object {
-      "Description": "S3 bucket for asset \\"0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2\\"",
+    "AssetParameters0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547afS3Bucket0C55E91B": Object {
+      "Description": "S3 bucket for asset \\"0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547af\\"",
       "Type": "String",
     },
-    "AssetParameters0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2S3VersionKey5A51414E": Object {
-      "Description": "S3 key for asset version \\"0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2\\"",
+    "AssetParameters0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547afS3VersionKeyFDBDFFC2": Object {
+      "Description": "S3 key for asset version \\"0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547af\\"",
       "Type": "String",
     },
     "AssetParameters0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9ArtifactHashB9E3BF29": Object {
@@ -21397,18 +21397,6 @@ Object {
       "Description": "S3 key for asset version \\"2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658\\"",
       "Type": "String",
     },
-    "AssetParameters375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727ArtifactHash117D71AA": Object {
-      "Description": "Artifact hash for asset \\"375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727\\"",
-      "Type": "String",
-    },
-    "AssetParameters375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727S3Bucket927BFE5C": Object {
-      "Description": "S3 bucket for asset \\"375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727\\"",
-      "Type": "String",
-    },
-    "AssetParameters375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727S3VersionKey80769D0D": Object {
-      "Description": "S3 key for asset version \\"375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727\\"",
-      "Type": "String",
-    },
     "AssetParameters4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbcArtifactHashF236251A": Object {
       "Description": "Artifact hash for asset \\"4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbc\\"",
       "Type": "String",
@@ -21419,6 +21407,18 @@ Object {
     },
     "AssetParameters4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbcS3VersionKey547E84F8": Object {
       "Description": "S3 key for asset version \\"4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbc\\"",
+      "Type": "String",
+    },
+    "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181ArtifactHash428CD1A0": Object {
+      "Description": "Artifact hash for asset \\"4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181\\"",
+      "Type": "String",
+    },
+    "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3BucketAEB068B9": Object {
+      "Description": "S3 bucket for asset \\"4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181\\"",
+      "Type": "String",
+    },
+    "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3VersionKey00947D36": Object {
+      "Description": "S3 key for asset version \\"4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181\\"",
       "Type": "String",
     },
     "AssetParameters51e6101c826732d4e632b2ee6a67e76518b05cea28bb0a00d6c5c697c83d89baArtifactHash102D0396": Object {
@@ -21493,16 +21493,16 @@ Object {
       "Description": "S3 key for asset version \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
     },
-    "AssetParameters945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17ArtifactHash3E3A0986": Object {
-      "Description": "Artifact hash for asset \\"945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17\\"",
+    "AssetParameters9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5fArtifactHash26A7736C": Object {
+      "Description": "Artifact hash for asset \\"9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5f\\"",
       "Type": "String",
     },
-    "AssetParameters945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17S3Bucket6A002A15": Object {
-      "Description": "S3 bucket for asset \\"945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17\\"",
+    "AssetParameters9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5fS3Bucket932E68D6": Object {
+      "Description": "S3 bucket for asset \\"9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5f\\"",
       "Type": "String",
     },
-    "AssetParameters945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17S3VersionKeyAC01152C": Object {
-      "Description": "S3 key for asset version \\"945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17\\"",
+    "AssetParameters9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5fS3VersionKey1EF690AA": Object {
+      "Description": "S3 key for asset version \\"9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5f\\"",
       "Type": "String",
     },
     "AssetParametersa01d4ca81a4167a5f4a8084ccd5b7f926995c222c590c70973b3ee2c7087b534ArtifactHash1057C76B": Object {
@@ -23535,7 +23535,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17S3Bucket6A002A15",
+            "Ref": "AssetParameters9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5fS3Bucket932E68D6",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -23548,7 +23548,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17S3VersionKeyAC01152C",
+                          "Ref": "AssetParameters9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5fS3VersionKey1EF690AA",
                         },
                       ],
                     },
@@ -23561,7 +23561,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17S3VersionKeyAC01152C",
+                          "Ref": "AssetParameters9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5fS3VersionKey1EF690AA",
                         },
                       ],
                     },
@@ -23997,7 +23997,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2S3BucketF895C157",
+            "Ref": "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3BucketAEB068B9",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -24010,7 +24010,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2S3VersionKey5A51414E",
+                          "Ref": "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3VersionKey00947D36",
                         },
                       ],
                     },
@@ -24023,7 +24023,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2S3VersionKey5A51414E",
+                          "Ref": "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3VersionKey00947D36",
                         },
                       ],
                     },
@@ -24053,7 +24053,7 @@ Direct link to the function: /lambda/home#/functions/",
           ],
         },
         "Runtime": "nodejs14.x",
-        "Timeout": 60,
+        "Timeout": 180,
         "TracingConfig": Object {
           "Mode": "Active",
         },
@@ -24199,7 +24199,7 @@ Direct link to the function: /lambda/home#/functions/",
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"StartAt\\":\\"Has a ContinuationToken?\\",\\"States\\":{\\"Has a ContinuationToken?\\":{\\"Type\\":\\"Choice\\",\\"Choices\\":[{\\"Variable\\":\\"$.ContinuationToken\\",\\"IsPresent\\":true,\\"Next\\":\\"S3.ListObjectsV2(NextPage)\\"}],\\"Default\\":\\"S3.ListObjectsV2(FirstPage)\\"},\\"S3.ListObjectsV2(FirstPage)\\":{\\"Next\\":\\"Is there more?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"S3.SdkClientException\\"]}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.response\\",\\"Resource\\":\\"arn:",
+              "{\\"StartAt\\":\\"Move input into $.params\\",\\"States\\":{\\"Move input into $.params\\":{\\"Type\\":\\"Pass\\",\\"Parameters\\":{\\"params.$\\":\\"$\\"},\\"Next\\":\\"Has a ContinuationToken?\\"},\\"Has a ContinuationToken?\\":{\\"Type\\":\\"Choice\\",\\"Choices\\":[{\\"Variable\\":\\"$.ContinuationToken\\",\\"IsPresent\\":true,\\"Next\\":\\"S3.ListObjectsV2(NextPage)\\"}],\\"Default\\":\\"S3.ListObjectsV2(FirstPage)\\"},\\"S3.ListObjectsV2(FirstPage)\\":{\\"Next\\":\\"Is there more?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"S3.SdkClientException\\"]}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.response\\",\\"Resource\\":\\"arn:",
               Object {
                 "Ref": "AWS::Partition",
               },
@@ -24215,7 +24215,7 @@ Direct link to the function: /lambda/home#/functions/",
               Object {
                 "Ref": "ConstructHubPackageDataDC5EF35E",
               },
-              "\\",\\"ContinuationToken.$\\":\\"$.ContinuationToken\\",\\"Prefix\\":\\"data/\\"}},\\"Process Result\\":{\\"Type\\":\\"Map\\",\\"ResultPath\\":null,\\"End\\":true,\\"Iterator\\":{\\"StartAt\\":\\"Is metadata object?\\",\\"States\\":{\\"Is metadata object?\\":{\\"Type\\":\\"Choice\\",\\"Choices\\":[{\\"Variable\\":\\"$.Key\\",\\"StringMatches\\":\\"*/metadata.json\\",\\"Next\\":\\"Send for reprocessing\\"}],\\"Default\\":\\"Nothing to do\\"},\\"Nothing to do\\":{\\"Type\\":\\"Succeed\\"},\\"Send for reprocessing\\":{\\"End\\":true,\\"Retry\\":[{\\"ErrorEquals\\":[\\"Lambda.ServiceException\\",\\"Lambda.AWSLambdaException\\",\\"Lambda.SdkClientException\\"],\\"IntervalSeconds\\":2,\\"MaxAttempts\\":6,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":30,\\"BackoffRate\\":1.1}],\\"Type\\":\\"Task\\",\\"Resource\\":\\"arn:",
+              "\\",\\"ContinuationToken.$\\":\\"$.ContinuationToken\\",\\"Prefix\\":\\"data/\\"}},\\"Process Result\\":{\\"Type\\":\\"Map\\",\\"ResultPath\\":null,\\"End\\":true,\\"Parameters\\":{\\"s3Object.$\\":\\"$$.Map.Item.Value\\",\\"params.$\\":\\"$.params\\"},\\"Iterator\\":{\\"StartAt\\":\\"Is metadata object?\\",\\"States\\":{\\"Is metadata object?\\":{\\"Type\\":\\"Choice\\",\\"Choices\\":[{\\"Variable\\":\\"$.s3Object.Key\\",\\"StringMatches\\":\\"*/metadata.json\\",\\"Next\\":\\"Send for reprocessing\\"}],\\"Default\\":\\"Nothing to do\\"},\\"Nothing to do\\":{\\"Type\\":\\"Succeed\\"},\\"Send for reprocessing\\":{\\"End\\":true,\\"Retry\\":[{\\"ErrorEquals\\":[\\"Lambda.ServiceException\\",\\"Lambda.AWSLambdaException\\",\\"Lambda.SdkClientException\\"],\\"IntervalSeconds\\":2,\\"MaxAttempts\\":6,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":30,\\"BackoffRate\\":1.1}],\\"Type\\":\\"Task\\",\\"Resource\\":\\"arn:",
               Object {
                 "Ref": "AWS::Partition",
               },
@@ -27954,7 +27954,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727S3Bucket927BFE5C",
+            "Ref": "AssetParameters0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547afS3Bucket0C55E91B",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -27967,7 +27967,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727S3VersionKey80769D0D",
+                          "Ref": "AssetParameters0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547afS3VersionKeyFDBDFFC2",
                         },
                       ],
                     },
@@ -27980,7 +27980,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727S3VersionKey80769D0D",
+                          "Ref": "AssetParameters0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547afS3VersionKeyFDBDFFC2",
                         },
                       ],
                     },
@@ -32488,16 +32488,16 @@ Object {
     },
   },
   "Parameters": Object {
-    "AssetParameters0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2ArtifactHash0B2B7704": Object {
-      "Description": "Artifact hash for asset \\"0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2\\"",
+    "AssetParameters0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547afArtifactHashBF1388E8": Object {
+      "Description": "Artifact hash for asset \\"0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547af\\"",
       "Type": "String",
     },
-    "AssetParameters0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2S3BucketF895C157": Object {
-      "Description": "S3 bucket for asset \\"0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2\\"",
+    "AssetParameters0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547afS3Bucket0C55E91B": Object {
+      "Description": "S3 bucket for asset \\"0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547af\\"",
       "Type": "String",
     },
-    "AssetParameters0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2S3VersionKey5A51414E": Object {
-      "Description": "S3 key for asset version \\"0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2\\"",
+    "AssetParameters0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547afS3VersionKeyFDBDFFC2": Object {
+      "Description": "S3 key for asset version \\"0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547af\\"",
       "Type": "String",
     },
     "AssetParameters0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9ArtifactHashB9E3BF29": Object {
@@ -32536,18 +32536,6 @@ Object {
       "Description": "S3 key for asset version \\"2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658\\"",
       "Type": "String",
     },
-    "AssetParameters375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727ArtifactHash117D71AA": Object {
-      "Description": "Artifact hash for asset \\"375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727\\"",
-      "Type": "String",
-    },
-    "AssetParameters375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727S3Bucket927BFE5C": Object {
-      "Description": "S3 bucket for asset \\"375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727\\"",
-      "Type": "String",
-    },
-    "AssetParameters375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727S3VersionKey80769D0D": Object {
-      "Description": "S3 key for asset version \\"375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727\\"",
-      "Type": "String",
-    },
     "AssetParameters4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbcArtifactHashF236251A": Object {
       "Description": "Artifact hash for asset \\"4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbc\\"",
       "Type": "String",
@@ -32558,6 +32546,18 @@ Object {
     },
     "AssetParameters4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbcS3VersionKey547E84F8": Object {
       "Description": "S3 key for asset version \\"4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbc\\"",
+      "Type": "String",
+    },
+    "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181ArtifactHash428CD1A0": Object {
+      "Description": "Artifact hash for asset \\"4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181\\"",
+      "Type": "String",
+    },
+    "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3BucketAEB068B9": Object {
+      "Description": "S3 bucket for asset \\"4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181\\"",
+      "Type": "String",
+    },
+    "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3VersionKey00947D36": Object {
+      "Description": "S3 key for asset version \\"4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181\\"",
       "Type": "String",
     },
     "AssetParameters51e6101c826732d4e632b2ee6a67e76518b05cea28bb0a00d6c5c697c83d89baArtifactHash102D0396": Object {
@@ -32608,16 +32608,16 @@ Object {
       "Description": "S3 key for asset version \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
     },
-    "AssetParameters945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17ArtifactHash3E3A0986": Object {
-      "Description": "Artifact hash for asset \\"945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17\\"",
+    "AssetParameters9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5fArtifactHash26A7736C": Object {
+      "Description": "Artifact hash for asset \\"9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5f\\"",
       "Type": "String",
     },
-    "AssetParameters945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17S3Bucket6A002A15": Object {
-      "Description": "S3 bucket for asset \\"945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17\\"",
+    "AssetParameters9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5fS3Bucket932E68D6": Object {
+      "Description": "S3 bucket for asset \\"9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5f\\"",
       "Type": "String",
     },
-    "AssetParameters945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17S3VersionKeyAC01152C": Object {
-      "Description": "S3 key for asset version \\"945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17\\"",
+    "AssetParameters9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5fS3VersionKey1EF690AA": Object {
+      "Description": "S3 key for asset version \\"9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5f\\"",
       "Type": "String",
     },
     "AssetParametersa01d4ca81a4167a5f4a8084ccd5b7f926995c222c590c70973b3ee2c7087b534ArtifactHash1057C76B": Object {
@@ -34436,7 +34436,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17S3Bucket6A002A15",
+            "Ref": "AssetParameters9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5fS3Bucket932E68D6",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -34449,7 +34449,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17S3VersionKeyAC01152C",
+                          "Ref": "AssetParameters9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5fS3VersionKey1EF690AA",
                         },
                       ],
                     },
@@ -34462,7 +34462,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17S3VersionKeyAC01152C",
+                          "Ref": "AssetParameters9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5fS3VersionKey1EF690AA",
                         },
                       ],
                     },
@@ -34898,7 +34898,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2S3BucketF895C157",
+            "Ref": "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3BucketAEB068B9",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -34911,7 +34911,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2S3VersionKey5A51414E",
+                          "Ref": "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3VersionKey00947D36",
                         },
                       ],
                     },
@@ -34924,7 +34924,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2S3VersionKey5A51414E",
+                          "Ref": "AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3VersionKey00947D36",
                         },
                       ],
                     },
@@ -34954,7 +34954,7 @@ Direct link to the function: /lambda/home#/functions/",
           ],
         },
         "Runtime": "nodejs14.x",
-        "Timeout": 60,
+        "Timeout": 180,
         "TracingConfig": Object {
           "Mode": "Active",
         },
@@ -35100,7 +35100,7 @@ Direct link to the function: /lambda/home#/functions/",
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"StartAt\\":\\"Has a ContinuationToken?\\",\\"States\\":{\\"Has a ContinuationToken?\\":{\\"Type\\":\\"Choice\\",\\"Choices\\":[{\\"Variable\\":\\"$.ContinuationToken\\",\\"IsPresent\\":true,\\"Next\\":\\"S3.ListObjectsV2(NextPage)\\"}],\\"Default\\":\\"S3.ListObjectsV2(FirstPage)\\"},\\"S3.ListObjectsV2(FirstPage)\\":{\\"Next\\":\\"Is there more?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"S3.SdkClientException\\"]}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.response\\",\\"Resource\\":\\"arn:",
+              "{\\"StartAt\\":\\"Move input into $.params\\",\\"States\\":{\\"Move input into $.params\\":{\\"Type\\":\\"Pass\\",\\"Parameters\\":{\\"params.$\\":\\"$\\"},\\"Next\\":\\"Has a ContinuationToken?\\"},\\"Has a ContinuationToken?\\":{\\"Type\\":\\"Choice\\",\\"Choices\\":[{\\"Variable\\":\\"$.ContinuationToken\\",\\"IsPresent\\":true,\\"Next\\":\\"S3.ListObjectsV2(NextPage)\\"}],\\"Default\\":\\"S3.ListObjectsV2(FirstPage)\\"},\\"S3.ListObjectsV2(FirstPage)\\":{\\"Next\\":\\"Is there more?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"S3.SdkClientException\\"]}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.response\\",\\"Resource\\":\\"arn:",
               Object {
                 "Ref": "AWS::Partition",
               },
@@ -35116,7 +35116,7 @@ Direct link to the function: /lambda/home#/functions/",
               Object {
                 "Ref": "ConstructHubPackageDataDC5EF35E",
               },
-              "\\",\\"ContinuationToken.$\\":\\"$.ContinuationToken\\",\\"Prefix\\":\\"data/\\"}},\\"Process Result\\":{\\"Type\\":\\"Map\\",\\"ResultPath\\":null,\\"End\\":true,\\"Iterator\\":{\\"StartAt\\":\\"Is metadata object?\\",\\"States\\":{\\"Is metadata object?\\":{\\"Type\\":\\"Choice\\",\\"Choices\\":[{\\"Variable\\":\\"$.Key\\",\\"StringMatches\\":\\"*/metadata.json\\",\\"Next\\":\\"Send for reprocessing\\"}],\\"Default\\":\\"Nothing to do\\"},\\"Nothing to do\\":{\\"Type\\":\\"Succeed\\"},\\"Send for reprocessing\\":{\\"End\\":true,\\"Retry\\":[{\\"ErrorEquals\\":[\\"Lambda.ServiceException\\",\\"Lambda.AWSLambdaException\\",\\"Lambda.SdkClientException\\"],\\"IntervalSeconds\\":2,\\"MaxAttempts\\":6,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":30,\\"BackoffRate\\":1.1}],\\"Type\\":\\"Task\\",\\"Resource\\":\\"arn:",
+              "\\",\\"ContinuationToken.$\\":\\"$.ContinuationToken\\",\\"Prefix\\":\\"data/\\"}},\\"Process Result\\":{\\"Type\\":\\"Map\\",\\"ResultPath\\":null,\\"End\\":true,\\"Parameters\\":{\\"s3Object.$\\":\\"$$.Map.Item.Value\\",\\"params.$\\":\\"$.params\\"},\\"Iterator\\":{\\"StartAt\\":\\"Is metadata object?\\",\\"States\\":{\\"Is metadata object?\\":{\\"Type\\":\\"Choice\\",\\"Choices\\":[{\\"Variable\\":\\"$.s3Object.Key\\",\\"StringMatches\\":\\"*/metadata.json\\",\\"Next\\":\\"Send for reprocessing\\"}],\\"Default\\":\\"Nothing to do\\"},\\"Nothing to do\\":{\\"Type\\":\\"Succeed\\"},\\"Send for reprocessing\\":{\\"End\\":true,\\"Retry\\":[{\\"ErrorEquals\\":[\\"Lambda.ServiceException\\",\\"Lambda.AWSLambdaException\\",\\"Lambda.SdkClientException\\"],\\"IntervalSeconds\\":2,\\"MaxAttempts\\":6,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":30,\\"BackoffRate\\":1.1}],\\"Type\\":\\"Task\\",\\"Resource\\":\\"arn:",
               Object {
                 "Ref": "AWS::Partition",
               },
@@ -37643,7 +37643,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727S3Bucket927BFE5C",
+            "Ref": "AssetParameters0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547afS3Bucket0C55E91B",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -37656,7 +37656,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727S3VersionKey80769D0D",
+                          "Ref": "AssetParameters0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547afS3VersionKeyFDBDFFC2",
                         },
                       ],
                     },
@@ -37669,7 +37669,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727S3VersionKey80769D0D",
+                          "Ref": "AssetParameters0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547afS3VersionKeyFDBDFFC2",
                         },
                       ],
                     },

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -3849,7 +3849,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3BucketAEB068B9
+          Ref: AssetParametersbe9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5S3Bucket0F67E5C9
         S3Key:
           Fn::Join:
             - ""
@@ -3857,12 +3857,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3VersionKey00947D36
+                      - Ref: AssetParametersbe9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5S3VersionKeyC402DD84
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3VersionKey00947D36
+                      - Ref: AssetParametersbe9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5S3VersionKeyC402DD84
       Role:
         Fn::GetAtt:
           - ConstructHubIngestionReprocessWorkflowFunctionServiceRoleA59056B1
@@ -3878,7 +3878,7 @@ Resources:
       Handler: index.handler
       MemorySize: 10240
       Runtime: nodejs14.x
-      Timeout: 180
+      Timeout: 60
       TracingConfig:
         Mode: Active
     DependsOn:
@@ -6325,18 +6325,18 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5f"
-  AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3BucketAEB068B9:
+  AssetParametersbe9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5S3Bucket0F67E5C9:
     Type: String
     Description: S3 bucket for asset
-      "4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181"
-  AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3VersionKey00947D36:
+      "be9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5"
+  AssetParametersbe9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5S3VersionKeyC402DD84:
     Type: String
     Description: S3 key for asset version
-      "4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181"
-  AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181ArtifactHash428CD1A0:
+      "be9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5"
+  AssetParametersbe9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5ArtifactHashE0B34747:
     Type: String
     Description: Artifact hash for asset
-      "4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181"
+      "be9806cbbce420371cb8b9b5f418d51a429b2f14a2ac7b56d683499db10c2ec5"
   AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3BucketF36A877E:
     Type: String
     Description: S3 bucket for asset

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -2319,7 +2319,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727S3Bucket927BFE5C
+          Ref: AssetParameters0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547afS3Bucket0C55E91B
         S3Key:
           Fn::Join:
             - ""
@@ -2327,12 +2327,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727S3VersionKey80769D0D
+                      - Ref: AssetParameters0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547afS3VersionKeyFDBDFFC2
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727S3VersionKey80769D0D
+                      - Ref: AssetParameters0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547afS3VersionKeyFDBDFFC2
       Role:
         Fn::GetAtt:
           - ConstructHubOrchestrationNeedsCatalogUpdateServiceRoleE6BF31C3
@@ -3666,7 +3666,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17S3Bucket6A002A15
+          Ref: AssetParameters9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5fS3Bucket932E68D6
         S3Key:
           Fn::Join:
             - ""
@@ -3674,12 +3674,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17S3VersionKeyAC01152C
+                      - Ref: AssetParameters9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5fS3VersionKey1EF690AA
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17S3VersionKeyAC01152C
+                      - Ref: AssetParameters9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5fS3VersionKey1EF690AA
       Role:
         Fn::GetAtt:
           - ConstructHubIngestionServiceRole6380BAB6
@@ -3849,7 +3849,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2S3BucketF895C157
+          Ref: AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3BucketAEB068B9
         S3Key:
           Fn::Join:
             - ""
@@ -3857,12 +3857,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2S3VersionKey5A51414E
+                      - Ref: AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3VersionKey00947D36
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2S3VersionKey5A51414E
+                      - Ref: AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3VersionKey00947D36
       Role:
         Fn::GetAtt:
           - ConstructHubIngestionReprocessWorkflowFunctionServiceRoleA59056B1
@@ -3878,7 +3878,7 @@ Resources:
       Handler: index.handler
       MemorySize: 10240
       Runtime: nodejs14.x
-      Timeout: 60
+      Timeout: 180
       TracingConfig:
         Mode: Active
     DependsOn:
@@ -3966,7 +3966,9 @@ Resources:
       DefinitionString:
         Fn::Join:
           - ""
-          - - '{"StartAt":"Has a ContinuationToken?","States":{"Has a
+          - - '{"StartAt":"Move input into $.params","States":{"Move input into
+              $.params":{"Type":"Pass","Parameters":{"params.$":"$"},"Next":"Has
+              a ContinuationToken?"},"Has a
               ContinuationToken?":{"Type":"Choice","Choices":[{"Variable":"$.ContinuationToken","IsPresent":true,"Next":"S3.ListObjectsV2(NextPage)"}],"Default":"S3.ListObjectsV2(FirstPage)"},"S3.ListObjectsV2(FirstPage)":{"Next":"Is
               there
               more?","Retry":[{"ErrorEquals":["S3.SdkClientException"]}],"Type":"Task","ResultPath":"$.response","Resource":"arn:'
@@ -3982,9 +3984,9 @@ Resources:
             - :states:::aws-sdk:s3:listObjectsV2","Parameters":{"Bucket":"
             - Ref: ConstructHubPackageDataDC5EF35E
             - '","ContinuationToken.$":"$.ContinuationToken","Prefix":"data/"}},"Process
-              Result":{"Type":"Map","ResultPath":null,"End":true,"Iterator":{"StartAt":"Is
+              Result":{"Type":"Map","ResultPath":null,"End":true,"Parameters":{"s3Object.$":"$$.Map.Item.Value","params.$":"$.params"},"Iterator":{"StartAt":"Is
               metadata object?","States":{"Is metadata
-              object?":{"Type":"Choice","Choices":[{"Variable":"$.Key","StringMatches":"*/metadata.json","Next":"Send
+              object?":{"Type":"Choice","Choices":[{"Variable":"$.s3Object.Key","StringMatches":"*/metadata.json","Next":"Send
               for reprocessing"}],"Default":"Nothing to do"},"Nothing to
               do":{"Type":"Succeed"},"Send for
               reprocessing":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["Lambda.TooManyRequestsException"],"IntervalSeconds":60,"MaxAttempts":30,"BackoffRate":1.1}],"Type":"Task","Resource":"arn:'
@@ -6275,18 +6277,18 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "51e6101c826732d4e632b2ee6a67e76518b05cea28bb0a00d6c5c697c83d89ba"
-  AssetParameters375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727S3Bucket927BFE5C:
+  AssetParameters0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547afS3Bucket0C55E91B:
     Type: String
     Description: S3 bucket for asset
-      "375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727"
-  AssetParameters375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727S3VersionKey80769D0D:
+      "0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547af"
+  AssetParameters0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547afS3VersionKeyFDBDFFC2:
     Type: String
     Description: S3 key for asset version
-      "375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727"
-  AssetParameters375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727ArtifactHash117D71AA:
+      "0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547af"
+  AssetParameters0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547afArtifactHashBF1388E8:
     Type: String
     Description: Artifact hash for asset
-      "375fd910cbad4bb447f68355c9834ce7ab686221d284c0d4f23038de6d3e7727"
+      "0b5465ddea9db1d4bbc514547760ad9b1f8e032c2d0e59c1fb6db4ec832547af"
   AssetParametersfc986584c099ea5046c4cc9515c34013472214b465565366d7e634dd9705258fS3Bucket44863F75:
     Type: String
     Description: S3 bucket for asset
@@ -6311,30 +6313,30 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "b69f8e77829ba765ee3a37c088671f56d5982ab8e2a57c2f3103bea15181e67b"
-  AssetParameters945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17S3Bucket6A002A15:
+  AssetParameters9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5fS3Bucket932E68D6:
     Type: String
     Description: S3 bucket for asset
-      "945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17"
-  AssetParameters945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17S3VersionKeyAC01152C:
+      "9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5f"
+  AssetParameters9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5fS3VersionKey1EF690AA:
     Type: String
     Description: S3 key for asset version
-      "945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17"
-  AssetParameters945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17ArtifactHash3E3A0986:
+      "9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5f"
+  AssetParameters9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5fArtifactHash26A7736C:
     Type: String
     Description: Artifact hash for asset
-      "945f3968c550f4c12b8d7f7f78f1ce8536d7007002590472233082927ae2dd17"
-  AssetParameters0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2S3BucketF895C157:
+      "9dd2c44da0fb4391955068937fe052fa8cf8cf8b33bb8b5cfbc5b0b4d3e76a5f"
+  AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3BucketAEB068B9:
     Type: String
     Description: S3 bucket for asset
-      "0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2"
-  AssetParameters0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2S3VersionKey5A51414E:
+      "4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181"
+  AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181S3VersionKey00947D36:
     Type: String
     Description: S3 key for asset version
-      "0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2"
-  AssetParameters0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2ArtifactHash0B2B7704:
+      "4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181"
+  AssetParameters4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181ArtifactHash428CD1A0:
     Type: String
     Description: Artifact hash for asset
-      "0609b74426991bff02eabb105c021a431b0c6bc6082837b3b882e331fb3bd8c2"
+      "4cdd75c213ddc5088e9cbc1c1674e5df62df8d15e64ec4730a324e20da974181"
   AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3BucketF36A877E:
     Type: String
     Description: S3 bucket for asset

--- a/src/backend/ingestion/ingestion.lambda.ts
+++ b/src/backend/ingestion/ingestion.lambda.ts
@@ -280,6 +280,12 @@ export const handler = metricScope(
       };
       console.log(`Created objects: ${JSON.stringify(created, null, 2)}`);
 
+      if (payload.skipDocgen) {
+        console.log('skipDocgen enabled, skipping StateMachine execution.');
+        continue;
+      }
+
+      // Hand off work to the orchestrator / doc generator
       const sfn = await aws
         .stepFunctions()
         .startExecution({

--- a/src/backend/orchestration/needs-catalog-update.lambda.ts
+++ b/src/backend/orchestration/needs-catalog-update.lambda.ts
@@ -20,7 +20,7 @@ export type Input = Pick<StateMachineInput, 'package'>;
 export async function handler(event: Input): Promise<boolean> {
   console.log(`Event: ${JSON.stringify(event, null, 2)}`);
 
-  const [, packageName, version] = STORAGE_KEY_FORMAT_REGEX.exec(event.package.key) ?? die(`Unecpedted/invalid package key: ${event.package.key}`);
+  const [, packageName, version] = STORAGE_KEY_FORMAT_REGEX.exec(event.package.key) ?? die(`Unexpected/invalid package key: ${event.package.key}`);
   const packageMajor = major(version);
 
   const catalogClient = await CatalogClient.newClient();

--- a/src/backend/shared/ingestion-input.lambda-shared.ts
+++ b/src/backend/shared/ingestion-input.lambda-shared.ts
@@ -22,4 +22,11 @@ export interface IngestionInput {
    * The time at which the version was published, encoded in ISO-8601 format.
    */
   readonly time: string;
+
+  /**
+   * Skip generating docs.
+   *
+   * @default false
+   */
+  readonly skipDocgen?: boolean;
 }


### PR DESCRIPTION
This adds a "skipDocgen" option to make it easier to defer regenerating all docs when all you need to do is update package metadata objects after making a change to `packageTags` or `packageLinks`, for example.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*