### PR TITLE
feat: package canary triggers high severity alarm

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ new ConstructHub(stack, 'ConstructHub', {
 ```
 
 In case the new package isn't fully available in the predefined SLA, a
-**low severity** CloudWatch alarm will trigger, which will in turn trigger
+**high severity** CloudWatch alarm will trigger, which will in turn trigger
 the configured action for low severity alarms.
 
 > See [Monitoring & Alarms](./docs/application-overview.md#monitoring--alarming)

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -3432,7 +3432,18 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":54,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Inventory Canary is not Running\\",\\"region\\":\\"",
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":54,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"New version visibility SLA breached\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ConstructHubSourcesNpmJsCanaryAlarmBE2B479E",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":60,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Inventory Canary is not Running\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -3443,7 +3454,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":60,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Inventory Canary is failing\\",\\"region\\":\\"",
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":66,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Inventory Canary is failing\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -7316,6 +7327,9 @@ Direct link to Lambda function: /lambda/home#/functions/",
         "ConstructHubLicenseListCustomResource323F0FD4",
       ],
       "Properties": Object {
+        "AlarmActions": Array [
+          "arn:aws:sns:us-east-1:123456789012:mystack-mytopic-NZJ5JSMVGFIE",
+        ],
         "AlarmDescription": "New versions of construct-hub-probe have been published over 5 minutes ago and are still not visible in construct hub
 Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md",
         "AlarmName": "Test/ConstructHub/Sources/NpmJs/Canary/SLA-Breached",
@@ -13880,7 +13894,18 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":54,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Inventory Canary is not Running\\",\\"region\\":\\"",
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":54,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"New version visibility SLA breached\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ConstructHubSourcesNpmJsCanaryAlarmBE2B479E",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":60,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Inventory Canary is not Running\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -13891,7 +13916,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":60,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Inventory Canary is failing\\",\\"region\\":\\"",
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":66,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Inventory Canary is failing\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -17837,6 +17862,9 @@ Direct link to Lambda function: /lambda/home#/functions/",
         "ConstructHubLicenseListCustomResource323F0FD4",
       ],
       "Properties": Object {
+        "AlarmActions": Array [
+          "arn:aws:sns:us-east-1:123456789012:mystack-mytopic-NZJ5JSMVGFIE",
+        ],
         "AlarmDescription": "New versions of construct-hub-probe have been published over 5 minutes ago and are still not visible in construct hub
 Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md",
         "AlarmName": "Test/ConstructHub/Sources/NpmJs/Canary/SLA-Breached",
@@ -24002,7 +24030,18 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":54,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Inventory Canary is not Running\\",\\"region\\":\\"",
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":54,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"New version visibility SLA breached\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ConstructHubSourcesNpmJsCanaryAlarmBE2B479E",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":60,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Inventory Canary is not Running\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -24013,7 +24052,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":60,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Inventory Canary is failing\\",\\"region\\":\\"",
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":66,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Inventory Canary is failing\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -27886,6 +27925,9 @@ Direct link to Lambda function: /lambda/home#/functions/",
         "ConstructHubLicenseListCustomResource323F0FD4",
       ],
       "Properties": Object {
+        "AlarmActions": Array [
+          "arn:aws:sns:us-east-1:123456789012:mystack-mytopic-NZJ5JSMVGFIE",
+        ],
         "AlarmDescription": "New versions of construct-hub-probe have been published over 5 minutes ago and are still not visible in construct hub
 Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md",
         "AlarmName": "Test/ConstructHub/Sources/NpmJs/Canary/SLA-Breached",
@@ -34256,7 +34298,18 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":66,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Inventory Canary is not Running\\",\\"region\\":\\"",
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":66,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"New version visibility SLA breached\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ConstructHubSourcesNpmJsCanaryAlarmBE2B479E",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":72,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Inventory Canary is not Running\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -34267,7 +34320,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":72,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Inventory Canary is failing\\",\\"region\\":\\"",
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":78,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Inventory Canary is failing\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -38127,6 +38180,9 @@ Direct link to Lambda function: /lambda/home#/functions/",
         "ConstructHubLicenseListCustomResource323F0FD4",
       ],
       "Properties": Object {
+        "AlarmActions": Array [
+          "arn:aws:sns:us-east-1:123456789012:mystack-mytopic-NZJ5JSMVGFIE",
+        ],
         "AlarmDescription": "New versions of construct-hub-probe have been published over 5 minutes ago and are still not visible in construct hub
 Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md",
         "AlarmName": "Test/ConstructHub/Sources/NpmJs/Canary/SLA-Breached",
@@ -44818,7 +44874,18 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":54,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Inventory Canary is not Running\\",\\"region\\":\\"",
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":54,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"New version visibility SLA breached\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ConstructHubSourcesNpmJsCanaryAlarmBE2B479E",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":60,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Inventory Canary is not Running\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -44829,7 +44896,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":60,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Inventory Canary is failing\\",\\"region\\":\\"",
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":66,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Inventory Canary is failing\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -48393,6 +48460,9 @@ Direct link to Lambda function: /lambda/home#/functions/",
         "ConstructHubLicenseListCustomResource323F0FD4",
       ],
       "Properties": Object {
+        "AlarmActions": Array [
+          "arn:aws:sns:us-east-1:123456789012:mystack-mytopic-NZJ5JSMVGFIE",
+        ],
         "AlarmDescription": "New versions of construct-hub-probe have been published over 5 minutes ago and are still not visible in construct hub
 Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md",
         "AlarmName": "Test/ConstructHub/Sources/NpmJs/Canary/SLA-Breached",

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -252,14 +252,21 @@ Resources:
             - Fn::GetAtt:
                 - ConstructHubSourcesdevConstructHubSourcesNpmJsStagerDLQNotEmpty3777A4EA
                 - Arn
-            - '"]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":54,"properties":{"view":"timeSeries","title":"Inventory
+            - '"]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":54,"properties":{"view":"timeSeries","title":"New
+              version visibility SLA breached","region":"'
+            - Ref: AWS::Region
+            - '","annotations":{"alarms":["'
+            - Fn::GetAtt:
+                - ConstructHubSourcesNpmJsCanaryAlarmBE2B479E
+                - Arn
+            - '"]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":60,"properties":{"view":"timeSeries","title":"Inventory
               Canary is not Running","region":"'
             - Ref: AWS::Region
             - '","annotations":{"alarms":["'
             - Fn::GetAtt:
                 - ConstructHubInventoryCanaryNotRunningAF44D71C
                 - Arn
-            - '"]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":60,"properties":{"view":"timeSeries","title":"Inventory
+            - '"]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":66,"properties":{"view":"timeSeries","title":"Inventory
               Canary is failing","region":"'
             - Ref: AWS::Region
             - '","annotations":{"alarms":["'

--- a/src/package-sources/npmjs.ts
+++ b/src/package-sources/npmjs.ts
@@ -445,7 +445,7 @@ export class NpmJs implements IPackageSource {
       treatMissingData: TreatMissingData.BREACHING,
       threshold: visibilitySla.toSeconds(),
     });
-    monitoring.addLowSeverityAlarm('New version visibility SLA breached', alarm);
+    monitoring.addHighSeverityAlarm('New version visibility SLA breached', alarm);
 
     return [
       new GraphWidget({


### PR DESCRIPTION
We initially triggered low severity alarms to gain confidence in the alarm without creating too much noise. 

Now, we apply the correct severity for this alarm as it indicates a either a malfunctioning pipeline or CloudFront distribution. 

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*