### PR TITLE
chore: add bucket versioning to configuration bucket

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -1712,6 +1712,9 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "IgnorePublicAcls": true,
           "RestrictPublicBuckets": true,
         },
+        "VersioningConfiguration": Object {
+          "Status": "Enabled",
+        },
       },
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Retain",
@@ -11294,6 +11297,9 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "IgnorePublicAcls": true,
           "RestrictPublicBuckets": true,
         },
+        "VersioningConfiguration": Object {
+          "Status": "Enabled",
+        },
       },
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Retain",
@@ -20709,6 +20715,9 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "BlockPublicPolicy": true,
           "IgnorePublicAcls": true,
           "RestrictPublicBuckets": true,
+        },
+        "VersioningConfiguration": Object {
+          "Status": "Enabled",
         },
       },
       "Type": "AWS::S3::Bucket",
@@ -30155,6 +30164,9 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "BlockPublicPolicy": true,
           "IgnorePublicAcls": true,
           "RestrictPublicBuckets": true,
+        },
+        "VersioningConfiguration": Object {
+          "Status": "Enabled",
         },
       },
       "Type": "AWS::S3::Bucket",
@@ -39827,6 +39839,9 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "BlockPublicPolicy": true,
           "IgnorePublicAcls": true,
           "RestrictPublicBuckets": true,
+        },
+        "VersioningConfiguration": Object {
+          "Status": "Enabled",
         },
       },
       "Type": "AWS::S3::Bucket",

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -3417,6 +3417,8 @@ Resources:
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
+      VersioningConfiguration:
+        Status: Enabled
     UpdateReplacePolicy: Retain
     DeletionPolicy: Retain
   ConstructHubIngestionConfigBucketPolicyF096914C:

--- a/src/backend/ingestion/index.ts
+++ b/src/backend/ingestion/index.ts
@@ -118,6 +118,7 @@ export class Ingestion extends Construct implements IGrantable {
     const configBucket = new Bucket(this, 'ConfigBucket', {
       blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
       enforceSSL: true,
+      versioned: true,
     });
 
     new BucketDeployment(this, 'DeployIngestionConfiguration', {


### PR DESCRIPTION
Adding bucket versioning to this makes it easier to debug when the configuration was updated / determining how long some package tag has been in effect etc.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*