### PR TITLE
fix: npmjs package canary failed on HEAD requests

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -69,6 +69,18 @@ Object {
       "Description": "S3 key for asset version \\"19cb1b080f1300d1f3cd407d29651076d8668e49a0bd8e54f95490f8e9081e03\\"",
       "Type": "String",
     },
+    "AssetParameters1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaedArtifactHash933B5E30": Object {
+      "Description": "Artifact hash for asset \\"1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaed\\"",
+      "Type": "String",
+    },
+    "AssetParameters1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaedS3BucketBD3E9BD7": Object {
+      "Description": "S3 bucket for asset \\"1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaed\\"",
+      "Type": "String",
+    },
+    "AssetParameters1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaedS3VersionKey87A963BD": Object {
+      "Description": "S3 key for asset version \\"1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaed\\"",
+      "Type": "String",
+    },
     "AssetParameters2014f4c1d30de902409ad3965bb488173ce030f76ee67fdcd0fae846487499cbArtifactHash76F4E4A1": Object {
       "Description": "Artifact hash for asset \\"2014f4c1d30de902409ad3965bb488173ce030f76ee67fdcd0fae846487499cb\\"",
       "Type": "String",
@@ -115,18 +127,6 @@ Object {
     },
     "AssetParameters38c1770692a189751614dd7f17bde0c2f84ed85cd04e83dc824739cc8b18d3aeS3VersionKeyF02ECD15": Object {
       "Description": "S3 key for asset version \\"38c1770692a189751614dd7f17bde0c2f84ed85cd04e83dc824739cc8b18d3ae\\"",
-      "Type": "String",
-    },
-    "AssetParameters40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46acArtifactHash1AFACE75": Object {
-      "Description": "Artifact hash for asset \\"40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46ac\\"",
-      "Type": "String",
-    },
-    "AssetParameters40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46acS3Bucket2674B809": Object {
-      "Description": "S3 bucket for asset \\"40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46ac\\"",
-      "Type": "String",
-    },
-    "AssetParameters40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46acS3VersionKeyD2C3153D": Object {
-      "Description": "S3 key for asset version \\"40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46ac\\"",
       "Type": "String",
     },
     "AssetParameters7412ee3c3ed97354b11100cb1f73e96631635318730a2733203b58c986337b81ArtifactHashF2C7E53A": Object {
@@ -6692,7 +6692,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46acS3Bucket2674B809",
+            "Ref": "AssetParameters1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaedS3BucketBD3E9BD7",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -6705,7 +6705,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46acS3VersionKeyD2C3153D",
+                          "Ref": "AssetParameters1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaedS3VersionKey87A963BD",
                         },
                       ],
                     },
@@ -6718,7 +6718,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46acS3VersionKeyD2C3153D",
+                          "Ref": "AssetParameters1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaedS3VersionKey87A963BD",
                         },
                       ],
                     },
@@ -6731,6 +6731,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {
           "Variables": Object {
+            "AWS_EMF_ENVIRONMENT": "Local",
             "CONSTRUCT_HUB_BASE_URL": Object {
               "Fn::Join": Array [
                 "",
@@ -9331,6 +9332,18 @@ Object {
       "Description": "S3 key for asset version \\"19cb1b080f1300d1f3cd407d29651076d8668e49a0bd8e54f95490f8e9081e03\\"",
       "Type": "String",
     },
+    "AssetParameters1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaedArtifactHash933B5E30": Object {
+      "Description": "Artifact hash for asset \\"1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaed\\"",
+      "Type": "String",
+    },
+    "AssetParameters1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaedS3BucketBD3E9BD7": Object {
+      "Description": "S3 bucket for asset \\"1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaed\\"",
+      "Type": "String",
+    },
+    "AssetParameters1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaedS3VersionKey87A963BD": Object {
+      "Description": "S3 key for asset version \\"1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaed\\"",
+      "Type": "String",
+    },
     "AssetParameters2014f4c1d30de902409ad3965bb488173ce030f76ee67fdcd0fae846487499cbArtifactHash76F4E4A1": Object {
       "Description": "Artifact hash for asset \\"2014f4c1d30de902409ad3965bb488173ce030f76ee67fdcd0fae846487499cb\\"",
       "Type": "String",
@@ -9389,18 +9402,6 @@ Object {
     },
     "AssetParameters4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbcS3VersionKey547E84F8": Object {
       "Description": "S3 key for asset version \\"4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbc\\"",
-      "Type": "String",
-    },
-    "AssetParameters40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46acArtifactHash1AFACE75": Object {
-      "Description": "Artifact hash for asset \\"40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46ac\\"",
-      "Type": "String",
-    },
-    "AssetParameters40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46acS3Bucket2674B809": Object {
-      "Description": "S3 bucket for asset \\"40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46ac\\"",
-      "Type": "String",
-    },
-    "AssetParameters40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46acS3VersionKeyD2C3153D": Object {
-      "Description": "S3 key for asset version \\"40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46ac\\"",
       "Type": "String",
     },
     "AssetParameters7412ee3c3ed97354b11100cb1f73e96631635318730a2733203b58c986337b81ArtifactHashF2C7E53A": Object {
@@ -16426,7 +16427,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46acS3Bucket2674B809",
+            "Ref": "AssetParameters1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaedS3BucketBD3E9BD7",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -16439,7 +16440,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46acS3VersionKeyD2C3153D",
+                          "Ref": "AssetParameters1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaedS3VersionKey87A963BD",
                         },
                       ],
                     },
@@ -16452,7 +16453,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46acS3VersionKeyD2C3153D",
+                          "Ref": "AssetParameters1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaedS3VersionKey87A963BD",
                         },
                       ],
                     },
@@ -16465,6 +16466,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {
           "Variables": Object {
+            "AWS_EMF_ENVIRONMENT": "Local",
             "CONSTRUCT_HUB_BASE_URL": Object {
               "Fn::Join": Array [
                 "",
@@ -19065,6 +19067,18 @@ Object {
       "Description": "S3 key for asset version \\"19cb1b080f1300d1f3cd407d29651076d8668e49a0bd8e54f95490f8e9081e03\\"",
       "Type": "String",
     },
+    "AssetParameters1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaedArtifactHash933B5E30": Object {
+      "Description": "Artifact hash for asset \\"1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaed\\"",
+      "Type": "String",
+    },
+    "AssetParameters1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaedS3BucketBD3E9BD7": Object {
+      "Description": "S3 bucket for asset \\"1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaed\\"",
+      "Type": "String",
+    },
+    "AssetParameters1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaedS3VersionKey87A963BD": Object {
+      "Description": "S3 key for asset version \\"1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaed\\"",
+      "Type": "String",
+    },
     "AssetParameters2014f4c1d30de902409ad3965bb488173ce030f76ee67fdcd0fae846487499cbArtifactHash76F4E4A1": Object {
       "Description": "Artifact hash for asset \\"2014f4c1d30de902409ad3965bb488173ce030f76ee67fdcd0fae846487499cb\\"",
       "Type": "String",
@@ -19111,18 +19125,6 @@ Object {
     },
     "AssetParameters38c1770692a189751614dd7f17bde0c2f84ed85cd04e83dc824739cc8b18d3aeS3VersionKeyF02ECD15": Object {
       "Description": "S3 key for asset version \\"38c1770692a189751614dd7f17bde0c2f84ed85cd04e83dc824739cc8b18d3ae\\"",
-      "Type": "String",
-    },
-    "AssetParameters40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46acArtifactHash1AFACE75": Object {
-      "Description": "Artifact hash for asset \\"40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46ac\\"",
-      "Type": "String",
-    },
-    "AssetParameters40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46acS3Bucket2674B809": Object {
-      "Description": "S3 bucket for asset \\"40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46ac\\"",
-      "Type": "String",
-    },
-    "AssetParameters40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46acS3VersionKeyD2C3153D": Object {
-      "Description": "S3 key for asset version \\"40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46ac\\"",
       "Type": "String",
     },
     "AssetParameters7412ee3c3ed97354b11100cb1f73e96631635318730a2733203b58c986337b81ArtifactHashF2C7E53A": Object {
@@ -25688,7 +25690,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46acS3Bucket2674B809",
+            "Ref": "AssetParameters1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaedS3BucketBD3E9BD7",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -25701,7 +25703,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46acS3VersionKeyD2C3153D",
+                          "Ref": "AssetParameters1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaedS3VersionKey87A963BD",
                         },
                       ],
                     },
@@ -25714,7 +25716,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46acS3VersionKeyD2C3153D",
+                          "Ref": "AssetParameters1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaedS3VersionKey87A963BD",
                         },
                       ],
                     },
@@ -25727,6 +25729,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {
           "Variables": Object {
+            "AWS_EMF_ENVIRONMENT": "Local",
             "CONSTRUCT_HUB_BASE_URL": Object {
               "Fn::Join": Array [
                 "",
@@ -28337,6 +28340,18 @@ Object {
       "Description": "S3 key for asset version \\"19cb1b080f1300d1f3cd407d29651076d8668e49a0bd8e54f95490f8e9081e03\\"",
       "Type": "String",
     },
+    "AssetParameters1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaedArtifactHash933B5E30": Object {
+      "Description": "Artifact hash for asset \\"1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaed\\"",
+      "Type": "String",
+    },
+    "AssetParameters1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaedS3BucketBD3E9BD7": Object {
+      "Description": "S3 bucket for asset \\"1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaed\\"",
+      "Type": "String",
+    },
+    "AssetParameters1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaedS3VersionKey87A963BD": Object {
+      "Description": "S3 key for asset version \\"1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaed\\"",
+      "Type": "String",
+    },
     "AssetParameters2014f4c1d30de902409ad3965bb488173ce030f76ee67fdcd0fae846487499cbArtifactHash76F4E4A1": Object {
       "Description": "Artifact hash for asset \\"2014f4c1d30de902409ad3965bb488173ce030f76ee67fdcd0fae846487499cb\\"",
       "Type": "String",
@@ -28383,18 +28398,6 @@ Object {
     },
     "AssetParameters38c1770692a189751614dd7f17bde0c2f84ed85cd04e83dc824739cc8b18d3aeS3VersionKeyF02ECD15": Object {
       "Description": "S3 key for asset version \\"38c1770692a189751614dd7f17bde0c2f84ed85cd04e83dc824739cc8b18d3ae\\"",
-      "Type": "String",
-    },
-    "AssetParameters40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46acArtifactHash1AFACE75": Object {
-      "Description": "Artifact hash for asset \\"40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46ac\\"",
-      "Type": "String",
-    },
-    "AssetParameters40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46acS3Bucket2674B809": Object {
-      "Description": "S3 bucket for asset \\"40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46ac\\"",
-      "Type": "String",
-    },
-    "AssetParameters40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46acS3VersionKeyD2C3153D": Object {
-      "Description": "S3 key for asset version \\"40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46ac\\"",
       "Type": "String",
     },
     "AssetParameters5465af3e563838faf87f189369af003b61ed4608e6c6423cf21af7189e21abafArtifactHash1E43F8AF": Object {
@@ -35155,7 +35158,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46acS3Bucket2674B809",
+            "Ref": "AssetParameters1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaedS3BucketBD3E9BD7",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -35168,7 +35171,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46acS3VersionKeyD2C3153D",
+                          "Ref": "AssetParameters1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaedS3VersionKey87A963BD",
                         },
                       ],
                     },
@@ -35181,7 +35184,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46acS3VersionKeyD2C3153D",
+                          "Ref": "AssetParameters1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaedS3VersionKey87A963BD",
                         },
                       ],
                     },
@@ -35194,6 +35197,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {
           "Variables": Object {
+            "AWS_EMF_ENVIRONMENT": "Local",
             "CONSTRUCT_HUB_BASE_URL": "https://my.construct.hub",
             "PACKAGE_CANARY_BUCKET_NAME": Object {
               "Ref": "ConstructHubSourcesNpmJsStagingBucketB286F0E6",
@@ -38060,6 +38064,18 @@ Object {
       "Description": "S3 key for asset version \\"19cb1b080f1300d1f3cd407d29651076d8668e49a0bd8e54f95490f8e9081e03\\"",
       "Type": "String",
     },
+    "AssetParameters1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaedArtifactHash933B5E30": Object {
+      "Description": "Artifact hash for asset \\"1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaed\\"",
+      "Type": "String",
+    },
+    "AssetParameters1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaedS3BucketBD3E9BD7": Object {
+      "Description": "S3 bucket for asset \\"1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaed\\"",
+      "Type": "String",
+    },
+    "AssetParameters1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaedS3VersionKey87A963BD": Object {
+      "Description": "S3 key for asset version \\"1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaed\\"",
+      "Type": "String",
+    },
     "AssetParameters2014f4c1d30de902409ad3965bb488173ce030f76ee67fdcd0fae846487499cbArtifactHash76F4E4A1": Object {
       "Description": "Artifact hash for asset \\"2014f4c1d30de902409ad3965bb488173ce030f76ee67fdcd0fae846487499cb\\"",
       "Type": "String",
@@ -38118,18 +38134,6 @@ Object {
     },
     "AssetParameters4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbcS3VersionKey547E84F8": Object {
       "Description": "S3 key for asset version \\"4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbc\\"",
-      "Type": "String",
-    },
-    "AssetParameters40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46acArtifactHash1AFACE75": Object {
-      "Description": "Artifact hash for asset \\"40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46ac\\"",
-      "Type": "String",
-    },
-    "AssetParameters40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46acS3Bucket2674B809": Object {
-      "Description": "S3 bucket for asset \\"40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46ac\\"",
-      "Type": "String",
-    },
-    "AssetParameters40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46acS3VersionKeyD2C3153D": Object {
-      "Description": "S3 key for asset version \\"40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46ac\\"",
       "Type": "String",
     },
     "AssetParameters7412ee3c3ed97354b11100cb1f73e96631635318730a2733203b58c986337b81ArtifactHashF2C7E53A": Object {
@@ -44621,7 +44625,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46acS3Bucket2674B809",
+            "Ref": "AssetParameters1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaedS3BucketBD3E9BD7",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -44634,7 +44638,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46acS3VersionKeyD2C3153D",
+                          "Ref": "AssetParameters1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaedS3VersionKey87A963BD",
                         },
                       ],
                     },
@@ -44647,7 +44651,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46acS3VersionKeyD2C3153D",
+                          "Ref": "AssetParameters1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaedS3VersionKey87A963BD",
                         },
                       ],
                     },
@@ -44660,6 +44664,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {
           "Variables": Object {
+            "AWS_EMF_ENVIRONMENT": "Local",
             "CONSTRUCT_HUB_BASE_URL": Object {
               "Fn::Join": Array [
                 "",

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -4942,7 +4942,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46acS3Bucket2674B809
+          Ref: AssetParameters1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaedS3BucketBD3E9BD7
         S3Key:
           Fn::Join:
             - ""
@@ -4950,12 +4950,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46acS3VersionKeyD2C3153D
+                      - Ref: AssetParameters1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaedS3VersionKey87A963BD
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46acS3VersionKeyD2C3153D
+                      - Ref: AssetParameters1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaedS3VersionKey87A963BD
       Role:
         Fn::GetAtt:
           - ConstructHubSourcesNpmJsCanaryServiceRoleC4CBCDA2
@@ -4964,6 +4964,7 @@ Resources:
         construct-hub-probe versions availability"
       Environment:
         Variables:
+          AWS_EMF_ENVIRONMENT: Local
           CONSTRUCT_HUB_BASE_URL:
             Fn::Join:
               - ""
@@ -6670,18 +6671,18 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "84199d8e6584a01a6a7bf1887a95373133eb9154bbc07f2e5ec0fc4268f1f2fb"
-  AssetParameters40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46acS3Bucket2674B809:
+  AssetParameters1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaedS3BucketBD3E9BD7:
     Type: String
     Description: S3 bucket for asset
-      "40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46ac"
-  AssetParameters40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46acS3VersionKeyD2C3153D:
+      "1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaed"
+  AssetParameters1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaedS3VersionKey87A963BD:
     Type: String
     Description: S3 key for asset version
-      "40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46ac"
-  AssetParameters40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46acArtifactHash1AFACE75:
+      "1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaed"
+  AssetParameters1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaedArtifactHash933B5E30:
     Type: String
     Description: Artifact hash for asset
-      "40dc54f32b7c1533a54f3fe1f5678eec5f4169a63a780184895a8744a6cb46ac"
+      "1ce2513b0d1c3a87a77ba8c0b884afd715f29c90bc7a54cd3fac65db7edbcaed"
   AssetParameters2014f4c1d30de902409ad3965bb488173ce030f76ee67fdcd0fae846487499cbS3BucketBDAE1430:
     Type: String
     Description: S3 bucket for asset

--- a/src/package-sources/npmjs/canary/index.ts
+++ b/src/package-sources/npmjs/canary/index.ts
@@ -21,6 +21,7 @@ export class NpmJsPackageCanary extends Construct {
       architecture: gravitonLambdaIfAvailable(this),
       description: `[${scope.node.path}/PackageCanary] Monitors ${props.packageName} versions availability`,
       environment: {
+        AWS_EMF_ENVIRONMENT: 'Local',
         [Environment.CONSTRUCT_HUB_BASE_URL]: props.constructHubBaseUrl,
         [Environment.PACKAGE_CANARY_BUCKET_NAME]: props.bucket.bucketName,
         [Environment.PACKAGE_NAME]: props.packageName,


### PR DESCRIPTION
The `.end()` call is necessary when using `https.request()`, but was
missing, which eventually resulted in the connection being aborted by
the service or firewall, which triggered an un-caught `ECONNRESET`
error.

This caused the `node` VM to abort, and ultimately prevented the updated
state object to be written to S3 in the `finally` clause.

---

Note - the `https.get` method (used in `getJSON`) does NOT need `.end()`
to be called, as that particular method does not allow a request payload
to be written.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*