### PR TITLE
feat: reduce assembly size even more

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -81,6 +81,18 @@ Object {
       "Description": "S3 key for asset version \\"3416b6d1c6347fa47603d8898795de205b2bd6b5dc24a30b7839eea2cb5f8903\\"",
       "Type": "String",
     },
+    "AssetParameters36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337fArtifactHash1B9B2A76": Object {
+      "Description": "Artifact hash for asset \\"36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337f\\"",
+      "Type": "String",
+    },
+    "AssetParameters36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337fS3BucketC24BE0E2": Object {
+      "Description": "S3 bucket for asset \\"36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337f\\"",
+      "Type": "String",
+    },
+    "AssetParameters36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337fS3VersionKey6F60C4B3": Object {
+      "Description": "S3 key for asset version \\"36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337f\\"",
+      "Type": "String",
+    },
     "AssetParameters4eca4d1b52b162aade7fdea6c9ba1f3b01eb5bd746b76ee41b9994d2b16d84a1ArtifactHash61E29678": Object {
       "Description": "Artifact hash for asset \\"4eca4d1b52b162aade7fdea6c9ba1f3b01eb5bd746b76ee41b9994d2b16d84a1\\"",
       "Type": "String",
@@ -117,18 +129,6 @@ Object {
       "Description": "S3 key for asset version \\"7412ee3c3ed97354b11100cb1f73e96631635318730a2733203b58c986337b81\\"",
       "Type": "String",
     },
-    "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eArtifactHash22EF1417": Object {
-      "Description": "Artifact hash for asset \\"78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3e\\"",
-      "Type": "String",
-    },
-    "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3Bucket3E098BA5": Object {
-      "Description": "S3 bucket for asset \\"78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3e\\"",
-      "Type": "String",
-    },
-    "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3VersionKeyAEA7FF0F": Object {
-      "Description": "S3 key for asset version \\"78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3e\\"",
-      "Type": "String",
-    },
     "AssetParameters7c158f248e4b8c4055bab463cf7161a06489f3c6b8cb338eaf1a3cdaeefa9bf5ArtifactHash191360E7": Object {
       "Description": "Artifact hash for asset \\"7c158f248e4b8c4055bab463cf7161a06489f3c6b8cb338eaf1a3cdaeefa9bf5\\"",
       "Type": "String",
@@ -163,6 +163,18 @@ Object {
     },
     "AssetParameters82fce0de1fd66c14056b03c8334213b6fd351f618d3db139501b43c1e27d9239S3VersionKey2D740AE6": Object {
       "Description": "S3 key for asset version \\"82fce0de1fd66c14056b03c8334213b6fd351f618d3db139501b43c1e27d9239\\"",
+      "Type": "String",
+    },
+    "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9ArtifactHash5CBB288C": Object {
+      "Description": "Artifact hash for asset \\"88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9\\"",
+      "Type": "String",
+    },
+    "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291": Object {
+      "Description": "S3 bucket for asset \\"88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9\\"",
+      "Type": "String",
+    },
+    "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3VersionKey6DDEB907": Object {
+      "Description": "S3 key for asset version \\"88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9\\"",
       "Type": "String",
     },
     "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900ArtifactHash121EF458": Object {
@@ -283,18 +295,6 @@ Object {
     },
     "AssetParametersec5ba82277d61b4c8f62eda97571cd57e350a84143f89d23270e8b9028d6f114S3VersionKey0F6A742F": Object {
       "Description": "S3 key for asset version \\"ec5ba82277d61b4c8f62eda97571cd57e350a84143f89d23270e8b9028d6f114\\"",
-      "Type": "String",
-    },
-    "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1ArtifactHash3D0E2730": Object {
-      "Description": "Artifact hash for asset \\"f18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1\\"",
-      "Type": "String",
-    },
-    "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75": Object {
-      "Description": "S3 bucket for asset \\"f18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1\\"",
-      "Type": "String",
-    },
-    "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3VersionKeyDE689547": Object {
-      "Description": "S3 key for asset version \\"f18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1\\"",
       "Type": "String",
     },
   },
@@ -1685,7 +1685,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3Bucket3E098BA5",
+            "Ref": "AssetParameters36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337fS3BucketC24BE0E2",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -1698,7 +1698,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3VersionKeyAEA7FF0F",
+                          "Ref": "AssetParameters36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337fS3VersionKey6F60C4B3",
                         },
                       ],
                     },
@@ -1711,7 +1711,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3VersionKeyAEA7FF0F",
+                          "Ref": "AssetParameters36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337fS3VersionKey6F60C4B3",
                         },
                       ],
                     },
@@ -8689,7 +8689,7 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75",
+            "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291",
           },
         ],
         "SourceObjectKeys": Array [
@@ -8704,7 +8704,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3VersionKeyDE689547",
+                          "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3VersionKey6DDEB907",
                         },
                       ],
                     },
@@ -8717,7 +8717,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3VersionKeyDE689547",
+                          "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3VersionKey6DDEB907",
                         },
                       ],
                     },
@@ -9423,7 +9423,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75",
+                        "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291",
                       },
                     ],
                   ],
@@ -9438,7 +9438,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75",
+                        "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291",
                       },
                       "/*",
                     ],
@@ -10130,6 +10130,18 @@ Object {
       "Description": "S3 key for asset version \\"3416b6d1c6347fa47603d8898795de205b2bd6b5dc24a30b7839eea2cb5f8903\\"",
       "Type": "String",
     },
+    "AssetParameters36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337fArtifactHash1B9B2A76": Object {
+      "Description": "Artifact hash for asset \\"36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337f\\"",
+      "Type": "String",
+    },
+    "AssetParameters36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337fS3BucketC24BE0E2": Object {
+      "Description": "S3 bucket for asset \\"36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337f\\"",
+      "Type": "String",
+    },
+    "AssetParameters36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337fS3VersionKey6F60C4B3": Object {
+      "Description": "S3 key for asset version \\"36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337f\\"",
+      "Type": "String",
+    },
     "AssetParameters4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbcArtifactHashF236251A": Object {
       "Description": "Artifact hash for asset \\"4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbc\\"",
       "Type": "String",
@@ -10178,18 +10190,6 @@ Object {
       "Description": "S3 key for asset version \\"7412ee3c3ed97354b11100cb1f73e96631635318730a2733203b58c986337b81\\"",
       "Type": "String",
     },
-    "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eArtifactHash22EF1417": Object {
-      "Description": "Artifact hash for asset \\"78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3e\\"",
-      "Type": "String",
-    },
-    "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3Bucket3E098BA5": Object {
-      "Description": "S3 bucket for asset \\"78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3e\\"",
-      "Type": "String",
-    },
-    "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3VersionKeyAEA7FF0F": Object {
-      "Description": "S3 key for asset version \\"78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3e\\"",
-      "Type": "String",
-    },
     "AssetParameters7c158f248e4b8c4055bab463cf7161a06489f3c6b8cb338eaf1a3cdaeefa9bf5ArtifactHash191360E7": Object {
       "Description": "Artifact hash for asset \\"7c158f248e4b8c4055bab463cf7161a06489f3c6b8cb338eaf1a3cdaeefa9bf5\\"",
       "Type": "String",
@@ -10224,6 +10224,18 @@ Object {
     },
     "AssetParameters82fce0de1fd66c14056b03c8334213b6fd351f618d3db139501b43c1e27d9239S3VersionKey2D740AE6": Object {
       "Description": "S3 key for asset version \\"82fce0de1fd66c14056b03c8334213b6fd351f618d3db139501b43c1e27d9239\\"",
+      "Type": "String",
+    },
+    "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9ArtifactHash5CBB288C": Object {
+      "Description": "Artifact hash for asset \\"88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9\\"",
+      "Type": "String",
+    },
+    "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291": Object {
+      "Description": "S3 bucket for asset \\"88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9\\"",
+      "Type": "String",
+    },
+    "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3VersionKey6DDEB907": Object {
+      "Description": "S3 key for asset version \\"88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9\\"",
       "Type": "String",
     },
     "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900ArtifactHash121EF458": Object {
@@ -10344,18 +10356,6 @@ Object {
     },
     "AssetParametersec5ba82277d61b4c8f62eda97571cd57e350a84143f89d23270e8b9028d6f114S3VersionKey0F6A742F": Object {
       "Description": "S3 key for asset version \\"ec5ba82277d61b4c8f62eda97571cd57e350a84143f89d23270e8b9028d6f114\\"",
-      "Type": "String",
-    },
-    "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1ArtifactHash3D0E2730": Object {
-      "Description": "Artifact hash for asset \\"f18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1\\"",
-      "Type": "String",
-    },
-    "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75": Object {
-      "Description": "S3 bucket for asset \\"f18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1\\"",
-      "Type": "String",
-    },
-    "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3VersionKeyDE689547": Object {
-      "Description": "S3 key for asset version \\"f18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1\\"",
       "Type": "String",
     },
   },
@@ -12035,7 +12035,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3Bucket3E098BA5",
+            "Ref": "AssetParameters36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337fS3BucketC24BE0E2",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -12048,7 +12048,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3VersionKeyAEA7FF0F",
+                          "Ref": "AssetParameters36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337fS3VersionKey6F60C4B3",
                         },
                       ],
                     },
@@ -12061,7 +12061,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3VersionKeyAEA7FF0F",
+                          "Ref": "AssetParameters36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337fS3VersionKey6F60C4B3",
                         },
                       ],
                     },
@@ -19210,7 +19210,7 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75",
+            "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291",
           },
         ],
         "SourceObjectKeys": Array [
@@ -19225,7 +19225,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3VersionKeyDE689547",
+                          "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3VersionKey6DDEB907",
                         },
                       ],
                     },
@@ -19238,7 +19238,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3VersionKeyDE689547",
+                          "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3VersionKey6DDEB907",
                         },
                       ],
                     },
@@ -19944,7 +19944,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75",
+                        "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291",
                       },
                     ],
                   ],
@@ -19959,7 +19959,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75",
+                        "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291",
                       },
                       "/*",
                     ],
@@ -20651,6 +20651,18 @@ Object {
       "Description": "S3 key for asset version \\"3416b6d1c6347fa47603d8898795de205b2bd6b5dc24a30b7839eea2cb5f8903\\"",
       "Type": "String",
     },
+    "AssetParameters36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337fArtifactHash1B9B2A76": Object {
+      "Description": "Artifact hash for asset \\"36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337f\\"",
+      "Type": "String",
+    },
+    "AssetParameters36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337fS3BucketC24BE0E2": Object {
+      "Description": "S3 bucket for asset \\"36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337f\\"",
+      "Type": "String",
+    },
+    "AssetParameters36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337fS3VersionKey6F60C4B3": Object {
+      "Description": "S3 key for asset version \\"36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337f\\"",
+      "Type": "String",
+    },
     "AssetParameters4eca4d1b52b162aade7fdea6c9ba1f3b01eb5bd746b76ee41b9994d2b16d84a1ArtifactHash61E29678": Object {
       "Description": "Artifact hash for asset \\"4eca4d1b52b162aade7fdea6c9ba1f3b01eb5bd746b76ee41b9994d2b16d84a1\\"",
       "Type": "String",
@@ -20687,18 +20699,6 @@ Object {
       "Description": "S3 key for asset version \\"7412ee3c3ed97354b11100cb1f73e96631635318730a2733203b58c986337b81\\"",
       "Type": "String",
     },
-    "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eArtifactHash22EF1417": Object {
-      "Description": "Artifact hash for asset \\"78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3e\\"",
-      "Type": "String",
-    },
-    "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3Bucket3E098BA5": Object {
-      "Description": "S3 bucket for asset \\"78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3e\\"",
-      "Type": "String",
-    },
-    "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3VersionKeyAEA7FF0F": Object {
-      "Description": "S3 key for asset version \\"78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3e\\"",
-      "Type": "String",
-    },
     "AssetParameters7c158f248e4b8c4055bab463cf7161a06489f3c6b8cb338eaf1a3cdaeefa9bf5ArtifactHash191360E7": Object {
       "Description": "Artifact hash for asset \\"7c158f248e4b8c4055bab463cf7161a06489f3c6b8cb338eaf1a3cdaeefa9bf5\\"",
       "Type": "String",
@@ -20733,6 +20733,18 @@ Object {
     },
     "AssetParameters82fce0de1fd66c14056b03c8334213b6fd351f618d3db139501b43c1e27d9239S3VersionKey2D740AE6": Object {
       "Description": "S3 key for asset version \\"82fce0de1fd66c14056b03c8334213b6fd351f618d3db139501b43c1e27d9239\\"",
+      "Type": "String",
+    },
+    "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9ArtifactHash5CBB288C": Object {
+      "Description": "Artifact hash for asset \\"88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9\\"",
+      "Type": "String",
+    },
+    "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291": Object {
+      "Description": "S3 bucket for asset \\"88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9\\"",
+      "Type": "String",
+    },
+    "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3VersionKey6DDEB907": Object {
+      "Description": "S3 key for asset version \\"88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9\\"",
       "Type": "String",
     },
     "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900ArtifactHash121EF458": Object {
@@ -20853,18 +20865,6 @@ Object {
     },
     "AssetParametersec5ba82277d61b4c8f62eda97571cd57e350a84143f89d23270e8b9028d6f114S3VersionKey0F6A742F": Object {
       "Description": "S3 key for asset version \\"ec5ba82277d61b4c8f62eda97571cd57e350a84143f89d23270e8b9028d6f114\\"",
-      "Type": "String",
-    },
-    "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1ArtifactHash3D0E2730": Object {
-      "Description": "Artifact hash for asset \\"f18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1\\"",
-      "Type": "String",
-    },
-    "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75": Object {
-      "Description": "S3 bucket for asset \\"f18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1\\"",
-      "Type": "String",
-    },
-    "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3VersionKeyDE689547": Object {
-      "Description": "S3 key for asset version \\"f18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1\\"",
       "Type": "String",
     },
   },
@@ -22255,7 +22255,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3Bucket3E098BA5",
+            "Ref": "AssetParameters36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337fS3BucketC24BE0E2",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -22268,7 +22268,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3VersionKeyAEA7FF0F",
+                          "Ref": "AssetParameters36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337fS3VersionKey6F60C4B3",
                         },
                       ],
                     },
@@ -22281,7 +22281,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3VersionKeyAEA7FF0F",
+                          "Ref": "AssetParameters36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337fS3VersionKey6F60C4B3",
                         },
                       ],
                     },
@@ -29259,7 +29259,7 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75",
+            "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291",
           },
         ],
         "SourceObjectKeys": Array [
@@ -29274,7 +29274,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3VersionKeyDE689547",
+                          "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3VersionKey6DDEB907",
                         },
                       ],
                     },
@@ -29287,7 +29287,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3VersionKeyDE689547",
+                          "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3VersionKey6DDEB907",
                         },
                       ],
                     },
@@ -29993,7 +29993,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75",
+                        "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291",
                       },
                     ],
                   ],
@@ -30008,7 +30008,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75",
+                        "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291",
                       },
                       "/*",
                     ],
@@ -30710,6 +30710,18 @@ Object {
       "Description": "S3 key for asset version \\"3416b6d1c6347fa47603d8898795de205b2bd6b5dc24a30b7839eea2cb5f8903\\"",
       "Type": "String",
     },
+    "AssetParameters36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337fArtifactHash1B9B2A76": Object {
+      "Description": "Artifact hash for asset \\"36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337f\\"",
+      "Type": "String",
+    },
+    "AssetParameters36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337fS3BucketC24BE0E2": Object {
+      "Description": "S3 bucket for asset \\"36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337f\\"",
+      "Type": "String",
+    },
+    "AssetParameters36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337fS3VersionKey6F60C4B3": Object {
+      "Description": "S3 key for asset version \\"36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337f\\"",
+      "Type": "String",
+    },
     "AssetParameters4eca4d1b52b162aade7fdea6c9ba1f3b01eb5bd746b76ee41b9994d2b16d84a1ArtifactHash61E29678": Object {
       "Description": "Artifact hash for asset \\"4eca4d1b52b162aade7fdea6c9ba1f3b01eb5bd746b76ee41b9994d2b16d84a1\\"",
       "Type": "String",
@@ -30758,18 +30770,6 @@ Object {
       "Description": "S3 key for asset version \\"7412ee3c3ed97354b11100cb1f73e96631635318730a2733203b58c986337b81\\"",
       "Type": "String",
     },
-    "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eArtifactHash22EF1417": Object {
-      "Description": "Artifact hash for asset \\"78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3e\\"",
-      "Type": "String",
-    },
-    "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3Bucket3E098BA5": Object {
-      "Description": "S3 bucket for asset \\"78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3e\\"",
-      "Type": "String",
-    },
-    "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3VersionKeyAEA7FF0F": Object {
-      "Description": "S3 key for asset version \\"78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3e\\"",
-      "Type": "String",
-    },
     "AssetParameters7af6295e521fd55af94332393ceffb3e866aac4dc4956321f7918f21e72199e4ArtifactHash5E28809B": Object {
       "Description": "Artifact hash for asset \\"7af6295e521fd55af94332393ceffb3e866aac4dc4956321f7918f21e72199e4\\"",
       "Type": "String",
@@ -30816,6 +30816,18 @@ Object {
     },
     "AssetParameters82fce0de1fd66c14056b03c8334213b6fd351f618d3db139501b43c1e27d9239S3VersionKey2D740AE6": Object {
       "Description": "S3 key for asset version \\"82fce0de1fd66c14056b03c8334213b6fd351f618d3db139501b43c1e27d9239\\"",
+      "Type": "String",
+    },
+    "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9ArtifactHash5CBB288C": Object {
+      "Description": "Artifact hash for asset \\"88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9\\"",
+      "Type": "String",
+    },
+    "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291": Object {
+      "Description": "S3 bucket for asset \\"88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9\\"",
+      "Type": "String",
+    },
+    "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3VersionKey6DDEB907": Object {
+      "Description": "S3 key for asset version \\"88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9\\"",
       "Type": "String",
     },
     "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900ArtifactHash121EF458": Object {
@@ -30936,18 +30948,6 @@ Object {
     },
     "AssetParametersec5ba82277d61b4c8f62eda97571cd57e350a84143f89d23270e8b9028d6f114S3VersionKey0F6A742F": Object {
       "Description": "S3 key for asset version \\"ec5ba82277d61b4c8f62eda97571cd57e350a84143f89d23270e8b9028d6f114\\"",
-      "Type": "String",
-    },
-    "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1ArtifactHash3D0E2730": Object {
-      "Description": "Artifact hash for asset \\"f18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1\\"",
-      "Type": "String",
-    },
-    "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75": Object {
-      "Description": "S3 bucket for asset \\"f18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1\\"",
-      "Type": "String",
-    },
-    "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3VersionKeyDE689547": Object {
-      "Description": "S3 key for asset version \\"f18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1\\"",
       "Type": "String",
     },
   },
@@ -32487,7 +32487,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3Bucket3E098BA5",
+            "Ref": "AssetParameters36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337fS3BucketC24BE0E2",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -32500,7 +32500,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3VersionKeyAEA7FF0F",
+                          "Ref": "AssetParameters36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337fS3VersionKey6F60C4B3",
                         },
                       ],
                     },
@@ -32513,7 +32513,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3VersionKeyAEA7FF0F",
+                          "Ref": "AssetParameters36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337fS3VersionKey6F60C4B3",
                         },
                       ],
                     },
@@ -39552,7 +39552,7 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75",
+            "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291",
           },
         ],
         "SourceObjectKeys": Array [
@@ -39567,7 +39567,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3VersionKeyDE689547",
+                          "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3VersionKey6DDEB907",
                         },
                       ],
                     },
@@ -39580,7 +39580,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3VersionKeyDE689547",
+                          "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3VersionKey6DDEB907",
                         },
                       ],
                     },
@@ -40513,7 +40513,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75",
+                        "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291",
                       },
                     ],
                   ],
@@ -40528,7 +40528,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75",
+                        "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291",
                       },
                       "/*",
                     ],
@@ -41220,6 +41220,18 @@ Object {
       "Description": "S3 key for asset version \\"3416b6d1c6347fa47603d8898795de205b2bd6b5dc24a30b7839eea2cb5f8903\\"",
       "Type": "String",
     },
+    "AssetParameters36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337fArtifactHash1B9B2A76": Object {
+      "Description": "Artifact hash for asset \\"36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337f\\"",
+      "Type": "String",
+    },
+    "AssetParameters36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337fS3BucketC24BE0E2": Object {
+      "Description": "S3 bucket for asset \\"36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337f\\"",
+      "Type": "String",
+    },
+    "AssetParameters36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337fS3VersionKey6F60C4B3": Object {
+      "Description": "S3 key for asset version \\"36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337f\\"",
+      "Type": "String",
+    },
     "AssetParameters4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbcArtifactHashF236251A": Object {
       "Description": "Artifact hash for asset \\"4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbc\\"",
       "Type": "String",
@@ -41268,18 +41280,6 @@ Object {
       "Description": "S3 key for asset version \\"7412ee3c3ed97354b11100cb1f73e96631635318730a2733203b58c986337b81\\"",
       "Type": "String",
     },
-    "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eArtifactHash22EF1417": Object {
-      "Description": "Artifact hash for asset \\"78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3e\\"",
-      "Type": "String",
-    },
-    "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3Bucket3E098BA5": Object {
-      "Description": "S3 bucket for asset \\"78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3e\\"",
-      "Type": "String",
-    },
-    "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3VersionKeyAEA7FF0F": Object {
-      "Description": "S3 key for asset version \\"78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3e\\"",
-      "Type": "String",
-    },
     "AssetParameters7c158f248e4b8c4055bab463cf7161a06489f3c6b8cb338eaf1a3cdaeefa9bf5ArtifactHash191360E7": Object {
       "Description": "Artifact hash for asset \\"7c158f248e4b8c4055bab463cf7161a06489f3c6b8cb338eaf1a3cdaeefa9bf5\\"",
       "Type": "String",
@@ -41314,6 +41314,18 @@ Object {
     },
     "AssetParameters82fce0de1fd66c14056b03c8334213b6fd351f618d3db139501b43c1e27d9239S3VersionKey2D740AE6": Object {
       "Description": "S3 key for asset version \\"82fce0de1fd66c14056b03c8334213b6fd351f618d3db139501b43c1e27d9239\\"",
+      "Type": "String",
+    },
+    "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9ArtifactHash5CBB288C": Object {
+      "Description": "Artifact hash for asset \\"88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9\\"",
+      "Type": "String",
+    },
+    "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291": Object {
+      "Description": "S3 bucket for asset \\"88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9\\"",
+      "Type": "String",
+    },
+    "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3VersionKey6DDEB907": Object {
+      "Description": "S3 key for asset version \\"88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9\\"",
       "Type": "String",
     },
     "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900ArtifactHash121EF458": Object {
@@ -41434,18 +41446,6 @@ Object {
     },
     "AssetParametersec5ba82277d61b4c8f62eda97571cd57e350a84143f89d23270e8b9028d6f114S3VersionKey0F6A742F": Object {
       "Description": "S3 key for asset version \\"ec5ba82277d61b4c8f62eda97571cd57e350a84143f89d23270e8b9028d6f114\\"",
-      "Type": "String",
-    },
-    "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1ArtifactHash3D0E2730": Object {
-      "Description": "Artifact hash for asset \\"f18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1\\"",
-      "Type": "String",
-    },
-    "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75": Object {
-      "Description": "S3 bucket for asset \\"f18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1\\"",
-      "Type": "String",
-    },
-    "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3VersionKeyDE689547": Object {
-      "Description": "S3 key for asset version \\"f18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1\\"",
       "Type": "String",
     },
   },
@@ -42945,7 +42945,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3Bucket3E098BA5",
+            "Ref": "AssetParameters36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337fS3BucketC24BE0E2",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -42958,7 +42958,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3VersionKeyAEA7FF0F",
+                          "Ref": "AssetParameters36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337fS3VersionKey6F60C4B3",
                         },
                       ],
                     },
@@ -42971,7 +42971,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3VersionKeyAEA7FF0F",
+                          "Ref": "AssetParameters36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337fS3VersionKey6F60C4B3",
                         },
                       ],
                     },
@@ -51472,7 +51472,7 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75",
+            "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291",
           },
         ],
         "SourceObjectKeys": Array [
@@ -51487,7 +51487,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3VersionKeyDE689547",
+                          "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3VersionKey6DDEB907",
                         },
                       ],
                     },
@@ -51500,7 +51500,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3VersionKeyDE689547",
+                          "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3VersionKey6DDEB907",
                         },
                       ],
                     },
@@ -52668,7 +52668,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75",
+                        "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291",
                       },
                     ],
                   ],
@@ -52683,7 +52683,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75",
+                        "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291",
                       },
                       "/*",
                     ],

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -117,6 +117,18 @@ Object {
       "Description": "S3 key for asset version \\"7412ee3c3ed97354b11100cb1f73e96631635318730a2733203b58c986337b81\\"",
       "Type": "String",
     },
+    "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eArtifactHash22EF1417": Object {
+      "Description": "Artifact hash for asset \\"78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3e\\"",
+      "Type": "String",
+    },
+    "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3Bucket3E098BA5": Object {
+      "Description": "S3 bucket for asset \\"78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3e\\"",
+      "Type": "String",
+    },
+    "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3VersionKeyAEA7FF0F": Object {
+      "Description": "S3 key for asset version \\"78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3e\\"",
+      "Type": "String",
+    },
     "AssetParameters7c158f248e4b8c4055bab463cf7161a06489f3c6b8cb338eaf1a3cdaeefa9bf5ArtifactHash191360E7": Object {
       "Description": "Artifact hash for asset \\"7c158f248e4b8c4055bab463cf7161a06489f3c6b8cb338eaf1a3cdaeefa9bf5\\"",
       "Type": "String",
@@ -153,18 +165,6 @@ Object {
       "Description": "S3 key for asset version \\"82fce0de1fd66c14056b03c8334213b6fd351f618d3db139501b43c1e27d9239\\"",
       "Type": "String",
     },
-    "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9ArtifactHash5CBB288C": Object {
-      "Description": "Artifact hash for asset \\"88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9\\"",
-      "Type": "String",
-    },
-    "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291": Object {
-      "Description": "S3 bucket for asset \\"88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9\\"",
-      "Type": "String",
-    },
-    "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3VersionKey6DDEB907": Object {
-      "Description": "S3 key for asset version \\"88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9\\"",
-      "Type": "String",
-    },
     "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900ArtifactHash121EF458": Object {
       "Description": "Artifact hash for asset \\"8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900\\"",
       "Type": "String",
@@ -199,18 +199,6 @@ Object {
     },
     "AssetParametersa06653c0fddc078791490ec0803bda19cf4effd0b9a7ecbb8b4ba1d52a74286bS3VersionKeyFEB3692B": Object {
       "Description": "S3 key for asset version \\"a06653c0fddc078791490ec0803bda19cf4effd0b9a7ecbb8b4ba1d52a74286b\\"",
-      "Type": "String",
-    },
-    "AssetParametersa081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7ebArtifactHash233CDC52": Object {
-      "Description": "Artifact hash for asset \\"a081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7eb\\"",
-      "Type": "String",
-    },
-    "AssetParametersa081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7ebS3Bucket365F97A0": Object {
-      "Description": "S3 bucket for asset \\"a081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7eb\\"",
-      "Type": "String",
-    },
-    "AssetParametersa081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7ebS3VersionKeyC005F9D4": Object {
-      "Description": "S3 key for asset version \\"a081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7eb\\"",
       "Type": "String",
     },
     "AssetParametersa3058ccb468d757ebb89df5363a1c20f5307c6911136f29d00e1a68c9b2aa7e8ArtifactHash238275D6": Object {
@@ -295,6 +283,18 @@ Object {
     },
     "AssetParametersec5ba82277d61b4c8f62eda97571cd57e350a84143f89d23270e8b9028d6f114S3VersionKey0F6A742F": Object {
       "Description": "S3 key for asset version \\"ec5ba82277d61b4c8f62eda97571cd57e350a84143f89d23270e8b9028d6f114\\"",
+      "Type": "String",
+    },
+    "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1ArtifactHash3D0E2730": Object {
+      "Description": "Artifact hash for asset \\"f18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1\\"",
+      "Type": "String",
+    },
+    "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75": Object {
+      "Description": "S3 bucket for asset \\"f18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1\\"",
+      "Type": "String",
+    },
+    "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3VersionKeyDE689547": Object {
+      "Description": "S3 key for asset version \\"f18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1\\"",
       "Type": "String",
     },
   },
@@ -1685,7 +1685,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersa081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7ebS3Bucket365F97A0",
+            "Ref": "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3Bucket3E098BA5",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -1698,7 +1698,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersa081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7ebS3VersionKeyC005F9D4",
+                          "Ref": "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3VersionKeyAEA7FF0F",
                         },
                       ],
                     },
@@ -1711,7 +1711,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersa081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7ebS3VersionKeyC005F9D4",
+                          "Ref": "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3VersionKeyAEA7FF0F",
                         },
                       ],
                     },
@@ -8689,7 +8689,7 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291",
+            "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75",
           },
         ],
         "SourceObjectKeys": Array [
@@ -8704,7 +8704,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3VersionKey6DDEB907",
+                          "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3VersionKeyDE689547",
                         },
                       ],
                     },
@@ -8717,7 +8717,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3VersionKey6DDEB907",
+                          "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3VersionKeyDE689547",
                         },
                       ],
                     },
@@ -9423,7 +9423,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291",
+                        "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75",
                       },
                     ],
                   ],
@@ -9438,7 +9438,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291",
+                        "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75",
                       },
                       "/*",
                     ],
@@ -10178,6 +10178,18 @@ Object {
       "Description": "S3 key for asset version \\"7412ee3c3ed97354b11100cb1f73e96631635318730a2733203b58c986337b81\\"",
       "Type": "String",
     },
+    "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eArtifactHash22EF1417": Object {
+      "Description": "Artifact hash for asset \\"78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3e\\"",
+      "Type": "String",
+    },
+    "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3Bucket3E098BA5": Object {
+      "Description": "S3 bucket for asset \\"78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3e\\"",
+      "Type": "String",
+    },
+    "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3VersionKeyAEA7FF0F": Object {
+      "Description": "S3 key for asset version \\"78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3e\\"",
+      "Type": "String",
+    },
     "AssetParameters7c158f248e4b8c4055bab463cf7161a06489f3c6b8cb338eaf1a3cdaeefa9bf5ArtifactHash191360E7": Object {
       "Description": "Artifact hash for asset \\"7c158f248e4b8c4055bab463cf7161a06489f3c6b8cb338eaf1a3cdaeefa9bf5\\"",
       "Type": "String",
@@ -10214,18 +10226,6 @@ Object {
       "Description": "S3 key for asset version \\"82fce0de1fd66c14056b03c8334213b6fd351f618d3db139501b43c1e27d9239\\"",
       "Type": "String",
     },
-    "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9ArtifactHash5CBB288C": Object {
-      "Description": "Artifact hash for asset \\"88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9\\"",
-      "Type": "String",
-    },
-    "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291": Object {
-      "Description": "S3 bucket for asset \\"88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9\\"",
-      "Type": "String",
-    },
-    "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3VersionKey6DDEB907": Object {
-      "Description": "S3 key for asset version \\"88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9\\"",
-      "Type": "String",
-    },
     "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900ArtifactHash121EF458": Object {
       "Description": "Artifact hash for asset \\"8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900\\"",
       "Type": "String",
@@ -10260,18 +10260,6 @@ Object {
     },
     "AssetParametersa06653c0fddc078791490ec0803bda19cf4effd0b9a7ecbb8b4ba1d52a74286bS3VersionKeyFEB3692B": Object {
       "Description": "S3 key for asset version \\"a06653c0fddc078791490ec0803bda19cf4effd0b9a7ecbb8b4ba1d52a74286b\\"",
-      "Type": "String",
-    },
-    "AssetParametersa081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7ebArtifactHash233CDC52": Object {
-      "Description": "Artifact hash for asset \\"a081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7eb\\"",
-      "Type": "String",
-    },
-    "AssetParametersa081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7ebS3Bucket365F97A0": Object {
-      "Description": "S3 bucket for asset \\"a081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7eb\\"",
-      "Type": "String",
-    },
-    "AssetParametersa081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7ebS3VersionKeyC005F9D4": Object {
-      "Description": "S3 key for asset version \\"a081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7eb\\"",
       "Type": "String",
     },
     "AssetParametersa3058ccb468d757ebb89df5363a1c20f5307c6911136f29d00e1a68c9b2aa7e8ArtifactHash238275D6": Object {
@@ -10356,6 +10344,18 @@ Object {
     },
     "AssetParametersec5ba82277d61b4c8f62eda97571cd57e350a84143f89d23270e8b9028d6f114S3VersionKey0F6A742F": Object {
       "Description": "S3 key for asset version \\"ec5ba82277d61b4c8f62eda97571cd57e350a84143f89d23270e8b9028d6f114\\"",
+      "Type": "String",
+    },
+    "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1ArtifactHash3D0E2730": Object {
+      "Description": "Artifact hash for asset \\"f18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1\\"",
+      "Type": "String",
+    },
+    "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75": Object {
+      "Description": "S3 bucket for asset \\"f18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1\\"",
+      "Type": "String",
+    },
+    "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3VersionKeyDE689547": Object {
+      "Description": "S3 key for asset version \\"f18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1\\"",
       "Type": "String",
     },
   },
@@ -12035,7 +12035,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersa081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7ebS3Bucket365F97A0",
+            "Ref": "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3Bucket3E098BA5",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -12048,7 +12048,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersa081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7ebS3VersionKeyC005F9D4",
+                          "Ref": "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3VersionKeyAEA7FF0F",
                         },
                       ],
                     },
@@ -12061,7 +12061,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersa081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7ebS3VersionKeyC005F9D4",
+                          "Ref": "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3VersionKeyAEA7FF0F",
                         },
                       ],
                     },
@@ -19210,7 +19210,7 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291",
+            "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75",
           },
         ],
         "SourceObjectKeys": Array [
@@ -19225,7 +19225,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3VersionKey6DDEB907",
+                          "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3VersionKeyDE689547",
                         },
                       ],
                     },
@@ -19238,7 +19238,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3VersionKey6DDEB907",
+                          "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3VersionKeyDE689547",
                         },
                       ],
                     },
@@ -19944,7 +19944,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291",
+                        "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75",
                       },
                     ],
                   ],
@@ -19959,7 +19959,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291",
+                        "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75",
                       },
                       "/*",
                     ],
@@ -20687,6 +20687,18 @@ Object {
       "Description": "S3 key for asset version \\"7412ee3c3ed97354b11100cb1f73e96631635318730a2733203b58c986337b81\\"",
       "Type": "String",
     },
+    "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eArtifactHash22EF1417": Object {
+      "Description": "Artifact hash for asset \\"78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3e\\"",
+      "Type": "String",
+    },
+    "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3Bucket3E098BA5": Object {
+      "Description": "S3 bucket for asset \\"78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3e\\"",
+      "Type": "String",
+    },
+    "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3VersionKeyAEA7FF0F": Object {
+      "Description": "S3 key for asset version \\"78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3e\\"",
+      "Type": "String",
+    },
     "AssetParameters7c158f248e4b8c4055bab463cf7161a06489f3c6b8cb338eaf1a3cdaeefa9bf5ArtifactHash191360E7": Object {
       "Description": "Artifact hash for asset \\"7c158f248e4b8c4055bab463cf7161a06489f3c6b8cb338eaf1a3cdaeefa9bf5\\"",
       "Type": "String",
@@ -20723,18 +20735,6 @@ Object {
       "Description": "S3 key for asset version \\"82fce0de1fd66c14056b03c8334213b6fd351f618d3db139501b43c1e27d9239\\"",
       "Type": "String",
     },
-    "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9ArtifactHash5CBB288C": Object {
-      "Description": "Artifact hash for asset \\"88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9\\"",
-      "Type": "String",
-    },
-    "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291": Object {
-      "Description": "S3 bucket for asset \\"88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9\\"",
-      "Type": "String",
-    },
-    "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3VersionKey6DDEB907": Object {
-      "Description": "S3 key for asset version \\"88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9\\"",
-      "Type": "String",
-    },
     "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900ArtifactHash121EF458": Object {
       "Description": "Artifact hash for asset \\"8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900\\"",
       "Type": "String",
@@ -20769,18 +20769,6 @@ Object {
     },
     "AssetParametersa06653c0fddc078791490ec0803bda19cf4effd0b9a7ecbb8b4ba1d52a74286bS3VersionKeyFEB3692B": Object {
       "Description": "S3 key for asset version \\"a06653c0fddc078791490ec0803bda19cf4effd0b9a7ecbb8b4ba1d52a74286b\\"",
-      "Type": "String",
-    },
-    "AssetParametersa081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7ebArtifactHash233CDC52": Object {
-      "Description": "Artifact hash for asset \\"a081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7eb\\"",
-      "Type": "String",
-    },
-    "AssetParametersa081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7ebS3Bucket365F97A0": Object {
-      "Description": "S3 bucket for asset \\"a081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7eb\\"",
-      "Type": "String",
-    },
-    "AssetParametersa081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7ebS3VersionKeyC005F9D4": Object {
-      "Description": "S3 key for asset version \\"a081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7eb\\"",
       "Type": "String",
     },
     "AssetParametersa3058ccb468d757ebb89df5363a1c20f5307c6911136f29d00e1a68c9b2aa7e8ArtifactHash238275D6": Object {
@@ -20865,6 +20853,18 @@ Object {
     },
     "AssetParametersec5ba82277d61b4c8f62eda97571cd57e350a84143f89d23270e8b9028d6f114S3VersionKey0F6A742F": Object {
       "Description": "S3 key for asset version \\"ec5ba82277d61b4c8f62eda97571cd57e350a84143f89d23270e8b9028d6f114\\"",
+      "Type": "String",
+    },
+    "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1ArtifactHash3D0E2730": Object {
+      "Description": "Artifact hash for asset \\"f18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1\\"",
+      "Type": "String",
+    },
+    "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75": Object {
+      "Description": "S3 bucket for asset \\"f18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1\\"",
+      "Type": "String",
+    },
+    "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3VersionKeyDE689547": Object {
+      "Description": "S3 key for asset version \\"f18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1\\"",
       "Type": "String",
     },
   },
@@ -22255,7 +22255,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersa081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7ebS3Bucket365F97A0",
+            "Ref": "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3Bucket3E098BA5",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -22268,7 +22268,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersa081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7ebS3VersionKeyC005F9D4",
+                          "Ref": "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3VersionKeyAEA7FF0F",
                         },
                       ],
                     },
@@ -22281,7 +22281,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersa081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7ebS3VersionKeyC005F9D4",
+                          "Ref": "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3VersionKeyAEA7FF0F",
                         },
                       ],
                     },
@@ -29259,7 +29259,7 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291",
+            "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75",
           },
         ],
         "SourceObjectKeys": Array [
@@ -29274,7 +29274,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3VersionKey6DDEB907",
+                          "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3VersionKeyDE689547",
                         },
                       ],
                     },
@@ -29287,7 +29287,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3VersionKey6DDEB907",
+                          "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3VersionKeyDE689547",
                         },
                       ],
                     },
@@ -29993,7 +29993,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291",
+                        "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75",
                       },
                     ],
                   ],
@@ -30008,7 +30008,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291",
+                        "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75",
                       },
                       "/*",
                     ],
@@ -30758,6 +30758,18 @@ Object {
       "Description": "S3 key for asset version \\"7412ee3c3ed97354b11100cb1f73e96631635318730a2733203b58c986337b81\\"",
       "Type": "String",
     },
+    "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eArtifactHash22EF1417": Object {
+      "Description": "Artifact hash for asset \\"78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3e\\"",
+      "Type": "String",
+    },
+    "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3Bucket3E098BA5": Object {
+      "Description": "S3 bucket for asset \\"78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3e\\"",
+      "Type": "String",
+    },
+    "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3VersionKeyAEA7FF0F": Object {
+      "Description": "S3 key for asset version \\"78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3e\\"",
+      "Type": "String",
+    },
     "AssetParameters7af6295e521fd55af94332393ceffb3e866aac4dc4956321f7918f21e72199e4ArtifactHash5E28809B": Object {
       "Description": "Artifact hash for asset \\"7af6295e521fd55af94332393ceffb3e866aac4dc4956321f7918f21e72199e4\\"",
       "Type": "String",
@@ -30806,18 +30818,6 @@ Object {
       "Description": "S3 key for asset version \\"82fce0de1fd66c14056b03c8334213b6fd351f618d3db139501b43c1e27d9239\\"",
       "Type": "String",
     },
-    "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9ArtifactHash5CBB288C": Object {
-      "Description": "Artifact hash for asset \\"88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9\\"",
-      "Type": "String",
-    },
-    "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291": Object {
-      "Description": "S3 bucket for asset \\"88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9\\"",
-      "Type": "String",
-    },
-    "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3VersionKey6DDEB907": Object {
-      "Description": "S3 key for asset version \\"88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9\\"",
-      "Type": "String",
-    },
     "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900ArtifactHash121EF458": Object {
       "Description": "Artifact hash for asset \\"8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900\\"",
       "Type": "String",
@@ -30852,18 +30852,6 @@ Object {
     },
     "AssetParametersa06653c0fddc078791490ec0803bda19cf4effd0b9a7ecbb8b4ba1d52a74286bS3VersionKeyFEB3692B": Object {
       "Description": "S3 key for asset version \\"a06653c0fddc078791490ec0803bda19cf4effd0b9a7ecbb8b4ba1d52a74286b\\"",
-      "Type": "String",
-    },
-    "AssetParametersa081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7ebArtifactHash233CDC52": Object {
-      "Description": "Artifact hash for asset \\"a081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7eb\\"",
-      "Type": "String",
-    },
-    "AssetParametersa081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7ebS3Bucket365F97A0": Object {
-      "Description": "S3 bucket for asset \\"a081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7eb\\"",
-      "Type": "String",
-    },
-    "AssetParametersa081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7ebS3VersionKeyC005F9D4": Object {
-      "Description": "S3 key for asset version \\"a081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7eb\\"",
       "Type": "String",
     },
     "AssetParametersa3058ccb468d757ebb89df5363a1c20f5307c6911136f29d00e1a68c9b2aa7e8ArtifactHash238275D6": Object {
@@ -30948,6 +30936,18 @@ Object {
     },
     "AssetParametersec5ba82277d61b4c8f62eda97571cd57e350a84143f89d23270e8b9028d6f114S3VersionKey0F6A742F": Object {
       "Description": "S3 key for asset version \\"ec5ba82277d61b4c8f62eda97571cd57e350a84143f89d23270e8b9028d6f114\\"",
+      "Type": "String",
+    },
+    "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1ArtifactHash3D0E2730": Object {
+      "Description": "Artifact hash for asset \\"f18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1\\"",
+      "Type": "String",
+    },
+    "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75": Object {
+      "Description": "S3 bucket for asset \\"f18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1\\"",
+      "Type": "String",
+    },
+    "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3VersionKeyDE689547": Object {
+      "Description": "S3 key for asset version \\"f18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1\\"",
       "Type": "String",
     },
   },
@@ -32487,7 +32487,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersa081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7ebS3Bucket365F97A0",
+            "Ref": "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3Bucket3E098BA5",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -32500,7 +32500,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersa081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7ebS3VersionKeyC005F9D4",
+                          "Ref": "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3VersionKeyAEA7FF0F",
                         },
                       ],
                     },
@@ -32513,7 +32513,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersa081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7ebS3VersionKeyC005F9D4",
+                          "Ref": "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3VersionKeyAEA7FF0F",
                         },
                       ],
                     },
@@ -39552,7 +39552,7 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291",
+            "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75",
           },
         ],
         "SourceObjectKeys": Array [
@@ -39567,7 +39567,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3VersionKey6DDEB907",
+                          "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3VersionKeyDE689547",
                         },
                       ],
                     },
@@ -39580,7 +39580,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3VersionKey6DDEB907",
+                          "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3VersionKeyDE689547",
                         },
                       ],
                     },
@@ -40513,7 +40513,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291",
+                        "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75",
                       },
                     ],
                   ],
@@ -40528,7 +40528,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291",
+                        "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75",
                       },
                       "/*",
                     ],
@@ -41268,6 +41268,18 @@ Object {
       "Description": "S3 key for asset version \\"7412ee3c3ed97354b11100cb1f73e96631635318730a2733203b58c986337b81\\"",
       "Type": "String",
     },
+    "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eArtifactHash22EF1417": Object {
+      "Description": "Artifact hash for asset \\"78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3e\\"",
+      "Type": "String",
+    },
+    "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3Bucket3E098BA5": Object {
+      "Description": "S3 bucket for asset \\"78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3e\\"",
+      "Type": "String",
+    },
+    "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3VersionKeyAEA7FF0F": Object {
+      "Description": "S3 key for asset version \\"78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3e\\"",
+      "Type": "String",
+    },
     "AssetParameters7c158f248e4b8c4055bab463cf7161a06489f3c6b8cb338eaf1a3cdaeefa9bf5ArtifactHash191360E7": Object {
       "Description": "Artifact hash for asset \\"7c158f248e4b8c4055bab463cf7161a06489f3c6b8cb338eaf1a3cdaeefa9bf5\\"",
       "Type": "String",
@@ -41304,18 +41316,6 @@ Object {
       "Description": "S3 key for asset version \\"82fce0de1fd66c14056b03c8334213b6fd351f618d3db139501b43c1e27d9239\\"",
       "Type": "String",
     },
-    "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9ArtifactHash5CBB288C": Object {
-      "Description": "Artifact hash for asset \\"88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9\\"",
-      "Type": "String",
-    },
-    "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291": Object {
-      "Description": "S3 bucket for asset \\"88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9\\"",
-      "Type": "String",
-    },
-    "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3VersionKey6DDEB907": Object {
-      "Description": "S3 key for asset version \\"88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9\\"",
-      "Type": "String",
-    },
     "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900ArtifactHash121EF458": Object {
       "Description": "Artifact hash for asset \\"8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900\\"",
       "Type": "String",
@@ -41350,18 +41350,6 @@ Object {
     },
     "AssetParametersa06653c0fddc078791490ec0803bda19cf4effd0b9a7ecbb8b4ba1d52a74286bS3VersionKeyFEB3692B": Object {
       "Description": "S3 key for asset version \\"a06653c0fddc078791490ec0803bda19cf4effd0b9a7ecbb8b4ba1d52a74286b\\"",
-      "Type": "String",
-    },
-    "AssetParametersa081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7ebArtifactHash233CDC52": Object {
-      "Description": "Artifact hash for asset \\"a081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7eb\\"",
-      "Type": "String",
-    },
-    "AssetParametersa081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7ebS3Bucket365F97A0": Object {
-      "Description": "S3 bucket for asset \\"a081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7eb\\"",
-      "Type": "String",
-    },
-    "AssetParametersa081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7ebS3VersionKeyC005F9D4": Object {
-      "Description": "S3 key for asset version \\"a081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7eb\\"",
       "Type": "String",
     },
     "AssetParametersa3058ccb468d757ebb89df5363a1c20f5307c6911136f29d00e1a68c9b2aa7e8ArtifactHash238275D6": Object {
@@ -41446,6 +41434,18 @@ Object {
     },
     "AssetParametersec5ba82277d61b4c8f62eda97571cd57e350a84143f89d23270e8b9028d6f114S3VersionKey0F6A742F": Object {
       "Description": "S3 key for asset version \\"ec5ba82277d61b4c8f62eda97571cd57e350a84143f89d23270e8b9028d6f114\\"",
+      "Type": "String",
+    },
+    "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1ArtifactHash3D0E2730": Object {
+      "Description": "Artifact hash for asset \\"f18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1\\"",
+      "Type": "String",
+    },
+    "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75": Object {
+      "Description": "S3 bucket for asset \\"f18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1\\"",
+      "Type": "String",
+    },
+    "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3VersionKeyDE689547": Object {
+      "Description": "S3 key for asset version \\"f18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1\\"",
       "Type": "String",
     },
   },
@@ -42945,7 +42945,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersa081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7ebS3Bucket365F97A0",
+            "Ref": "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3Bucket3E098BA5",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -42958,7 +42958,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersa081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7ebS3VersionKeyC005F9D4",
+                          "Ref": "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3VersionKeyAEA7FF0F",
                         },
                       ],
                     },
@@ -42971,7 +42971,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersa081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7ebS3VersionKeyC005F9D4",
+                          "Ref": "AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3VersionKeyAEA7FF0F",
                         },
                       ],
                     },
@@ -51472,7 +51472,7 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291",
+            "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75",
           },
         ],
         "SourceObjectKeys": Array [
@@ -51487,7 +51487,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3VersionKey6DDEB907",
+                          "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3VersionKeyDE689547",
                         },
                       ],
                     },
@@ -51500,7 +51500,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3VersionKey6DDEB907",
+                          "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3VersionKeyDE689547",
                         },
                       ],
                     },
@@ -52668,7 +52668,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291",
+                        "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75",
                       },
                     ],
                   ],
@@ -52683,7 +52683,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291",
+                        "Ref": "AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75",
                       },
                       "/*",
                     ],

--- a/src/__tests__/backend/ingestion/ingestion.lambda.test.ts
+++ b/src/__tests__/backend/ingestion/ingestion.lambda.test.ts
@@ -1865,14 +1865,18 @@ class FakeStream extends EventEmitter {
 }
 
 function assertAssembly(expected: string, actual: string | undefined) {
-  const expectedAssembly = JSON.parse(expected);
-  const actualAssembly = JSON.parse(actual ?? '{}');
+  const expectedAssembly: Assembly = JSON.parse(expected);
+  const actualAssembly: Assembly = JSON.parse(actual ?? '{}');
 
   // sanity: we have 2 types in the fake assembly
-  expect(Object.keys(expectedAssembly.types).length).toBe(2);
+  expect(expectedAssembly.types).toBeDefined();
+  expect(expectedAssembly.readme).toBeDefined();
+  expect(expectedAssembly.dependencyClosure).toBeDefined();
 
-  // service deletes "types" from the assembly to reduce size
+  // handler deletes these fields from the assembly to reduce size
   delete expectedAssembly.types;
+  delete expectedAssembly.readme;
+  delete expectedAssembly.dependencyClosure;
 
   expect(actualAssembly).toStrictEqual(expectedAssembly);
 }
@@ -1887,6 +1891,12 @@ function fakeAssembly(name: string, version: string, license: string): Assembly 
     repository: { url: 'ssh://localhost.fake/repository.git', type: 'git' },
     author: { name: 'ACME', email: 'test@acme', organization: true, roles: ['author'] },
     description: 'This is a fake package assembly',
+    readme: { markdown: 'Foo Bar ReadMe' },
+    dependencyClosure: {
+      'foo-boo': {
+        readme: { markdown: 'hey' },
+      },
+    },
     jsiiVersion: '0.0.0+head',
     fingerprint: 'NOPE',
     types: {

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -4037,7 +4037,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParametersa081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7ebS3Bucket365F97A0
+          Ref: AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3Bucket3E098BA5
         S3Key:
           Fn::Join:
             - ""
@@ -4045,12 +4045,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersa081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7ebS3VersionKeyC005F9D4
+                      - Ref: AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3VersionKeyAEA7FF0F
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersa081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7ebS3VersionKeyC005F9D4
+                      - Ref: AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3VersionKeyAEA7FF0F
       Role:
         Fn::GetAtt:
           - ConstructHubIngestionServiceRole6380BAB6
@@ -4841,7 +4841,7 @@ Resources:
           - CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536
           - Arn
       SourceBucketNames:
-        - Ref: AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291
+        - Ref: AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75
       SourceObjectKeys:
         - Fn::Join:
             - ""
@@ -4849,12 +4849,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3VersionKey6DDEB907
+                      - Ref: AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3VersionKeyDE689547
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3VersionKey6DDEB907
+                      - Ref: AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3VersionKeyDE689547
       DestinationBucketName:
         Ref: ConstructHubWebAppWebsiteBucket4B2B9DB2
       Prune: false
@@ -6527,13 +6527,13 @@ Resources:
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291
+                    - Ref: AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75
               - Fn::Join:
                   - ""
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291
+                    - Ref: AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75
                     - /*
           - Action:
               - s3:GetObject*
@@ -7186,18 +7186,18 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "b69f8e77829ba765ee3a37c088671f56d5982ab8e2a57c2f3103bea15181e67b"
-  AssetParametersa081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7ebS3Bucket365F97A0:
+  AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3Bucket3E098BA5:
     Type: String
     Description: S3 bucket for asset
-      "a081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7eb"
-  AssetParametersa081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7ebS3VersionKeyC005F9D4:
+      "78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3e"
+  AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3VersionKeyAEA7FF0F:
     Type: String
     Description: S3 key for asset version
-      "a081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7eb"
-  AssetParametersa081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7ebArtifactHash233CDC52:
+      "78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3e"
+  AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eArtifactHash22EF1417:
     Type: String
     Description: Artifact hash for asset
-      "a081b67b87124b85f46cd17382d0fb9a04917b3eb8529396b928f4ae2d79d7eb"
+      "78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3e"
   AssetParameters6539334465145d138a2ca35862ccb798cddf768799e264b5ec811f9b33c18c3cS3Bucket674182B9:
     Type: String
     Description: S3 bucket for asset
@@ -7222,18 +7222,18 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900"
-  AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291:
+  AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75:
     Type: String
     Description: S3 bucket for asset
-      "88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9"
-  AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3VersionKey6DDEB907:
+      "f18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1"
+  AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3VersionKeyDE689547:
     Type: String
     Description: S3 key for asset version
-      "88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9"
-  AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9ArtifactHash5CBB288C:
+      "f18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1"
+  AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1ArtifactHash3D0E2730:
     Type: String
     Description: Artifact hash for asset
-      "88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9"
+      "f18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1"
   AssetParameters43fbac1b0c0d0299f39ad46ea91bbec840fe10d899a884e06a8a89a9c87987adS3Bucket118915A9:
     Type: String
     Description: S3 bucket for asset

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -4037,7 +4037,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3Bucket3E098BA5
+          Ref: AssetParameters36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337fS3BucketC24BE0E2
         S3Key:
           Fn::Join:
             - ""
@@ -4045,12 +4045,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3VersionKeyAEA7FF0F
+                      - Ref: AssetParameters36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337fS3VersionKey6F60C4B3
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3VersionKeyAEA7FF0F
+                      - Ref: AssetParameters36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337fS3VersionKey6F60C4B3
       Role:
         Fn::GetAtt:
           - ConstructHubIngestionServiceRole6380BAB6
@@ -4841,7 +4841,7 @@ Resources:
           - CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536
           - Arn
       SourceBucketNames:
-        - Ref: AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75
+        - Ref: AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291
       SourceObjectKeys:
         - Fn::Join:
             - ""
@@ -4849,12 +4849,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3VersionKeyDE689547
+                      - Ref: AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3VersionKey6DDEB907
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3VersionKeyDE689547
+                      - Ref: AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3VersionKey6DDEB907
       DestinationBucketName:
         Ref: ConstructHubWebAppWebsiteBucket4B2B9DB2
       Prune: false
@@ -6527,13 +6527,13 @@ Resources:
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75
+                    - Ref: AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291
               - Fn::Join:
                   - ""
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75
+                    - Ref: AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291
                     - /*
           - Action:
               - s3:GetObject*
@@ -7186,18 +7186,18 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "b69f8e77829ba765ee3a37c088671f56d5982ab8e2a57c2f3103bea15181e67b"
-  AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3Bucket3E098BA5:
+  AssetParameters36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337fS3BucketC24BE0E2:
     Type: String
     Description: S3 bucket for asset
-      "78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3e"
-  AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eS3VersionKeyAEA7FF0F:
+      "36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337f"
+  AssetParameters36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337fS3VersionKey6F60C4B3:
     Type: String
     Description: S3 key for asset version
-      "78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3e"
-  AssetParameters78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3eArtifactHash22EF1417:
+      "36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337f"
+  AssetParameters36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337fArtifactHash1B9B2A76:
     Type: String
     Description: Artifact hash for asset
-      "78d1dffcacc4c3537cde7e30358314cd46c5a00ea14efb377c6138f35ab30e3e"
+      "36fdff7194ab7151b2c9746ada7c14f23c6458aae01f87fd1ed875481b7d337f"
   AssetParameters6539334465145d138a2ca35862ccb798cddf768799e264b5ec811f9b33c18c3cS3Bucket674182B9:
     Type: String
     Description: S3 bucket for asset
@@ -7222,18 +7222,18 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900"
-  AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3BucketC5665D75:
+  AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3Bucket15CC8291:
     Type: String
     Description: S3 bucket for asset
-      "f18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1"
-  AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1S3VersionKeyDE689547:
+      "88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9"
+  AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9S3VersionKey6DDEB907:
     Type: String
     Description: S3 key for asset version
-      "f18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1"
-  AssetParametersf18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1ArtifactHash3D0E2730:
+      "88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9"
+  AssetParameters88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9ArtifactHash5CBB288C:
     Type: String
     Description: Artifact hash for asset
-      "f18a713b43ae97178f0b9d01469e67337e7d8bd54a5ad25277658255bfce38f1"
+      "88e103c5171dd777f50a9c96aaa39bc91bb572e9340528e8dc4329e6e1a915b9"
   AssetParameters43fbac1b0c0d0299f39ad46ea91bbec840fe10d899a884e06a8a89a9c87987adS3Bucket118915A9:
     Type: String
     Description: S3 bucket for asset

--- a/src/backend/ingestion/ingestion.lambda.ts
+++ b/src/backend/ingestion/ingestion.lambda.ts
@@ -101,15 +101,19 @@ export const handler = metricScope(
       try {
         parsedAssembly = validateAssembly(JSON.parse(dotJsii.toString('utf-8')));
 
-        // "types" is huge and not needed downstream because doc generation happens in the backend,
-        // so we drop it. See https://github.com/cdklabs/construct-hub-webapp/issues/691
-        delete parsedAssembly.types;
-
+        // needs `dependencyClosure`
         constructFramework = detectConstructFramework(parsedAssembly);
         const { license, name, version } = parsedAssembly;
         packageLicense = license;
         packageName = name;
         packageVersion = version;
+
+        // Delete some fields not used by the client to reduce the size of the assembly.
+        // See https://github.com/cdklabs/construct-hub-webapp/issues/691
+        delete parsedAssembly.types;
+        delete parsedAssembly.readme;
+        delete parsedAssembly.dependencyClosure;
+
         metrics.putMetric(MetricName.INVALID_ASSEMBLY, 0, Unit.Count);
       } catch (ex) {
         console.error(


### PR DESCRIPTION
As a follow up to #567, delete additional large fields from `assembly.json` that are not used by the client. Namely: `readme` and `dependencyClosure`.

Related to cdklabs/construct-hub-webapp#691


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*