### PR TITLE
chore: add new licenses to the default allow-list

### DIFF
--- a/.projenrc.js
+++ b/.projenrc.js
@@ -770,11 +770,47 @@ function generateSpdxLicenseEnum() {
   ts.close('}');
 
   ts.line();
+  ts.line('/** The CDDL family of licenses */');
+  ts.open('public static cddl(): SpdxLicense[] {');
+  ts.open('return [');
+  for (const id of Object.keys(spdx)) {
+    if (id.startsWith('CDDL-')) {
+      ts.line(`SpdxLicense.${slugify(id)},`);
+    }
+  }
+  ts.close('];');
+  ts.close('}');
+
+  ts.line();
+  ts.line('/** The EPL family of licenses */');
+  ts.open('public static epl(): SpdxLicense[] {');
+  ts.open('return [');
+  for (const id of Object.keys(spdx)) {
+    if (id.startsWith('EPL-')) {
+      ts.line(`SpdxLicense.${slugify(id)},`);
+    }
+  }
+  ts.close('];');
+  ts.close('}');
+
+  ts.line();
   ts.line('/** The MIT family of licenses */');
   ts.open('public static mit(): SpdxLicense[] {');
   ts.open('return [');
   for (const id of Object.keys(spdx)) {
     if (id === 'AML' || id === 'MIT' || id === 'MITNFA' || id.startsWith('MIT-')) {
+      ts.line(`SpdxLicense.${slugify(id)},`);
+    }
+  }
+  ts.close('];');
+  ts.close('}');
+
+  ts.line();
+  ts.line('/** The MPL family of licenses */');
+  ts.open('public static mpl(): SpdxLicense[] {');
+  ts.open('return [');
+  for (const id of Object.keys(spdx)) {
+    if (id.startsWith('MPL-')) {
       ts.line(`SpdxLicense.${slugify(id)},`);
     }
   }

--- a/API.md
+++ b/API.md
@@ -208,7 +208,7 @@ public readonly allowedLicenses: SpdxLicense[];
 ```
 
 - *Type:* [`construct-hub.SpdxLicense`](#construct-hub.SpdxLicense)[]
-- *Default:* [...SpdxLicense.apache(),...SpdxLicense.bsd(),...SpdxLicense.mit()]
+- *Default:* [...SpdxLicense.apache(),...SpdxLicense.bsd(),...SpdxLicense.cddl(),...SpdxLicense.epl(),SpdxLicense.ISC,...SpdxLicense.mit(),...SpdxLicense.mpl()]
 
 The allowed licenses for packages indexed by this instance of ConstructHub.
 
@@ -1345,12 +1345,36 @@ import { SpdxLicense } from 'construct-hub'
 SpdxLicense.bsd()
 ```
 
+##### `cddl` <a name="construct-hub.SpdxLicense.cddl"></a>
+
+```typescript
+import { SpdxLicense } from 'construct-hub'
+
+SpdxLicense.cddl()
+```
+
+##### `epl` <a name="construct-hub.SpdxLicense.epl"></a>
+
+```typescript
+import { SpdxLicense } from 'construct-hub'
+
+SpdxLicense.epl()
+```
+
 ##### `mit` <a name="construct-hub.SpdxLicense.mit"></a>
 
 ```typescript
 import { SpdxLicense } from 'construct-hub'
 
 SpdxLicense.mit()
+```
+
+##### `mpl` <a name="construct-hub.SpdxLicense.mpl"></a>
+
+```typescript
+import { SpdxLicense } from 'construct-hub'
+
+SpdxLicense.mpl()
 ```
 
 ##### `osiApproved` <a name="construct-hub.SpdxLicense.osiApproved"></a>

--- a/API.md
+++ b/API.md
@@ -208,7 +208,7 @@ public readonly allowedLicenses: SpdxLicense[];
 ```
 
 - *Type:* [`construct-hub.SpdxLicense`](#construct-hub.SpdxLicense)[]
-- *Default:* [...SpdxLicense.apache(),...SpdxLicense.bsd(),...SpdxLicense.cddl(),...SpdxLicense.epl(),SpdxLicense.ISC,...SpdxLicense.mit(),...SpdxLicense.mpl()]
+- *Default:* [...SpdxLicense.apache(),...SpdxLicense.bsd(),...SpdxLicense.cddl(),...SpdxLicense.epl(),SpdxLicense.ISC,...SpdxLicense.mit(),SpdxLicense.MPL_2_0]
 
 The allowed licenses for packages indexed by this instance of ConstructHub.
 

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -129,18 +129,6 @@ Object {
       "Description": "S3 key for asset version \\"7412ee3c3ed97354b11100cb1f73e96631635318730a2733203b58c986337b81\\"",
       "Type": "String",
     },
-    "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292ArtifactHash5EAA9945": Object {
-      "Description": "Artifact hash for asset \\"7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292\\"",
-      "Type": "String",
-    },
-    "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2": Object {
-      "Description": "S3 bucket for asset \\"7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292\\"",
-      "Type": "String",
-    },
-    "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3VersionKey252F23A8": Object {
-      "Description": "S3 key for asset version \\"7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292\\"",
-      "Type": "String",
-    },
     "AssetParameters84199d8e6584a01a6a7bf1887a95373133eb9154bbc07f2e5ec0fc4268f1f2fbArtifactHash27057DB9": Object {
       "Description": "Artifact hash for asset \\"84199d8e6584a01a6a7bf1887a95373133eb9154bbc07f2e5ec0fc4268f1f2fb\\"",
       "Type": "String",
@@ -151,6 +139,18 @@ Object {
     },
     "AssetParameters84199d8e6584a01a6a7bf1887a95373133eb9154bbc07f2e5ec0fc4268f1f2fbS3VersionKey6238C82F": Object {
       "Description": "S3 key for asset version \\"84199d8e6584a01a6a7bf1887a95373133eb9154bbc07f2e5ec0fc4268f1f2fb\\"",
+      "Type": "String",
+    },
+    "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900ArtifactHash121EF458": Object {
+      "Description": "Artifact hash for asset \\"8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900\\"",
+      "Type": "String",
+    },
+    "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3BucketB2DE6865": Object {
+      "Description": "S3 bucket for asset \\"8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900\\"",
+      "Type": "String",
+    },
+    "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3VersionKeyD40FAA20": Object {
+      "Description": "S3 key for asset version \\"8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900\\"",
       "Type": "String",
     },
     "AssetParameters8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064ArtifactHashEA963870": Object {
@@ -3172,7 +3172,7 @@ Direct link to function: /lambda/home#/functions/",
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2",
+            "Ref": "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3BucketB2DE6865",
           },
         ],
         "SourceObjectKeys": Array [
@@ -3187,7 +3187,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3VersionKey252F23A8",
+                          "Ref": "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3VersionKeyD40FAA20",
                         },
                       ],
                     },
@@ -3200,7 +3200,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3VersionKey252F23A8",
+                          "Ref": "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3VersionKeyD40FAA20",
                         },
                       ],
                     },
@@ -8804,7 +8804,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2",
+                        "Ref": "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3BucketB2DE6865",
                       },
                     ],
                   ],
@@ -8819,7 +8819,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2",
+                        "Ref": "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3BucketB2DE6865",
                       },
                       "/*",
                     ],
@@ -9404,18 +9404,6 @@ Object {
       "Description": "S3 key for asset version \\"7412ee3c3ed97354b11100cb1f73e96631635318730a2733203b58c986337b81\\"",
       "Type": "String",
     },
-    "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292ArtifactHash5EAA9945": Object {
-      "Description": "Artifact hash for asset \\"7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292\\"",
-      "Type": "String",
-    },
-    "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2": Object {
-      "Description": "S3 bucket for asset \\"7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292\\"",
-      "Type": "String",
-    },
-    "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3VersionKey252F23A8": Object {
-      "Description": "S3 key for asset version \\"7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292\\"",
-      "Type": "String",
-    },
     "AssetParameters84199d8e6584a01a6a7bf1887a95373133eb9154bbc07f2e5ec0fc4268f1f2fbArtifactHash27057DB9": Object {
       "Description": "Artifact hash for asset \\"84199d8e6584a01a6a7bf1887a95373133eb9154bbc07f2e5ec0fc4268f1f2fb\\"",
       "Type": "String",
@@ -9426,6 +9414,18 @@ Object {
     },
     "AssetParameters84199d8e6584a01a6a7bf1887a95373133eb9154bbc07f2e5ec0fc4268f1f2fbS3VersionKey6238C82F": Object {
       "Description": "S3 key for asset version \\"84199d8e6584a01a6a7bf1887a95373133eb9154bbc07f2e5ec0fc4268f1f2fb\\"",
+      "Type": "String",
+    },
+    "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900ArtifactHash121EF458": Object {
+      "Description": "Artifact hash for asset \\"8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900\\"",
+      "Type": "String",
+    },
+    "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3BucketB2DE6865": Object {
+      "Description": "S3 bucket for asset \\"8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900\\"",
+      "Type": "String",
+    },
+    "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3VersionKeyD40FAA20": Object {
+      "Description": "S3 key for asset version \\"8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900\\"",
       "Type": "String",
     },
     "AssetParameters8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064ArtifactHashEA963870": Object {
@@ -12834,7 +12834,7 @@ Direct link to function: /lambda/home#/functions/",
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2",
+            "Ref": "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3BucketB2DE6865",
           },
         ],
         "SourceObjectKeys": Array [
@@ -12849,7 +12849,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3VersionKey252F23A8",
+                          "Ref": "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3VersionKeyD40FAA20",
                         },
                       ],
                     },
@@ -12862,7 +12862,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3VersionKey252F23A8",
+                          "Ref": "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3VersionKeyD40FAA20",
                         },
                       ],
                     },
@@ -18539,7 +18539,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2",
+                        "Ref": "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3BucketB2DE6865",
                       },
                     ],
                   ],
@@ -18554,7 +18554,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2",
+                        "Ref": "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3BucketB2DE6865",
                       },
                       "/*",
                     ],
@@ -19127,18 +19127,6 @@ Object {
       "Description": "S3 key for asset version \\"7412ee3c3ed97354b11100cb1f73e96631635318730a2733203b58c986337b81\\"",
       "Type": "String",
     },
-    "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292ArtifactHash5EAA9945": Object {
-      "Description": "Artifact hash for asset \\"7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292\\"",
-      "Type": "String",
-    },
-    "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2": Object {
-      "Description": "S3 bucket for asset \\"7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292\\"",
-      "Type": "String",
-    },
-    "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3VersionKey252F23A8": Object {
-      "Description": "S3 key for asset version \\"7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292\\"",
-      "Type": "String",
-    },
     "AssetParameters84199d8e6584a01a6a7bf1887a95373133eb9154bbc07f2e5ec0fc4268f1f2fbArtifactHash27057DB9": Object {
       "Description": "Artifact hash for asset \\"84199d8e6584a01a6a7bf1887a95373133eb9154bbc07f2e5ec0fc4268f1f2fb\\"",
       "Type": "String",
@@ -19149,6 +19137,18 @@ Object {
     },
     "AssetParameters84199d8e6584a01a6a7bf1887a95373133eb9154bbc07f2e5ec0fc4268f1f2fbS3VersionKey6238C82F": Object {
       "Description": "S3 key for asset version \\"84199d8e6584a01a6a7bf1887a95373133eb9154bbc07f2e5ec0fc4268f1f2fb\\"",
+      "Type": "String",
+    },
+    "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900ArtifactHash121EF458": Object {
+      "Description": "Artifact hash for asset \\"8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900\\"",
+      "Type": "String",
+    },
+    "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3BucketB2DE6865": Object {
+      "Description": "S3 bucket for asset \\"8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900\\"",
+      "Type": "String",
+    },
+    "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3VersionKeyD40FAA20": Object {
+      "Description": "S3 key for asset version \\"8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900\\"",
       "Type": "String",
     },
     "AssetParameters8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064ArtifactHashEA963870": Object {
@@ -22170,7 +22170,7 @@ Direct link to function: /lambda/home#/functions/",
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2",
+            "Ref": "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3BucketB2DE6865",
           },
         ],
         "SourceObjectKeys": Array [
@@ -22185,7 +22185,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3VersionKey252F23A8",
+                          "Ref": "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3VersionKeyD40FAA20",
                         },
                       ],
                     },
@@ -22198,7 +22198,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3VersionKey252F23A8",
+                          "Ref": "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3VersionKeyD40FAA20",
                         },
                       ],
                     },
@@ -27802,7 +27802,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2",
+                        "Ref": "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3BucketB2DE6865",
                       },
                     ],
                   ],
@@ -27817,7 +27817,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2",
+                        "Ref": "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3BucketB2DE6865",
                       },
                       "/*",
                     ],
@@ -28424,18 +28424,6 @@ Object {
       "Description": "S3 key for asset version \\"7af6295e521fd55af94332393ceffb3e866aac4dc4956321f7918f21e72199e4\\"",
       "Type": "String",
     },
-    "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292ArtifactHash5EAA9945": Object {
-      "Description": "Artifact hash for asset \\"7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292\\"",
-      "Type": "String",
-    },
-    "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2": Object {
-      "Description": "S3 bucket for asset \\"7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292\\"",
-      "Type": "String",
-    },
-    "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3VersionKey252F23A8": Object {
-      "Description": "S3 key for asset version \\"7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292\\"",
-      "Type": "String",
-    },
     "AssetParameters84199d8e6584a01a6a7bf1887a95373133eb9154bbc07f2e5ec0fc4268f1f2fbArtifactHash27057DB9": Object {
       "Description": "Artifact hash for asset \\"84199d8e6584a01a6a7bf1887a95373133eb9154bbc07f2e5ec0fc4268f1f2fb\\"",
       "Type": "String",
@@ -28446,6 +28434,18 @@ Object {
     },
     "AssetParameters84199d8e6584a01a6a7bf1887a95373133eb9154bbc07f2e5ec0fc4268f1f2fbS3VersionKey6238C82F": Object {
       "Description": "S3 key for asset version \\"84199d8e6584a01a6a7bf1887a95373133eb9154bbc07f2e5ec0fc4268f1f2fb\\"",
+      "Type": "String",
+    },
+    "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900ArtifactHash121EF458": Object {
+      "Description": "Artifact hash for asset \\"8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900\\"",
+      "Type": "String",
+    },
+    "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3BucketB2DE6865": Object {
+      "Description": "S3 bucket for asset \\"8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900\\"",
+      "Type": "String",
+    },
+    "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3VersionKeyD40FAA20": Object {
+      "Description": "S3 key for asset version \\"8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900\\"",
       "Type": "String",
     },
     "AssetParameters8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064ArtifactHashEA963870": Object {
@@ -31616,7 +31616,7 @@ Direct link to function: /lambda/home#/functions/",
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2",
+            "Ref": "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3BucketB2DE6865",
           },
         ],
         "SourceObjectKeys": Array [
@@ -31631,7 +31631,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3VersionKey252F23A8",
+                          "Ref": "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3VersionKeyD40FAA20",
                         },
                       ],
                     },
@@ -31644,7 +31644,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3VersionKey252F23A8",
+                          "Ref": "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3VersionKeyD40FAA20",
                         },
                       ],
                     },
@@ -37536,7 +37536,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2",
+                        "Ref": "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3BucketB2DE6865",
                       },
                     ],
                   ],
@@ -37551,7 +37551,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2",
+                        "Ref": "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3BucketB2DE6865",
                       },
                       "/*",
                     ],
@@ -38136,18 +38136,6 @@ Object {
       "Description": "S3 key for asset version \\"7412ee3c3ed97354b11100cb1f73e96631635318730a2733203b58c986337b81\\"",
       "Type": "String",
     },
-    "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292ArtifactHash5EAA9945": Object {
-      "Description": "Artifact hash for asset \\"7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292\\"",
-      "Type": "String",
-    },
-    "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2": Object {
-      "Description": "S3 bucket for asset \\"7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292\\"",
-      "Type": "String",
-    },
-    "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3VersionKey252F23A8": Object {
-      "Description": "S3 key for asset version \\"7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292\\"",
-      "Type": "String",
-    },
     "AssetParameters84199d8e6584a01a6a7bf1887a95373133eb9154bbc07f2e5ec0fc4268f1f2fbArtifactHash27057DB9": Object {
       "Description": "Artifact hash for asset \\"84199d8e6584a01a6a7bf1887a95373133eb9154bbc07f2e5ec0fc4268f1f2fb\\"",
       "Type": "String",
@@ -38158,6 +38146,18 @@ Object {
     },
     "AssetParameters84199d8e6584a01a6a7bf1887a95373133eb9154bbc07f2e5ec0fc4268f1f2fbS3VersionKey6238C82F": Object {
       "Description": "S3 key for asset version \\"84199d8e6584a01a6a7bf1887a95373133eb9154bbc07f2e5ec0fc4268f1f2fb\\"",
+      "Type": "String",
+    },
+    "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900ArtifactHash121EF458": Object {
+      "Description": "Artifact hash for asset \\"8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900\\"",
+      "Type": "String",
+    },
+    "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3BucketB2DE6865": Object {
+      "Description": "S3 bucket for asset \\"8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900\\"",
+      "Type": "String",
+    },
+    "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3VersionKeyD40FAA20": Object {
+      "Description": "S3 key for asset version \\"8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900\\"",
       "Type": "String",
     },
     "AssetParameters8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064ArtifactHashEA963870": Object {
@@ -41414,7 +41414,7 @@ Direct link to function: /lambda/home#/functions/",
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2",
+            "Ref": "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3BucketB2DE6865",
           },
         ],
         "SourceObjectKeys": Array [
@@ -41429,7 +41429,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3VersionKey252F23A8",
+                          "Ref": "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3VersionKeyD40FAA20",
                         },
                       ],
                     },
@@ -41442,7 +41442,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3VersionKey252F23A8",
+                          "Ref": "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3VersionKeyD40FAA20",
                         },
                       ],
                     },
@@ -48608,7 +48608,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2",
+                        "Ref": "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3BucketB2DE6865",
                       },
                     ],
                   ],
@@ -48623,7 +48623,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2",
+                        "Ref": "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3BucketB2DE6865",
                       },
                       "/*",
                     ],

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -93,18 +93,6 @@ Object {
       "Description": "S3 key for asset version \\"2014f4c1d30de902409ad3965bb488173ce030f76ee67fdcd0fae846487499cb\\"",
       "Type": "String",
     },
-    "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658ArtifactHashA026490C": Object {
-      "Description": "Artifact hash for asset \\"2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658\\"",
-      "Type": "String",
-    },
-    "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3BucketF36A877E": Object {
-      "Description": "S3 bucket for asset \\"2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658\\"",
-      "Type": "String",
-    },
-    "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3VersionKeyF7596361": Object {
-      "Description": "S3 key for asset version \\"2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658\\"",
-      "Type": "String",
-    },
     "AssetParameters34077b3b7b0d34c15f8604e9e9a7ca2f3f74e0593b4dc3ed61da46044e23ea1fArtifactHash940BDAA3": Object {
       "Description": "Artifact hash for asset \\"34077b3b7b0d34c15f8604e9e9a7ca2f3f74e0593b4dc3ed61da46044e23ea1f\\"",
       "Type": "String",
@@ -139,6 +127,18 @@ Object {
     },
     "AssetParameters7412ee3c3ed97354b11100cb1f73e96631635318730a2733203b58c986337b81S3VersionKeyF938270D": Object {
       "Description": "S3 key for asset version \\"7412ee3c3ed97354b11100cb1f73e96631635318730a2733203b58c986337b81\\"",
+      "Type": "String",
+    },
+    "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292ArtifactHash5EAA9945": Object {
+      "Description": "Artifact hash for asset \\"7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292\\"",
+      "Type": "String",
+    },
+    "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2": Object {
+      "Description": "S3 bucket for asset \\"7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292\\"",
+      "Type": "String",
+    },
+    "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3VersionKey252F23A8": Object {
+      "Description": "S3 key for asset version \\"7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292\\"",
       "Type": "String",
     },
     "AssetParameters84199d8e6584a01a6a7bf1887a95373133eb9154bbc07f2e5ec0fc4268f1f2fbArtifactHash27057DB9": Object {
@@ -3172,7 +3172,7 @@ Direct link to function: /lambda/home#/functions/",
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3BucketF36A877E",
+            "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2",
           },
         ],
         "SourceObjectKeys": Array [
@@ -3187,7 +3187,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3VersionKeyF7596361",
+                          "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3VersionKey252F23A8",
                         },
                       ],
                     },
@@ -3200,7 +3200,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3VersionKeyF7596361",
+                          "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3VersionKey252F23A8",
                         },
                       ],
                     },
@@ -8804,7 +8804,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3BucketF36A877E",
+                        "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2",
                       },
                     ],
                   ],
@@ -8819,7 +8819,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3BucketF36A877E",
+                        "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2",
                       },
                       "/*",
                     ],
@@ -9356,18 +9356,6 @@ Object {
       "Description": "S3 key for asset version \\"2014f4c1d30de902409ad3965bb488173ce030f76ee67fdcd0fae846487499cb\\"",
       "Type": "String",
     },
-    "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658ArtifactHashA026490C": Object {
-      "Description": "Artifact hash for asset \\"2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658\\"",
-      "Type": "String",
-    },
-    "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3BucketF36A877E": Object {
-      "Description": "S3 bucket for asset \\"2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658\\"",
-      "Type": "String",
-    },
-    "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3VersionKeyF7596361": Object {
-      "Description": "S3 key for asset version \\"2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658\\"",
-      "Type": "String",
-    },
     "AssetParameters34077b3b7b0d34c15f8604e9e9a7ca2f3f74e0593b4dc3ed61da46044e23ea1fArtifactHash940BDAA3": Object {
       "Description": "Artifact hash for asset \\"34077b3b7b0d34c15f8604e9e9a7ca2f3f74e0593b4dc3ed61da46044e23ea1f\\"",
       "Type": "String",
@@ -9414,6 +9402,18 @@ Object {
     },
     "AssetParameters7412ee3c3ed97354b11100cb1f73e96631635318730a2733203b58c986337b81S3VersionKeyF938270D": Object {
       "Description": "S3 key for asset version \\"7412ee3c3ed97354b11100cb1f73e96631635318730a2733203b58c986337b81\\"",
+      "Type": "String",
+    },
+    "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292ArtifactHash5EAA9945": Object {
+      "Description": "Artifact hash for asset \\"7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292\\"",
+      "Type": "String",
+    },
+    "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2": Object {
+      "Description": "S3 bucket for asset \\"7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292\\"",
+      "Type": "String",
+    },
+    "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3VersionKey252F23A8": Object {
+      "Description": "S3 key for asset version \\"7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292\\"",
       "Type": "String",
     },
     "AssetParameters84199d8e6584a01a6a7bf1887a95373133eb9154bbc07f2e5ec0fc4268f1f2fbArtifactHash27057DB9": Object {
@@ -12834,7 +12834,7 @@ Direct link to function: /lambda/home#/functions/",
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3BucketF36A877E",
+            "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2",
           },
         ],
         "SourceObjectKeys": Array [
@@ -12849,7 +12849,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3VersionKeyF7596361",
+                          "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3VersionKey252F23A8",
                         },
                       ],
                     },
@@ -12862,7 +12862,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3VersionKeyF7596361",
+                          "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3VersionKey252F23A8",
                         },
                       ],
                     },
@@ -18539,7 +18539,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3BucketF36A877E",
+                        "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2",
                       },
                     ],
                   ],
@@ -18554,7 +18554,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3BucketF36A877E",
+                        "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2",
                       },
                       "/*",
                     ],
@@ -19091,18 +19091,6 @@ Object {
       "Description": "S3 key for asset version \\"2014f4c1d30de902409ad3965bb488173ce030f76ee67fdcd0fae846487499cb\\"",
       "Type": "String",
     },
-    "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658ArtifactHashA026490C": Object {
-      "Description": "Artifact hash for asset \\"2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658\\"",
-      "Type": "String",
-    },
-    "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3BucketF36A877E": Object {
-      "Description": "S3 bucket for asset \\"2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658\\"",
-      "Type": "String",
-    },
-    "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3VersionKeyF7596361": Object {
-      "Description": "S3 key for asset version \\"2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658\\"",
-      "Type": "String",
-    },
     "AssetParameters34077b3b7b0d34c15f8604e9e9a7ca2f3f74e0593b4dc3ed61da46044e23ea1fArtifactHash940BDAA3": Object {
       "Description": "Artifact hash for asset \\"34077b3b7b0d34c15f8604e9e9a7ca2f3f74e0593b4dc3ed61da46044e23ea1f\\"",
       "Type": "String",
@@ -19137,6 +19125,18 @@ Object {
     },
     "AssetParameters7412ee3c3ed97354b11100cb1f73e96631635318730a2733203b58c986337b81S3VersionKeyF938270D": Object {
       "Description": "S3 key for asset version \\"7412ee3c3ed97354b11100cb1f73e96631635318730a2733203b58c986337b81\\"",
+      "Type": "String",
+    },
+    "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292ArtifactHash5EAA9945": Object {
+      "Description": "Artifact hash for asset \\"7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292\\"",
+      "Type": "String",
+    },
+    "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2": Object {
+      "Description": "S3 bucket for asset \\"7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292\\"",
+      "Type": "String",
+    },
+    "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3VersionKey252F23A8": Object {
+      "Description": "S3 key for asset version \\"7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292\\"",
       "Type": "String",
     },
     "AssetParameters84199d8e6584a01a6a7bf1887a95373133eb9154bbc07f2e5ec0fc4268f1f2fbArtifactHash27057DB9": Object {
@@ -22170,7 +22170,7 @@ Direct link to function: /lambda/home#/functions/",
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3BucketF36A877E",
+            "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2",
           },
         ],
         "SourceObjectKeys": Array [
@@ -22185,7 +22185,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3VersionKeyF7596361",
+                          "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3VersionKey252F23A8",
                         },
                       ],
                     },
@@ -22198,7 +22198,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3VersionKeyF7596361",
+                          "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3VersionKey252F23A8",
                         },
                       ],
                     },
@@ -27802,7 +27802,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3BucketF36A877E",
+                        "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2",
                       },
                     ],
                   ],
@@ -27817,7 +27817,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3BucketF36A877E",
+                        "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2",
                       },
                       "/*",
                     ],
@@ -28364,18 +28364,6 @@ Object {
       "Description": "S3 key for asset version \\"2014f4c1d30de902409ad3965bb488173ce030f76ee67fdcd0fae846487499cb\\"",
       "Type": "String",
     },
-    "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658ArtifactHashA026490C": Object {
-      "Description": "Artifact hash for asset \\"2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658\\"",
-      "Type": "String",
-    },
-    "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3BucketF36A877E": Object {
-      "Description": "S3 bucket for asset \\"2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658\\"",
-      "Type": "String",
-    },
-    "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3VersionKeyF7596361": Object {
-      "Description": "S3 key for asset version \\"2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658\\"",
-      "Type": "String",
-    },
     "AssetParameters34077b3b7b0d34c15f8604e9e9a7ca2f3f74e0593b4dc3ed61da46044e23ea1fArtifactHash940BDAA3": Object {
       "Description": "Artifact hash for asset \\"34077b3b7b0d34c15f8604e9e9a7ca2f3f74e0593b4dc3ed61da46044e23ea1f\\"",
       "Type": "String",
@@ -28434,6 +28422,18 @@ Object {
     },
     "AssetParameters7af6295e521fd55af94332393ceffb3e866aac4dc4956321f7918f21e72199e4S3VersionKey326451BC": Object {
       "Description": "S3 key for asset version \\"7af6295e521fd55af94332393ceffb3e866aac4dc4956321f7918f21e72199e4\\"",
+      "Type": "String",
+    },
+    "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292ArtifactHash5EAA9945": Object {
+      "Description": "Artifact hash for asset \\"7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292\\"",
+      "Type": "String",
+    },
+    "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2": Object {
+      "Description": "S3 bucket for asset \\"7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292\\"",
+      "Type": "String",
+    },
+    "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3VersionKey252F23A8": Object {
+      "Description": "S3 key for asset version \\"7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292\\"",
       "Type": "String",
     },
     "AssetParameters84199d8e6584a01a6a7bf1887a95373133eb9154bbc07f2e5ec0fc4268f1f2fbArtifactHash27057DB9": Object {
@@ -31616,7 +31616,7 @@ Direct link to function: /lambda/home#/functions/",
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3BucketF36A877E",
+            "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2",
           },
         ],
         "SourceObjectKeys": Array [
@@ -31631,7 +31631,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3VersionKeyF7596361",
+                          "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3VersionKey252F23A8",
                         },
                       ],
                     },
@@ -31644,7 +31644,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3VersionKeyF7596361",
+                          "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3VersionKey252F23A8",
                         },
                       ],
                     },
@@ -37536,7 +37536,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3BucketF36A877E",
+                        "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2",
                       },
                     ],
                   ],
@@ -37551,7 +37551,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3BucketF36A877E",
+                        "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2",
                       },
                       "/*",
                     ],
@@ -38088,18 +38088,6 @@ Object {
       "Description": "S3 key for asset version \\"2014f4c1d30de902409ad3965bb488173ce030f76ee67fdcd0fae846487499cb\\"",
       "Type": "String",
     },
-    "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658ArtifactHashA026490C": Object {
-      "Description": "Artifact hash for asset \\"2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658\\"",
-      "Type": "String",
-    },
-    "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3BucketF36A877E": Object {
-      "Description": "S3 bucket for asset \\"2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658\\"",
-      "Type": "String",
-    },
-    "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3VersionKeyF7596361": Object {
-      "Description": "S3 key for asset version \\"2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658\\"",
-      "Type": "String",
-    },
     "AssetParameters34077b3b7b0d34c15f8604e9e9a7ca2f3f74e0593b4dc3ed61da46044e23ea1fArtifactHash940BDAA3": Object {
       "Description": "Artifact hash for asset \\"34077b3b7b0d34c15f8604e9e9a7ca2f3f74e0593b4dc3ed61da46044e23ea1f\\"",
       "Type": "String",
@@ -38146,6 +38134,18 @@ Object {
     },
     "AssetParameters7412ee3c3ed97354b11100cb1f73e96631635318730a2733203b58c986337b81S3VersionKeyF938270D": Object {
       "Description": "S3 key for asset version \\"7412ee3c3ed97354b11100cb1f73e96631635318730a2733203b58c986337b81\\"",
+      "Type": "String",
+    },
+    "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292ArtifactHash5EAA9945": Object {
+      "Description": "Artifact hash for asset \\"7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292\\"",
+      "Type": "String",
+    },
+    "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2": Object {
+      "Description": "S3 bucket for asset \\"7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292\\"",
+      "Type": "String",
+    },
+    "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3VersionKey252F23A8": Object {
+      "Description": "S3 key for asset version \\"7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292\\"",
       "Type": "String",
     },
     "AssetParameters84199d8e6584a01a6a7bf1887a95373133eb9154bbc07f2e5ec0fc4268f1f2fbArtifactHash27057DB9": Object {
@@ -41414,7 +41414,7 @@ Direct link to function: /lambda/home#/functions/",
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3BucketF36A877E",
+            "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2",
           },
         ],
         "SourceObjectKeys": Array [
@@ -41429,7 +41429,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3VersionKeyF7596361",
+                          "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3VersionKey252F23A8",
                         },
                       ],
                     },
@@ -41442,7 +41442,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3VersionKeyF7596361",
+                          "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3VersionKey252F23A8",
                         },
                       ],
                     },
@@ -48608,7 +48608,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3BucketF36A877E",
+                        "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2",
                       },
                     ],
                   ],
@@ -48623,7 +48623,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3BucketF36A877E",
+                        "Ref": "AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2",
                       },
                       "/*",
                     ],

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -4166,7 +4166,7 @@ Resources:
           - CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536
           - Arn
       SourceBucketNames:
-        - Ref: AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2
+        - Ref: AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3BucketB2DE6865
       SourceObjectKeys:
         - Fn::Join:
             - ""
@@ -4174,12 +4174,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3VersionKey252F23A8
+                      - Ref: AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3VersionKeyD40FAA20
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3VersionKey252F23A8
+                      - Ref: AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3VersionKeyD40FAA20
       DestinationBucketName:
         Ref: ConstructHubLicenseListBucket9334047F
       RetainOnDelete: false
@@ -6000,13 +6000,13 @@ Resources:
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2
+                    - Ref: AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3BucketB2DE6865
               - Fn::Join:
                   - ""
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2
+                    - Ref: AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3BucketB2DE6865
                     - /*
           - Action:
               - s3:GetObject*
@@ -6599,18 +6599,18 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "a35e65c6829d52a4f29a3f9b3839fded34c00c2d3a4ec5de9b39c607701781da"
-  AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2:
+  AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3BucketB2DE6865:
     Type: String
     Description: S3 bucket for asset
-      "7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292"
-  AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3VersionKey252F23A8:
+      "8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900"
+  AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3VersionKeyD40FAA20:
     Type: String
     Description: S3 key for asset version
-      "7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292"
-  AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292ArtifactHash5EAA9945:
+      "8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900"
+  AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900ArtifactHash121EF458:
     Type: String
     Description: Artifact hash for asset
-      "7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292"
+      "8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900"
   AssetParameters38c1770692a189751614dd7f17bde0c2f84ed85cd04e83dc824739cc8b18d3aeS3Bucket33F21758:
     Type: String
     Description: S3 bucket for asset

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -4166,7 +4166,7 @@ Resources:
           - CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536
           - Arn
       SourceBucketNames:
-        - Ref: AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3BucketF36A877E
+        - Ref: AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2
       SourceObjectKeys:
         - Fn::Join:
             - ""
@@ -4174,12 +4174,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3VersionKeyF7596361
+                      - Ref: AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3VersionKey252F23A8
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3VersionKeyF7596361
+                      - Ref: AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3VersionKey252F23A8
       DestinationBucketName:
         Ref: ConstructHubLicenseListBucket9334047F
       RetainOnDelete: false
@@ -6000,13 +6000,13 @@ Resources:
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3BucketF36A877E
+                    - Ref: AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2
               - Fn::Join:
                   - ""
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3BucketF36A877E
+                    - Ref: AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2
                     - /*
           - Action:
               - s3:GetObject*
@@ -6599,18 +6599,18 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "a35e65c6829d52a4f29a3f9b3839fded34c00c2d3a4ec5de9b39c607701781da"
-  AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3BucketF36A877E:
+  AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3BucketDC3E18E2:
     Type: String
     Description: S3 bucket for asset
-      "2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658"
-  AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658S3VersionKeyF7596361:
+      "7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292"
+  AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292S3VersionKey252F23A8:
     Type: String
     Description: S3 key for asset version
-      "2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658"
-  AssetParameters2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658ArtifactHashA026490C:
+      "7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292"
+  AssetParameters7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292ArtifactHash5EAA9945:
     Type: String
     Description: Artifact hash for asset
-      "2d57e6bb8a166048eeaa118c1f0e1a8d760395e6f71185ebbd03869b25a22658"
+      "7ee315e777b3e3adf44520a475ccc1a09e44731b92b34bdbf9325ee127312292"
   AssetParameters38c1770692a189751614dd7f17bde0c2f84ed85cd04e83dc824739cc8b18d3aeS3Bucket33F21758:
     Type: String
     Description: S3 bucket for asset

--- a/src/construct-hub.ts
+++ b/src/construct-hub.ts
@@ -97,7 +97,7 @@ export interface ConstructHubProps {
   /**
    * The allowed licenses for packages indexed by this instance of ConstructHub.
    *
-   * @default [...SpdxLicense.apache(),...SpdxLicense.bsd(),...SpdxLicense.cddl(),...SpdxLicense.epl(),SpdxLicense.ISC,...SpdxLicense.mit(),...SpdxLicense.mpl()]
+   * @default [...SpdxLicense.apache(),...SpdxLicense.bsd(),...SpdxLicense.cddl(),...SpdxLicense.epl(),SpdxLicense.ISC,...SpdxLicense.mit(),SpdxLicense.MPL_2_0]
    */
   readonly allowedLicenses?: SpdxLicense[];
 
@@ -286,7 +286,7 @@ export class ConstructHub extends CoreConstruct implements iam.IGrantable {
         ...SpdxLicense.epl(),
         SpdxLicense.ISC,
         ...SpdxLicense.mit(),
-        ...SpdxLicense.mpl(),
+        SpdxLicense.MPL_2_0,
       ],
     });
 

--- a/src/construct-hub.ts
+++ b/src/construct-hub.ts
@@ -97,7 +97,7 @@ export interface ConstructHubProps {
   /**
    * The allowed licenses for packages indexed by this instance of ConstructHub.
    *
-   * @default [...SpdxLicense.apache(),...SpdxLicense.bsd(),...SpdxLicense.mit()]
+   * @default [...SpdxLicense.apache(),...SpdxLicense.bsd(),...SpdxLicense.cddl(),...SpdxLicense.epl(),SpdxLicense.ISC,...SpdxLicense.mit(),...SpdxLicense.mpl()]
    */
   readonly allowedLicenses?: SpdxLicense[];
 
@@ -282,7 +282,11 @@ export class ConstructHub extends CoreConstruct implements iam.IGrantable {
       licenses: props.allowedLicenses ?? [
         ...SpdxLicense.apache(),
         ...SpdxLicense.bsd(),
+        ...SpdxLicense.cddl(),
+        ...SpdxLicense.epl(),
+        SpdxLicense.ISC,
         ...SpdxLicense.mit(),
+        ...SpdxLicense.mpl(),
       ],
     });
 

--- a/src/spdx-license.ts
+++ b/src/spdx-license.ts
@@ -3594,6 +3594,22 @@ export class SpdxLicense {
     ];
   }
 
+  /** The CDDL family of licenses */
+  public static cddl(): SpdxLicense[] {
+    return [
+      SpdxLicense.CDDL_1_0,
+      SpdxLicense.CDDL_1_1,
+    ];
+  }
+
+  /** The EPL family of licenses */
+  public static epl(): SpdxLicense[] {
+    return [
+      SpdxLicense.EPL_1_0,
+      SpdxLicense.EPL_2_0,
+    ];
+  }
+
   /** The MIT family of licenses */
   public static mit(): SpdxLicense[] {
     return [
@@ -3606,6 +3622,16 @@ export class SpdxLicense {
       SpdxLicense.MIT_FEH,
       SpdxLicense.MIT_OPEN_GROUP,
       SpdxLicense.MITNFA,
+    ];
+  }
+
+  /** The MPL family of licenses */
+  public static mpl(): SpdxLicense[] {
+    return [
+      SpdxLicense.MPL_1_0,
+      SpdxLicense.MPL_1_1,
+      SpdxLicense.MPL_2_0,
+      SpdxLicense.MPL_2_0_NO_COPYLEFT_EXCEPTION,
     ];
   }
   //#endregion


### PR DESCRIPTION
Adding the CDDL, EPL, ISC and MPL-2.0 license families to the Hub's
default license allow-list, following legal review of their terms.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*