### PR TITLE
chore: use JSONStream to be safe with large responses

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -255,6 +255,10 @@
       "type": "build"
     },
     {
+      "name": "JSONStream",
+      "type": "build"
+    },
+    {
       "name": "normalize-registry-metadata",
       "type": "build"
     },

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -877,7 +877,7 @@
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade @aws-sdk/client-sfn @jsii/spec @types/aws-lambda @types/fs-extra @types/jest @types/node @types/semver @types/tar-stream @typescript-eslint/eslint-plugin @typescript-eslint/parser aws-embedded-metrics aws-sdk aws-sdk-mock aws-xray-sdk-core case cdk-triggers construct-hub-webapp esbuild eslint eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import fs-extra glob got jest jest-junit jsii jsii-diff jsii-docgen jsii-pacmak json-schema normalize-registry-metadata npm-check-updates projen semver spdx-license-list standard-version tar-stream typescript uuid yaml"
+          "exec": "yarn upgrade @aws-sdk/client-sfn @jsii/spec @types/aws-lambda @types/fs-extra @types/jest @types/node @types/semver @types/tar-stream @typescript-eslint/eslint-plugin @typescript-eslint/parser aws-embedded-metrics aws-sdk aws-sdk-mock aws-xray-sdk-core case cdk-triggers construct-hub-webapp esbuild eslint eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import fs-extra glob got jest jest-junit jsii jsii-diff jsii-docgen jsii-pacmak json-schema JSONStream normalize-registry-metadata npm-check-updates projen semver spdx-license-list standard-version tar-stream typescript uuid yaml"
         },
         {
           "exec": "npx projen"

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -72,6 +72,7 @@ const project = new JsiiProject({
     'esbuild',
     'fs-extra',
     'got',
+    'JSONStream',
     'semver',
     'spdx-license-list',
     'tar-stream',

--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
     "jsii-docgen": "^3.8.24",
     "jsii-pacmak": "^1.43.0",
     "json-schema": "^0.4.0",
+    "JSONStream": "^1.3.5",
     "normalize-registry-metadata": "^1.1.2",
     "npm-check-updates": "^11",
     "projen": "^0.33.2",

--- a/src/JSONStream.d.ts
+++ b/src/JSONStream.d.ts
@@ -1,7 +1,7 @@
 /**
  * Partial hand-written declarations for the JSONStream module. Refer to the JS
  * module's documentation for additional operations, and more explanations on
- * posisble usage.
+ * possible usage.
  *
  * @see https://github.com/dominictarr/JSONStream
  */

--- a/src/JSONStream.d.ts
+++ b/src/JSONStream.d.ts
@@ -1,0 +1,29 @@
+/**
+ * Partial hand-written declarations for the JSONStream module. Refer to the JS
+ * module's documentation for additional operations, and more explanations on
+ * posisble usage.
+ *
+ * @see https://github.com/dominictarr/JSONStream
+ */
+declare module 'JSONStream' {
+
+  export function parse(pattern: any, map?: (value: any) => any): JSONStream;
+  export function parse(patterns: any[], map?: (value: any) => any): JSONStream;
+
+  interface JSONStream extends NodeJS.ReadWriteStream {
+    on(event: 'header', handler: (value: any) => void): this;
+    once(event: 'header', handler: (value: any) => void): this;
+
+    on(event: 'data', handler: (value: any) => void): this;
+    once(event: 'data', handler: (value: any) => void): this;
+
+    on(event: 'footer', handler: (value: any) => void): this;
+    once(event: 'footer', handler: (value: any) => void): this;
+
+    on(event: 'error', handler: (cause: any) => void): this;
+    once(event: 'error', handler: (cause: any) => void): this;
+
+    on(event: 'end', handler: () => void): this;
+    once(event: 'end', handler: () => void): this;
+  }
+}

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -57,18 +57,6 @@ Object {
       "Description": "S3 key for asset version \\"0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9\\"",
       "Type": "String",
     },
-    "AssetParameters1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28ArtifactHashE770D013": Object {
-      "Description": "Artifact hash for asset \\"1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28\\"",
-      "Type": "String",
-    },
-    "AssetParameters1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28S3Bucket58E2E453": Object {
-      "Description": "S3 bucket for asset \\"1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28\\"",
-      "Type": "String",
-    },
-    "AssetParameters1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28S3VersionKeyDDAC85C3": Object {
-      "Description": "S3 key for asset version \\"1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28\\"",
-      "Type": "String",
-    },
     "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658ArtifactHashA026490C": Object {
       "Description": "Artifact hash for asset \\"2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658\\"",
       "Type": "String",
@@ -235,6 +223,18 @@ Object {
     },
     "AssetParameterscc6d7142efe459ae578414b0f727c0634382fe26ad2ad67f59029ba7d82d7988S3VersionKeyC76335A1": Object {
       "Description": "S3 key for asset version \\"cc6d7142efe459ae578414b0f727c0634382fe26ad2ad67f59029ba7d82d7988\\"",
+      "Type": "String",
+    },
+    "AssetParametersda259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5ArtifactHash6964816D": Object {
+      "Description": "Artifact hash for asset \\"da259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5\\"",
+      "Type": "String",
+    },
+    "AssetParametersda259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5S3Bucket9A98EAF8": Object {
+      "Description": "S3 bucket for asset \\"da259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5\\"",
+      "Type": "String",
+    },
+    "AssetParametersda259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5S3VersionKey8CD7C9B0": Object {
+      "Description": "S3 key for asset version \\"da259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5\\"",
       "Type": "String",
     },
     "AssetParametersdb68808056dddd29d69f21d6e61c1338671d29364cdebd04c0c74a2ee619995aArtifactHash47B0D876": Object {
@@ -8402,7 +8402,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28S3Bucket58E2E453",
+            "Ref": "AssetParametersda259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5S3Bucket9A98EAF8",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -8415,7 +8415,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28S3VersionKeyDDAC85C3",
+                          "Ref": "AssetParametersda259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5S3VersionKey8CD7C9B0",
                         },
                       ],
                     },
@@ -8428,7 +8428,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28S3VersionKeyDDAC85C3",
+                          "Ref": "AssetParametersda259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5S3VersionKey8CD7C9B0",
                         },
                       ],
                     },
@@ -10833,18 +10833,6 @@ Object {
       "Description": "S3 key for asset version \\"0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9\\"",
       "Type": "String",
     },
-    "AssetParameters1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28ArtifactHashE770D013": Object {
-      "Description": "Artifact hash for asset \\"1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28\\"",
-      "Type": "String",
-    },
-    "AssetParameters1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28S3Bucket58E2E453": Object {
-      "Description": "S3 bucket for asset \\"1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28\\"",
-      "Type": "String",
-    },
-    "AssetParameters1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28S3VersionKeyDDAC85C3": Object {
-      "Description": "S3 key for asset version \\"1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28\\"",
-      "Type": "String",
-    },
     "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658ArtifactHashA026490C": Object {
       "Description": "Artifact hash for asset \\"2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658\\"",
       "Type": "String",
@@ -11011,6 +10999,18 @@ Object {
     },
     "AssetParameterscc6d7142efe459ae578414b0f727c0634382fe26ad2ad67f59029ba7d82d7988S3VersionKeyC76335A1": Object {
       "Description": "S3 key for asset version \\"cc6d7142efe459ae578414b0f727c0634382fe26ad2ad67f59029ba7d82d7988\\"",
+      "Type": "String",
+    },
+    "AssetParametersda259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5ArtifactHash6964816D": Object {
+      "Description": "Artifact hash for asset \\"da259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5\\"",
+      "Type": "String",
+    },
+    "AssetParametersda259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5S3Bucket9A98EAF8": Object {
+      "Description": "S3 bucket for asset \\"da259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5\\"",
+      "Type": "String",
+    },
+    "AssetParametersda259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5S3VersionKey8CD7C9B0": Object {
+      "Description": "S3 key for asset version \\"da259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5\\"",
       "Type": "String",
     },
     "AssetParametersdb68808056dddd29d69f21d6e61c1338671d29364cdebd04c0c74a2ee619995aArtifactHash47B0D876": Object {
@@ -19154,7 +19154,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28S3Bucket58E2E453",
+            "Ref": "AssetParametersda259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5S3Bucket9A98EAF8",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -19167,7 +19167,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28S3VersionKeyDDAC85C3",
+                          "Ref": "AssetParametersda259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5S3VersionKey8CD7C9B0",
                         },
                       ],
                     },
@@ -19180,7 +19180,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28S3VersionKeyDDAC85C3",
+                          "Ref": "AssetParametersda259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5S3VersionKey8CD7C9B0",
                         },
                       ],
                     },
@@ -21595,18 +21595,6 @@ Object {
       "Description": "S3 key for asset version \\"0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9\\"",
       "Type": "String",
     },
-    "AssetParameters1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28ArtifactHashE770D013": Object {
-      "Description": "Artifact hash for asset \\"1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28\\"",
-      "Type": "String",
-    },
-    "AssetParameters1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28S3Bucket58E2E453": Object {
-      "Description": "S3 bucket for asset \\"1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28\\"",
-      "Type": "String",
-    },
-    "AssetParameters1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28S3VersionKeyDDAC85C3": Object {
-      "Description": "S3 key for asset version \\"1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28\\"",
-      "Type": "String",
-    },
     "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658ArtifactHashA026490C": Object {
       "Description": "Artifact hash for asset \\"2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658\\"",
       "Type": "String",
@@ -21797,6 +21785,18 @@ Object {
     },
     "AssetParameterscc6d7142efe459ae578414b0f727c0634382fe26ad2ad67f59029ba7d82d7988S3VersionKeyC76335A1": Object {
       "Description": "S3 key for asset version \\"cc6d7142efe459ae578414b0f727c0634382fe26ad2ad67f59029ba7d82d7988\\"",
+      "Type": "String",
+    },
+    "AssetParametersda259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5ArtifactHash6964816D": Object {
+      "Description": "Artifact hash for asset \\"da259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5\\"",
+      "Type": "String",
+    },
+    "AssetParametersda259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5S3Bucket9A98EAF8": Object {
+      "Description": "S3 bucket for asset \\"da259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5\\"",
+      "Type": "String",
+    },
+    "AssetParametersda259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5S3VersionKey8CD7C9B0": Object {
+      "Description": "S3 key for asset version \\"da259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5\\"",
       "Type": "String",
     },
     "AssetParametersdb68808056dddd29d69f21d6e61c1338671d29364cdebd04c0c74a2ee619995aArtifactHash47B0D876": Object {
@@ -30135,7 +30135,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28S3Bucket58E2E453",
+            "Ref": "AssetParametersda259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5S3Bucket9A98EAF8",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -30148,7 +30148,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28S3VersionKeyDDAC85C3",
+                          "Ref": "AssetParametersda259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5S3VersionKey8CD7C9B0",
                         },
                       ],
                     },
@@ -30161,7 +30161,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28S3VersionKeyDDAC85C3",
+                          "Ref": "AssetParametersda259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5S3VersionKey8CD7C9B0",
                         },
                       ],
                     },
@@ -32845,18 +32845,6 @@ Object {
       "Description": "S3 key for asset version \\"0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9\\"",
       "Type": "String",
     },
-    "AssetParameters1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28ArtifactHashE770D013": Object {
-      "Description": "Artifact hash for asset \\"1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28\\"",
-      "Type": "String",
-    },
-    "AssetParameters1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28S3Bucket58E2E453": Object {
-      "Description": "S3 bucket for asset \\"1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28\\"",
-      "Type": "String",
-    },
-    "AssetParameters1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28S3VersionKeyDDAC85C3": Object {
-      "Description": "S3 key for asset version \\"1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28\\"",
-      "Type": "String",
-    },
     "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658ArtifactHashA026490C": Object {
       "Description": "Artifact hash for asset \\"2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658\\"",
       "Type": "String",
@@ -33023,6 +33011,18 @@ Object {
     },
     "AssetParameterscc6d7142efe459ae578414b0f727c0634382fe26ad2ad67f59029ba7d82d7988S3VersionKeyC76335A1": Object {
       "Description": "S3 key for asset version \\"cc6d7142efe459ae578414b0f727c0634382fe26ad2ad67f59029ba7d82d7988\\"",
+      "Type": "String",
+    },
+    "AssetParametersda259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5ArtifactHash6964816D": Object {
+      "Description": "Artifact hash for asset \\"da259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5\\"",
+      "Type": "String",
+    },
+    "AssetParametersda259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5S3Bucket9A98EAF8": Object {
+      "Description": "S3 bucket for asset \\"da259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5\\"",
+      "Type": "String",
+    },
+    "AssetParametersda259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5S3VersionKey8CD7C9B0": Object {
+      "Description": "S3 key for asset version \\"da259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5\\"",
       "Type": "String",
     },
     "AssetParametersdb68808056dddd29d69f21d6e61c1338671d29364cdebd04c0c74a2ee619995aArtifactHash47B0D876": Object {
@@ -39905,7 +39905,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28S3Bucket58E2E453",
+            "Ref": "AssetParametersda259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5S3Bucket9A98EAF8",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -39918,7 +39918,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28S3VersionKeyDDAC85C3",
+                          "Ref": "AssetParametersda259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5S3VersionKey8CD7C9B0",
                         },
                       ],
                     },
@@ -39931,7 +39931,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28S3VersionKeyDDAC85C3",
+                          "Ref": "AssetParametersda259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5S3VersionKey8CD7C9B0",
                         },
                       ],
                     },

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -4485,7 +4485,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28S3Bucket58E2E453
+          Ref: AssetParametersda259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5S3Bucket9A98EAF8
         S3Key:
           Fn::Join:
             - ""
@@ -4493,12 +4493,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28S3VersionKeyDDAC85C3
+                      - Ref: AssetParametersda259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5S3VersionKey8CD7C9B0
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28S3VersionKeyDDAC85C3
+                      - Ref: AssetParametersda259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5S3VersionKey8CD7C9B0
       Role:
         Fn::GetAtt:
           - ConstructHubSourcesNpmJsServiceRoleAC3F7AA6
@@ -6441,18 +6441,18 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "a01d4ca81a4167a5f4a8084ccd5b7f926995c222c590c70973b3ee2c7087b534"
-  AssetParameters1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28S3Bucket58E2E453:
+  AssetParametersda259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5S3Bucket9A98EAF8:
     Type: String
     Description: S3 bucket for asset
-      "1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28"
-  AssetParameters1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28S3VersionKeyDDAC85C3:
+      "da259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5"
+  AssetParametersda259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5S3VersionKey8CD7C9B0:
     Type: String
     Description: S3 key for asset version
-      "1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28"
-  AssetParameters1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28ArtifactHashE770D013:
+      "da259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5"
+  AssetParametersda259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5ArtifactHash6964816D:
     Type: String
     Description: Artifact hash for asset
-      "1d620d4124ee5160192eccc4817c0f6b0e2625d7504332aee3b12f257746ed28"
+      "da259481087e617cddf544931de12aab5204222e9fa77e0e93611494a07439c5"
   AssetParameters5af0e476215eecf6a11d9344451dbb927349489ea7d76b481334b7558057b5c3S3Bucket9C2F7A99:
     Type: String
     Description: S3 bucket for asset

--- a/yarn.lock
+++ b/yarn.lock
@@ -4931,7 +4931,7 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
-JSONStream@^1.0.4:
+JSONStream@^1.0.4, JSONStream@^1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
   integrity sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==


### PR DESCRIPTION
Instead of limiting the response size, leverage JSONStream to parse the
JSON objects in a streaming fashion. This simplifies the code for
handling the HTTP response payloads.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*