### PR TITLE
feat: browse categories

### DIFF
--- a/API.md
+++ b/API.md
@@ -141,6 +141,46 @@ This must be an ARN that can be used with CloudWatch alarms.
 
 ---
 
+### Category <a name="construct-hub.Category"></a>
+
+A category of packages.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```typescript
+import { Category } from 'construct-hub'
+
+const category: Category = { ... }
+```
+
+##### `title`<sup>Required</sup> <a name="construct-hub.Category.property.title"></a>
+
+```typescript
+public readonly title: string;
+```
+
+- *Type:* `string`
+
+The title on the category button as it appears in the Construct Hub home page.
+
+---
+
+##### `url`<sup>Required</sup> <a name="construct-hub.Category.property.url"></a>
+
+```typescript
+public readonly url: string;
+```
+
+- *Type:* `string`
+
+The URL that this category links to.
+
+This is the full path to the link that
+this category button will have. You can use any query options such as
+`?keywords=`, `?q=`, or a combination thereof.
+
+---
+
 ### CodeArtifactDomainProps <a name="construct-hub.CodeArtifactDomainProps"></a>
 
 Information pertaining to an existing CodeArtifact Domain.
@@ -223,6 +263,21 @@ public readonly backendDashboardName: string;
 - *Type:* `string`
 
 The name of the CloudWatch dashboard that represents the health of backend systems.
+
+---
+
+##### `categories`<sup>Optional</sup> <a name="construct-hub.ConstructHubProps.property.categories"></a>
+
+```typescript
+public readonly categories: Category[];
+```
+
+- *Type:* [`construct-hub.Category`](#construct-hub.Category)[]
+
+Browse categories.
+
+Each category will appear in the home page as a button
+with a link to the relevant search query.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ instance with personalized configuration.
 
 [aws-cdk]: https://github.com/aws/aws-cdk
 
-
 ## :question: Getting Started
 
 > :warning: Disclaimer
@@ -152,7 +151,6 @@ ConstructHub instance only indexes *trusted* packages (as could be the case for
 an instance that does not list packages from the public `npmjs.com` registry),
 you may set the `isolateLambdas` setting to `false`.
 
-
 ## :gear: Operating a self-hosted instance
 
 1. [Application Overview](./docs/application-overview.md) provides a high-level
@@ -239,6 +237,7 @@ trusted organizations, or any other arbitrary conditions, and can be referenced
 while searching.
 
 For example:
+
 ```ts
 new ConstructHub(this, "ConstructHub", {
   ...myProps,
@@ -292,6 +291,7 @@ with a checkbox for each `AWS` and `Community` packages, allowing users to
 filter results by the presence of these tags.
 
 Combinations of conditions are also supported:
+
 ```ts
 new ConstructHub(this, "ConstructHub", {
   ...myProps,
@@ -313,6 +313,7 @@ condition: TagCondition.or(
 ```
 
 You can assert against any value within package json including nested ones.
+
 ```ts
 TagCondition.field('constructHub', 'nested', 'key').eq('value');
 
@@ -326,6 +327,7 @@ Configuring package links allows you to replace the `Repository`, `License`,
 and `Registry` links on the package details page with whatever you choose.
 
 For example:
+
 ```ts
 new ConstructHub(this, "ConstructHub", {
   ...myProps,
@@ -362,6 +364,7 @@ Currently, for a given section you can display either the most recently updated
 packages, or a curated list of packages.
 
 For example:
+
 ```ts
 new ConstructHub(this, "ConstructHub", {
   ...myProps,
@@ -395,24 +398,43 @@ new ConstructHub(this, "ConstructHub", {
 });
 ```
 
+#### Browse Categories
+
+The Construct Hub home page includes a section that displays a set of buttons
+that represent browsing categories (e.g. "Databases", "Monitoring",
+"Serverless", etc).
+
+You can use the `categories` option to configure these categories. Each category
+is defined by a `title` and a `url`, which will be the link associated with the
+button.
+
+```ts
+new ConstructHub(this, "ConstructHub", {
+  ...myProps,
+  categories: [
+    { title: 'Databases', url: '?keywords=databases' },
+    { title: 'Monitoring', url: '?q=monitoring' },
+    { title: 'Partners', url: '?tags=aws-partner' }
+  ]
+});
+```
+
 #### Feature Flags
 
 Feature flags for the web app can be used to enable or disable experimental
 features. These can be customized through the `featureFlags` property - for
 more information about the available flags, check the documentation for
-https://github.com/cdklabs/construct-hub-webapp/.
+<https://github.com/cdklabs/construct-hub-webapp/>.
 
 ## :raised_hand: Contributing
 
 If you are looking to contribute to this project, but don't know where to start,
 have a look at our [contributing guide](CONTRIBUTING.md)!
 
-
 ## :cop: Security
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more
 information.
-
 
 ## :balance_scale: License
 

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -4521,7 +4521,7 @@ Resources:
           - CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536
           - Arn
       SourceBucketNames:
-        - Ref: AssetParameters15477b1cef671e2df0f65fb8523278d3a6331c3ae8912a7e3a85d656f694622fS3BucketD12474B4
+        - Ref: AssetParameters43fbac1b0c0d0299f39ad46ea91bbec840fe10d899a884e06a8a89a9c87987adS3Bucket118915A9
       SourceObjectKeys:
         - Fn::Join:
             - ""
@@ -4529,12 +4529,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters15477b1cef671e2df0f65fb8523278d3a6331c3ae8912a7e3a85d656f694622fS3VersionKey99E4F89D
+                      - Ref: AssetParameters43fbac1b0c0d0299f39ad46ea91bbec840fe10d899a884e06a8a89a9c87987adS3VersionKey653FDF42
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters15477b1cef671e2df0f65fb8523278d3a6331c3ae8912a7e3a85d656f694622fS3VersionKey99E4F89D
+                      - Ref: AssetParameters43fbac1b0c0d0299f39ad46ea91bbec840fe10d899a884e06a8a89a9c87987adS3VersionKey653FDF42
       DestinationBucketName:
         Ref: ConstructHubWebAppWebsiteBucket4B2B9DB2
       Prune: false
@@ -6079,13 +6079,13 @@ Resources:
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParameters15477b1cef671e2df0f65fb8523278d3a6331c3ae8912a7e3a85d656f694622fS3BucketD12474B4
+                    - Ref: AssetParameters43fbac1b0c0d0299f39ad46ea91bbec840fe10d899a884e06a8a89a9c87987adS3Bucket118915A9
               - Fn::Join:
                   - ""
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParameters15477b1cef671e2df0f65fb8523278d3a6331c3ae8912a7e3a85d656f694622fS3BucketD12474B4
+                    - Ref: AssetParameters43fbac1b0c0d0299f39ad46ea91bbec840fe10d899a884e06a8a89a9c87987adS3Bucket118915A9
                     - /*
         Version: 2012-10-17
       PolicyName: CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF
@@ -6623,18 +6623,18 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "38c1770692a189751614dd7f17bde0c2f84ed85cd04e83dc824739cc8b18d3ae"
-  AssetParameters15477b1cef671e2df0f65fb8523278d3a6331c3ae8912a7e3a85d656f694622fS3BucketD12474B4:
+  AssetParameters43fbac1b0c0d0299f39ad46ea91bbec840fe10d899a884e06a8a89a9c87987adS3Bucket118915A9:
     Type: String
     Description: S3 bucket for asset
-      "15477b1cef671e2df0f65fb8523278d3a6331c3ae8912a7e3a85d656f694622f"
-  AssetParameters15477b1cef671e2df0f65fb8523278d3a6331c3ae8912a7e3a85d656f694622fS3VersionKey99E4F89D:
+      "43fbac1b0c0d0299f39ad46ea91bbec840fe10d899a884e06a8a89a9c87987ad"
+  AssetParameters43fbac1b0c0d0299f39ad46ea91bbec840fe10d899a884e06a8a89a9c87987adS3VersionKey653FDF42:
     Type: String
     Description: S3 key for asset version
-      "15477b1cef671e2df0f65fb8523278d3a6331c3ae8912a7e3a85d656f694622f"
-  AssetParameters15477b1cef671e2df0f65fb8523278d3a6331c3ae8912a7e3a85d656f694622fArtifactHashC85449A8:
+      "43fbac1b0c0d0299f39ad46ea91bbec840fe10d899a884e06a8a89a9c87987ad"
+  AssetParameters43fbac1b0c0d0299f39ad46ea91bbec840fe10d899a884e06a8a89a9c87987adArtifactHash6CA8E694:
     Type: String
     Description: Artifact hash for asset
-      "15477b1cef671e2df0f65fb8523278d3a6331c3ae8912a7e3a85d656f694622f"
+      "43fbac1b0c0d0299f39ad46ea91bbec840fe10d899a884e06a8a89a9c87987ad"
   AssetParameterscc6d7142efe459ae578414b0f727c0634382fe26ad2ad67f59029ba7d82d7988S3Bucket442D5AEC:
     Type: String
     Description: S3 bucket for asset

--- a/src/__tests__/devapp/dev-stack.ts
+++ b/src/__tests__/devapp/dev-stack.ts
@@ -57,6 +57,10 @@ export class DevStack extends Stack {
           display: 'AWS',
         },
       }],
+      categories: [
+        { title: 'Category1', url: '/search?q=cat1' },
+        { title: 'Category2', url: '/search?keywords=boom' },
+      ],
     });
   }
 }

--- a/src/__tests__/webapp/config.test.ts
+++ b/src/__tests__/webapp/config.test.ts
@@ -1,5 +1,6 @@
 import { readJsonSync } from 'fs-extra';
 import { TagCondition } from '../../package-tag';
+import { Category } from '../../webapp';
 import { WebappConfig } from '../../webapp/config';
 
 const DEFAULT_CONFIG = {
@@ -218,5 +219,23 @@ test('feature flags', () => {
   expect(file).toEqual({
     ...DEFAULT_CONFIG,
     featureFlags,
+  });
+});
+
+test('categories', () => {
+  // GIVEN
+  const categories: Category[] = [
+    { title: 'Monitoring', url: '/search?q=monitoring' },
+    { title: 'Kubernetes', url: '/search?keywords=k8s' },
+  ];
+
+  // WHEN
+  const config = new WebappConfig({ categories });
+
+  // THEN
+  const file = readJsonSync(config.file.path);
+  expect(file).toEqual({
+    ...DEFAULT_CONFIG,
+    categories,
   });
 });

--- a/src/construct-hub.ts
+++ b/src/construct-hub.ts
@@ -23,7 +23,7 @@ import { IPackageSource } from './package-source';
 import { NpmJs } from './package-sources';
 import { PackageTag } from './package-tag';
 import { SpdxLicense } from './spdx-license';
-import { WebApp, PackageLinkConfig, FeaturedPackages, FeatureFlags } from './webapp';
+import { WebApp, PackageLinkConfig, FeaturedPackages, FeatureFlags, Category } from './webapp';
 
 /**
  * Props for `ConstructHub`.
@@ -142,6 +142,12 @@ export interface ConstructHubProps {
    * used), false otherwise
    */
   readonly fetchPackageStats?: boolean;
+
+  /**
+   * Browse categories. Each category will appear in the home page as a button
+   * with a link to the relevant search query.
+   */
+  readonly categories?: Category[];
 }
 
 /**
@@ -299,6 +305,7 @@ export class ConstructHub extends CoreConstruct implements iam.IGrantable {
       featuredPackages: props.featuredPackages,
       packageStats,
       featureFlags: props.featureFlags,
+      categories: props.categories,
     });
 
     const sources = new CoreConstruct(this, 'Sources');

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,4 +4,4 @@ export * from './package-source';
 export * as sources from './package-sources';
 export * from './spdx-license';
 export * from './package-tag';
-export { PackageLinkConfig, FeaturedPackages, FeaturedPackagesSection, FeaturedPackagesDetail, FeatureFlags } from './webapp';
+export { PackageLinkConfig, FeaturedPackages, FeaturedPackagesSection, FeaturedPackagesDetail, FeatureFlags, Category } from './webapp';

--- a/src/webapp/config.ts
+++ b/src/webapp/config.ts
@@ -1,4 +1,4 @@
-import { FeaturedPackages, FeatureFlags, PackageLinkConfig } from '.';
+import { Category, FeaturedPackages, FeatureFlags, PackageLinkConfig } from '.';
 import { ConfigFile } from '../config-file';
 import { PackageTagConfig } from '../package-tag';
 
@@ -37,6 +37,7 @@ interface FrontendConfig {
   featuredPackages?: FrontendFeaturedPackagesConfig;
   packageStats?: boolean;
   featureFlags?: FeatureFlags;
+  categories?: Category[];
 }
 
 export interface WebappConfigProps {
@@ -67,6 +68,12 @@ export interface WebappConfigProps {
    * @default true
    */
   readonly showPackageStats?: boolean;
+
+  /**
+   * Browse categories. Each category will appear in the home page as a button
+   * with a link to the relevant search query.
+   */
+  readonly categories?: Category[];
 }
 
 export class WebappConfig {
@@ -82,6 +89,7 @@ export class WebappConfig {
       featuredPackages: this.featuredPackages,
       packageStats: this.props.showPackageStats ?? true,
       featureFlags: this.props.featureFlags,
+      categories: this.props.categories,
     };
   }
 

--- a/src/webapp/index.ts
+++ b/src/webapp/index.ts
@@ -99,6 +99,26 @@ export interface FeatureFlags {
   [key: string]: any;
 }
 
+/**
+ * A category of packages.
+ */
+export interface Category {
+  /**
+   * The title on the category button as it appears in the Construct Hub home page.
+   */
+  readonly title: string;
+
+  /**
+   * The URL that this category links to. This is the full path to the link that
+   * this category button will have. You can use any query options such as
+   * `?keywords=`, `?q=`, or a combination thereof.
+   *
+   * @example "/search?keywords=monitoring"
+   */
+  readonly url: string;
+}
+
+
 export interface WebAppProps extends WebappConfigProps {
   /**
    * Connect to a domain.
@@ -242,6 +262,7 @@ export class WebApp extends Construct {
       featuredPackages: props.featuredPackages,
       showPackageStats: props.showPackageStats ?? props.packageStats !== undefined,
       featureFlags: props.featureFlags,
+      categories: props.categories,
     });
 
     new s3deploy.BucketDeployment(this, 'DeployWebsiteConfig', {


### PR DESCRIPTION
Allow configuring browse categories. Each category has a `title` and a `url`. Categories are rendered into the `config.json` file that the frontend consumes in order to render the home page.

Related cdklabs/construct-hub-webapp#682


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*