### PR TITLE
fix: unable to deploy updated IP allow-lists

### DIFF
--- a/src/__tests__/__snapshots__/_limited-internet-access.test.ts.snap
+++ b/src/__tests__/__snapshots__/_limited-internet-access.test.ts.snap
@@ -791,21 +791,6 @@ Object {
       },
       "Type": "AWS::EC2::VPCGatewayAttachment",
     },
-    "cloudflareIPv408A0FEE4": Object {
-      "Properties": Object {
-        "GroupDescription": "TestStack/cloudflare-IPv4",
-        "Tags": Array [
-          Object {
-            "Key": "Name",
-            "Value": "cloudflare.IPv4",
-          },
-        ],
-        "VpcId": Object {
-          "Ref": "VPCB9E5F0B4",
-        },
-      },
-      "Type": "AWS::EC2::SecurityGroup",
-    },
     "cloudflareIPv4c2cf61493c41a0c1519c61e5aad250b74ec16388": Object {
       "Properties": Object {
         "AddressFamily": "IPv4",
@@ -861,7 +846,22 @@ Object {
       },
       "Type": "AWS::EC2::PrefixList",
     },
-    "cloudflareIPv4toTestStackcloudflareIPv4c2cf61493c41a0c1519c61e5aad250b74ec163884434980EDAB": Object {
+    "cloudflareIPv4c2cf61493c41a0c1519c61e5aad250b74ec16388D0AFA17A": Object {
+      "Properties": Object {
+        "GroupDescription": "TestStack/cloudflare-IPv4",
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "cloudflare.IPv4",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "VPCB9E5F0B4",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "cloudflareIPv4c2cf61493c41a0c1519c61e5aad250b74ec16388toTestStackcloudflareIPv4c2cf61493c41a0c1519c61e5aad250b74ec163884432973C5B9": Object {
       "Properties": Object {
         "Description": "to cloudflare (IPv4)",
         "DestinationPrefixListId": Object {
@@ -873,7 +873,7 @@ Object {
         "FromPort": 443,
         "GroupId": Object {
           "Fn::GetAtt": Array [
-            "cloudflareIPv408A0FEE4",
+            "cloudflareIPv4c2cf61493c41a0c1519c61e5aad250b74ec16388D0AFA17A",
             "GroupId",
           ],
         },
@@ -881,21 +881,6 @@ Object {
         "ToPort": 443,
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
-    },
-    "githubgitIPv454D2EFF8": Object {
-      "Properties": Object {
-        "GroupDescription": "TestStack/github.git-IPv4",
-        "Tags": Array [
-          Object {
-            "Key": "Name",
-            "Value": "github.git.IPv4",
-          },
-        ],
-        "VpcId": Object {
-          "Ref": "VPCB9E5F0B4",
-        },
-      },
-      "Type": "AWS::EC2::SecurityGroup",
     },
     "githubgitIPv4b08084c572c0b5ff4dd2b9f42c0c0386b35abd6d": Object {
       "Properties": Object {
@@ -997,7 +982,22 @@ Object {
       },
       "Type": "AWS::EC2::PrefixList",
     },
-    "githubgitIPv4toTestStackgithubgitIPv4b08084c572c0b5ff4dd2b9f42c0c0386b35abd6d443CC366A5A": Object {
+    "githubgitIPv4b08084c572c0b5ff4dd2b9f42c0c0386b35abd6dA1E32585": Object {
+      "Properties": Object {
+        "GroupDescription": "TestStack/github.git-IPv4",
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "github.git.IPv4",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "VPCB9E5F0B4",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "githubgitIPv4b08084c572c0b5ff4dd2b9f42c0c0386b35abd6dtoTestStackgithubgitIPv4b08084c572c0b5ff4dd2b9f42c0c0386b35abd6d4435A75B4DA": Object {
       "Properties": Object {
         "Description": "to github.git (IPv4)",
         "DestinationPrefixListId": Object {
@@ -1009,7 +1009,7 @@ Object {
         "FromPort": 443,
         "GroupId": Object {
           "Fn::GetAtt": Array [
-            "githubgitIPv454D2EFF8",
+            "githubgitIPv4b08084c572c0b5ff4dd2b9f42c0c0386b35abd6dA1E32585",
             "GroupId",
           ],
         },
@@ -1079,7 +1079,7 @@ Object {
       },
       "Type": "AWS::EC2::PrefixList",
     },
-    "githubwebIPv4BCE4F6B8": Object {
+    "githubwebIPv49b292faed277d68adffe79e317cbcff49762581aED35DB49": Object {
       "Properties": Object {
         "GroupDescription": "TestStack/github.web-IPv4",
         "Tags": Array [
@@ -1094,7 +1094,7 @@ Object {
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
-    "githubwebIPv4toTestStackgithubwebIPv49b292faed277d68adffe79e317cbcff49762581a443A1798199": Object {
+    "githubwebIPv49b292faed277d68adffe79e317cbcff49762581atoTestStackgithubwebIPv49b292faed277d68adffe79e317cbcff49762581a44397D88D6F": Object {
       "Properties": Object {
         "Description": "to github.web (IPv4)",
         "DestinationPrefixListId": Object {
@@ -1106,7 +1106,7 @@ Object {
         "FromPort": 443,
         "GroupId": Object {
           "Fn::GetAtt": Array [
-            "githubwebIPv4BCE4F6B8",
+            "githubwebIPv49b292faed277d68adffe79e317cbcff49762581aED35DB49",
             "GroupId",
           ],
         },

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -48796,21 +48796,21 @@ Direct link to function: /lambda/home#/functions/",
               "\\",\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ConstructHubcloudflareIPv4232AD0EA",
+                  "ConstructHubcloudflareIPv4c2cf61493c41a0c1519c61e5aad250b74ec16388066AC9B4",
                   "GroupId",
                 ],
               },
               "\\",\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ConstructHubgithubgitIPv4225A5F0E",
+                  "ConstructHubgithubgitIPv4b08084c572c0b5ff4dd2b9f42c0c0386b35abd6dAAE47857",
                   "GroupId",
                 ],
               },
               "\\",\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ConstructHubgithubwebIPv4DFDA57C5",
+                  "ConstructHubgithubwebIPv49b292faed277d68adffe79e317cbcff49762581a063DBAB2",
                   "GroupId",
                 ],
               },
@@ -53165,19 +53165,19 @@ Direct link to Lambda function: /lambda/home#/functions/",
           },
           Object {
             "Fn::GetAtt": Array [
-              "ConstructHubcloudflareIPv4232AD0EA",
+              "ConstructHubcloudflareIPv4c2cf61493c41a0c1519c61e5aad250b74ec16388066AC9B4",
               "GroupId",
             ],
           },
           Object {
             "Fn::GetAtt": Array [
-              "ConstructHubgithubgitIPv4225A5F0E",
+              "ConstructHubgithubgitIPv4b08084c572c0b5ff4dd2b9f42c0c0386b35abd6dAAE47857",
               "GroupId",
             ],
           },
           Object {
             "Fn::GetAtt": Array [
-              "ConstructHubgithubwebIPv4DFDA57C5",
+              "ConstructHubgithubwebIPv49b292faed277d68adffe79e317cbcff49762581a063DBAB2",
               "GroupId",
             ],
           },
@@ -53240,19 +53240,19 @@ Direct link to Lambda function: /lambda/home#/functions/",
           },
           Object {
             "Fn::GetAtt": Array [
-              "ConstructHubcloudflareIPv4232AD0EA",
+              "ConstructHubcloudflareIPv4c2cf61493c41a0c1519c61e5aad250b74ec16388066AC9B4",
               "GroupId",
             ],
           },
           Object {
             "Fn::GetAtt": Array [
-              "ConstructHubgithubgitIPv4225A5F0E",
+              "ConstructHubgithubgitIPv4b08084c572c0b5ff4dd2b9f42c0c0386b35abd6dAAE47857",
               "GroupId",
             ],
           },
           Object {
             "Fn::GetAtt": Array [
-              "ConstructHubgithubwebIPv4DFDA57C5",
+              "ConstructHubgithubwebIPv49b292faed277d68adffe79e317cbcff49762581a063DBAB2",
               "GroupId",
             ],
           },
@@ -53338,19 +53338,19 @@ Direct link to Lambda function: /lambda/home#/functions/",
           },
           Object {
             "Fn::GetAtt": Array [
-              "ConstructHubcloudflareIPv4232AD0EA",
+              "ConstructHubcloudflareIPv4c2cf61493c41a0c1519c61e5aad250b74ec16388066AC9B4",
               "GroupId",
             ],
           },
           Object {
             "Fn::GetAtt": Array [
-              "ConstructHubgithubgitIPv4225A5F0E",
+              "ConstructHubgithubgitIPv4b08084c572c0b5ff4dd2b9f42c0c0386b35abd6dAAE47857",
               "GroupId",
             ],
           },
           Object {
             "Fn::GetAtt": Array [
-              "ConstructHubgithubwebIPv4DFDA57C5",
+              "ConstructHubgithubwebIPv49b292faed277d68adffe79e317cbcff49762581a063DBAB2",
               "GroupId",
             ],
           },
@@ -54908,19 +54908,19 @@ Direct link to Lambda function: /lambda/home#/functions/",
           },
           Object {
             "Fn::GetAtt": Array [
-              "ConstructHubcloudflareIPv4232AD0EA",
+              "ConstructHubcloudflareIPv4c2cf61493c41a0c1519c61e5aad250b74ec16388066AC9B4",
               "GroupId",
             ],
           },
           Object {
             "Fn::GetAtt": Array [
-              "ConstructHubgithubgitIPv4225A5F0E",
+              "ConstructHubgithubgitIPv4b08084c572c0b5ff4dd2b9f42c0c0386b35abd6dAAE47857",
               "GroupId",
             ],
           },
           Object {
             "Fn::GetAtt": Array [
-              "ConstructHubgithubwebIPv4DFDA57C5",
+              "ConstructHubgithubwebIPv49b292faed277d68adffe79e317cbcff49762581a063DBAB2",
               "GroupId",
             ],
           },
@@ -55519,7 +55519,7 @@ function handler(event) {
       },
       "Type": "AWS::S3::BucketPolicy",
     },
-    "ConstructHubcloudflareIPv4232AD0EA": Object {
+    "ConstructHubcloudflareIPv4c2cf61493c41a0c1519c61e5aad250b74ec16388066AC9B4": Object {
       "Properties": Object {
         "GroupDescription": "Test/ConstructHub/cloudflare-IPv4",
         "SecurityGroupIngress": Array [
@@ -55617,7 +55617,7 @@ function handler(event) {
       },
       "Type": "AWS::EC2::PrefixList",
     },
-    "ConstructHubcloudflareIPv4toTestConstructHubcloudflareIPv4c2cf61493c41a0c1519c61e5aad250b74ec16388443540911A0": Object {
+    "ConstructHubcloudflareIPv4c2cf61493c41a0c1519c61e5aad250b74ec16388toTestConstructHubcloudflareIPv4c2cf61493c41a0c1519c61e5aad250b74ec16388443BC06895C": Object {
       "Properties": Object {
         "Description": "to cloudflare (IPv4)",
         "DestinationPrefixListId": Object {
@@ -55629,7 +55629,7 @@ function handler(event) {
         "FromPort": 443,
         "GroupId": Object {
           "Fn::GetAtt": Array [
-            "ConstructHubcloudflareIPv4232AD0EA",
+            "ConstructHubcloudflareIPv4c2cf61493c41a0c1519c61e5aad250b74ec16388066AC9B4",
             "GroupId",
           ],
         },
@@ -55637,49 +55637,6 @@ function handler(event) {
         "ToPort": 443,
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
-    },
-    "ConstructHubgithubgitIPv4225A5F0E": Object {
-      "Properties": Object {
-        "GroupDescription": "Test/ConstructHub/github.git-IPv4",
-        "SecurityGroupIngress": Array [
-          Object {
-            "CidrIp": Object {
-              "Fn::GetAtt": Array [
-                "ConstructHubVPC16ECCEA2",
-                "CidrBlock",
-              ],
-            },
-            "Description": Object {
-              "Fn::Join": Array [
-                "",
-                Array [
-                  "from ",
-                  Object {
-                    "Fn::GetAtt": Array [
-                      "ConstructHubVPC16ECCEA2",
-                      "CidrBlock",
-                    ],
-                  },
-                  ":443",
-                ],
-              ],
-            },
-            "FromPort": 443,
-            "IpProtocol": "tcp",
-            "ToPort": 443,
-          },
-        ],
-        "Tags": Array [
-          Object {
-            "Key": "Name",
-            "Value": "github.git.IPv4",
-          },
-        ],
-        "VpcId": Object {
-          "Ref": "ConstructHubVPC16ECCEA2",
-        },
-      },
-      "Type": "AWS::EC2::SecurityGroup",
     },
     "ConstructHubgithubgitIPv4b08084c572c0b5ff4dd2b9f42c0c0386b35abd6d7EF35713": Object {
       "Properties": Object {
@@ -55781,7 +55738,50 @@ function handler(event) {
       },
       "Type": "AWS::EC2::PrefixList",
     },
-    "ConstructHubgithubgitIPv4toTestConstructHubgithubgitIPv4b08084c572c0b5ff4dd2b9f42c0c0386b35abd6d443CF18F4C4": Object {
+    "ConstructHubgithubgitIPv4b08084c572c0b5ff4dd2b9f42c0c0386b35abd6dAAE47857": Object {
+      "Properties": Object {
+        "GroupDescription": "Test/ConstructHub/github.git-IPv4",
+        "SecurityGroupIngress": Array [
+          Object {
+            "CidrIp": Object {
+              "Fn::GetAtt": Array [
+                "ConstructHubVPC16ECCEA2",
+                "CidrBlock",
+              ],
+            },
+            "Description": Object {
+              "Fn::Join": Array [
+                "",
+                Array [
+                  "from ",
+                  Object {
+                    "Fn::GetAtt": Array [
+                      "ConstructHubVPC16ECCEA2",
+                      "CidrBlock",
+                    ],
+                  },
+                  ":443",
+                ],
+              ],
+            },
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "github.git.IPv4",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "ConstructHubVPC16ECCEA2",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "ConstructHubgithubgitIPv4b08084c572c0b5ff4dd2b9f42c0c0386b35abd6dtoTestConstructHubgithubgitIPv4b08084c572c0b5ff4dd2b9f42c0c0386b35abd6d4439207512F": Object {
       "Properties": Object {
         "Description": "to github.git (IPv4)",
         "DestinationPrefixListId": Object {
@@ -55793,7 +55793,7 @@ function handler(event) {
         "FromPort": 443,
         "GroupId": Object {
           "Fn::GetAtt": Array [
-            "ConstructHubgithubgitIPv4225A5F0E",
+            "ConstructHubgithubgitIPv4b08084c572c0b5ff4dd2b9f42c0c0386b35abd6dAAE47857",
             "GroupId",
           ],
         },
@@ -55801,6 +55801,49 @@ function handler(event) {
         "ToPort": 443,
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
+    },
+    "ConstructHubgithubwebIPv49b292faed277d68adffe79e317cbcff49762581a063DBAB2": Object {
+      "Properties": Object {
+        "GroupDescription": "Test/ConstructHub/github.web-IPv4",
+        "SecurityGroupIngress": Array [
+          Object {
+            "CidrIp": Object {
+              "Fn::GetAtt": Array [
+                "ConstructHubVPC16ECCEA2",
+                "CidrBlock",
+              ],
+            },
+            "Description": Object {
+              "Fn::Join": Array [
+                "",
+                Array [
+                  "from ",
+                  Object {
+                    "Fn::GetAtt": Array [
+                      "ConstructHubVPC16ECCEA2",
+                      "CidrBlock",
+                    ],
+                  },
+                  ":443",
+                ],
+              ],
+            },
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "github.web.IPv4",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "ConstructHubVPC16ECCEA2",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
     },
     "ConstructHubgithubwebIPv49b292faed277d68adffe79e317cbcff49762581a2E205F15": Object {
       "Properties": Object {
@@ -55863,50 +55906,7 @@ function handler(event) {
       },
       "Type": "AWS::EC2::PrefixList",
     },
-    "ConstructHubgithubwebIPv4DFDA57C5": Object {
-      "Properties": Object {
-        "GroupDescription": "Test/ConstructHub/github.web-IPv4",
-        "SecurityGroupIngress": Array [
-          Object {
-            "CidrIp": Object {
-              "Fn::GetAtt": Array [
-                "ConstructHubVPC16ECCEA2",
-                "CidrBlock",
-              ],
-            },
-            "Description": Object {
-              "Fn::Join": Array [
-                "",
-                Array [
-                  "from ",
-                  Object {
-                    "Fn::GetAtt": Array [
-                      "ConstructHubVPC16ECCEA2",
-                      "CidrBlock",
-                    ],
-                  },
-                  ":443",
-                ],
-              ],
-            },
-            "FromPort": 443,
-            "IpProtocol": "tcp",
-            "ToPort": 443,
-          },
-        ],
-        "Tags": Array [
-          Object {
-            "Key": "Name",
-            "Value": "github.web.IPv4",
-          },
-        ],
-        "VpcId": Object {
-          "Ref": "ConstructHubVPC16ECCEA2",
-        },
-      },
-      "Type": "AWS::EC2::SecurityGroup",
-    },
-    "ConstructHubgithubwebIPv4toTestConstructHubgithubwebIPv49b292faed277d68adffe79e317cbcff49762581a443F3482608": Object {
+    "ConstructHubgithubwebIPv49b292faed277d68adffe79e317cbcff49762581atoTestConstructHubgithubwebIPv49b292faed277d68adffe79e317cbcff49762581a443065213F2": Object {
       "Properties": Object {
         "Description": "to github.web (IPv4)",
         "DestinationPrefixListId": Object {
@@ -55918,7 +55918,7 @@ function handler(event) {
         "FromPort": 443,
         "GroupId": Object {
           "Fn::GetAtt": Array [
-            "ConstructHubgithubwebIPv4DFDA57C5",
+            "ConstructHubgithubwebIPv49b292faed277d68adffe79e317cbcff49762581a063DBAB2",
             "GroupId",
           ],
         },

--- a/src/_limited-internet-access.ts
+++ b/src/_limited-internet-access.ts
@@ -58,10 +58,16 @@ export function createRestrictedSecurityGroups(scope: Construct, vpc: IVpc): ISe
       entries,
       maxEntries: entries.length,
     });
-    const id = `${namespace}-${ipLabel}`;
-    const sg = new SecurityGroup(scope, id, {
+    // Note: the CfnPrefixList above uses a `.` separator bewteen namespace and
+    // ipLabel, since we use a `-` here, we are not colliding. The has is used
+    // here to replace the SG when the PL is updated. Failure to do so may
+    // result in the SG having both the old & updated PLs in its rule set until
+    // the CloudFormation clean-up phase completes, which might exceed the
+    // maximum amount of rules allowed on a SG.
+    const descr = `${namespace}-${ipLabel}`;
+    const sg = new SecurityGroup(scope, `${descr}#${hash}`, {
       allowAllOutbound: false,
-      description: `${scope.node.path}/${id}`,
+      description: `${scope.node.path}/${descr}`,
       vpc,
     });
 


### PR DESCRIPTION
We have provisions to cause the `CfnPrefixList` resource to be replaced
when its allow-list changes (the CIDR range capacity of `CfnPrefixList`
cannot be updated once it's deployed).

Due to how SecurityGroup in-/e-gress rules are managed by CDK, this
means the SecurityGroup that uses a `CfnPrefixList` will first be
updated by CloudFormation to add the new `CfnPrefixList` reference, and
during `CLEAN_UP`, the outdated list will be removed. This has the
potential of exceeding SecurityGroup rule count limits relatively
easily.

In order to address this problem, this causes the SecurityGroup to be
replaced whenever the `CfnPrefixList` gets replaced. As the
SecurityGroups are only used by Fargate task definitions, this will
cause a new revision of the task definition to be created, and will
hence not risk hitting the maximum number of SecurityGroups bound to a
network interface.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*