### PR TITLE
feat: support preloadScript

### DIFF
--- a/API.md
+++ b/API.md
@@ -358,6 +358,7 @@ const constructHubProps: ConstructHubProps = { ... }
 | [`packageLinks`](#constructhubconstructhubpropspropertypackagelinks) | [`construct-hub.PackageLinkConfig`](#construct-hub.PackageLinkConfig)[] | Configuration for custom package page links. |
 | [`packageSources`](#constructhubconstructhubpropspropertypackagesources) | [`construct-hub.IPackageSource`](#construct-hub.IPackageSource)[] | The package sources to register with this ConstructHub instance. |
 | [`packageTags`](#constructhubconstructhubpropspropertypackagetags) | [`construct-hub.PackageTag`](#construct-hub.PackageTag)[] | Configuration for custom package tags. |
+| [`preloadScript`](#constructhubconstructhubpropspropertypreloadscript) | `string` | Defines source code for a preload.js script inserted at the top of the <head /> of the webapp. |
 | [`reprocessFrequency`](#constructhubconstructhubpropspropertyreprocessfrequency) | [`@aws-cdk/core.Duration`](#@aws-cdk/core.Duration) | How frequently all packages should get fully reprocessed. |
 | [`sensitiveTaskIsolation`](#constructhubconstructhubpropspropertysensitivetaskisolation) | [`construct-hub.Isolation`](#construct-hub.Isolation) | Whether compute environments for sensitive tasks (which operate on un-trusted complex data, such as the transliterator, which operates with externally-sourced npm package tarballs) should run in network-isolated environments. |
 
@@ -584,6 +585,18 @@ public readonly packageTags: PackageTag[];
 - *Type:* [`construct-hub.PackageTag`](#construct-hub.PackageTag)[]
 
 Configuration for custom package tags.
+
+---
+
+##### `preloadScript`<sup>Optional</sup> <a name="construct-hub.ConstructHubProps.property.preloadScript" id="constructhubconstructhubpropspropertypreloadscript"></a>
+
+```typescript
+public readonly preloadScript: string;
+```
+
+- *Type:* `string`
+
+Defines source code for a preload.js script inserted at the top of the <head /> of the webapp.
 
 ---
 

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -153,6 +153,18 @@ Object {
       "Description": "S3 key for asset version \\"05fc44b7067de3c7c80efc65857efbca626a669b107bc5169f68db4e8e98a39c\\"",
       "Type": "String",
     },
+    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440ArtifactHash87A9FF22": Object {
+      "Description": "Artifact hash for asset \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
+      "Type": "String",
+    },
+    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054": Object {
+      "Description": "S3 bucket for asset \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
+      "Type": "String",
+    },
+    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49": Object {
+      "Description": "S3 key for asset version \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
+      "Type": "String",
+    },
     "AssetParameters0c1f2823005f5fcc50c5090ef8f20982fe0437f1ab276dfb167e2001275b6572ArtifactHash62D2EC70": Object {
       "Description": "Artifact hash for asset \\"0c1f2823005f5fcc50c5090ef8f20982fe0437f1ab276dfb167e2001275b6572\\"",
       "Type": "String",
@@ -9611,6 +9623,9 @@ function handler(event) {
           Object {
             "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1",
           },
+          Object {
+            "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
+          },
         ],
         "SourceObjectKeys": Array [
           Object {
@@ -9638,6 +9653,39 @@ function handler(event) {
                         "||",
                         Object {
                           "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3VersionKeyBA1CB663",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            ],
+          },
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                Object {
+                  "Fn::Select": Array [
+                    0,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                Object {
+                  "Fn::Select": Array [
+                    1,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49",
                         },
                       ],
                     },
@@ -10486,6 +10534,47 @@ function handler(event) {
                 },
               ],
             },
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
+                      },
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
           ],
           "Version": "2012-10-17",
         },
@@ -11248,6 +11337,18 @@ Object {
     },
     "AssetParameters05fc44b7067de3c7c80efc65857efbca626a669b107bc5169f68db4e8e98a39cS3VersionKeyEBF73F61": Object {
       "Description": "S3 key for asset version \\"05fc44b7067de3c7c80efc65857efbca626a669b107bc5169f68db4e8e98a39c\\"",
+      "Type": "String",
+    },
+    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440ArtifactHash87A9FF22": Object {
+      "Description": "Artifact hash for asset \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
+      "Type": "String",
+    },
+    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054": Object {
+      "Description": "S3 bucket for asset \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
+      "Type": "String",
+    },
+    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49": Object {
+      "Description": "S3 key for asset version \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
       "Type": "String",
     },
     "AssetParameters0c1f2823005f5fcc50c5090ef8f20982fe0437f1ab276dfb167e2001275b6572ArtifactHash62D2EC70": Object {
@@ -21180,6 +21281,9 @@ function handler(event) {
           Object {
             "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1",
           },
+          Object {
+            "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
+          },
         ],
         "SourceObjectKeys": Array [
           Object {
@@ -21207,6 +21311,39 @@ function handler(event) {
                         "||",
                         Object {
                           "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3VersionKeyBA1CB663",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            ],
+          },
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                Object {
+                  "Fn::Select": Array [
+                    0,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                Object {
+                  "Fn::Select": Array [
+                    1,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49",
                         },
                       ],
                     },
@@ -22055,6 +22192,47 @@ function handler(event) {
                 },
               ],
             },
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
+                      },
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
           ],
           "Version": "2012-10-17",
         },
@@ -22817,6 +22995,18 @@ Object {
     },
     "AssetParameters05fc44b7067de3c7c80efc65857efbca626a669b107bc5169f68db4e8e98a39cS3VersionKeyEBF73F61": Object {
       "Description": "S3 key for asset version \\"05fc44b7067de3c7c80efc65857efbca626a669b107bc5169f68db4e8e98a39c\\"",
+      "Type": "String",
+    },
+    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440ArtifactHash87A9FF22": Object {
+      "Description": "Artifact hash for asset \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
+      "Type": "String",
+    },
+    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054": Object {
+      "Description": "S3 bucket for asset \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
+      "Type": "String",
+    },
+    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49": Object {
+      "Description": "S3 key for asset version \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
       "Type": "String",
     },
     "AssetParameters0c1f2823005f5fcc50c5090ef8f20982fe0437f1ab276dfb167e2001275b6572ArtifactHash62D2EC70": Object {
@@ -32277,6 +32467,9 @@ function handler(event) {
           Object {
             "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1",
           },
+          Object {
+            "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
+          },
         ],
         "SourceObjectKeys": Array [
           Object {
@@ -32304,6 +32497,39 @@ function handler(event) {
                         "||",
                         Object {
                           "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3VersionKeyBA1CB663",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            ],
+          },
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                Object {
+                  "Fn::Select": Array [
+                    0,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                Object {
+                  "Fn::Select": Array [
+                    1,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49",
                         },
                       ],
                     },
@@ -33152,6 +33378,47 @@ function handler(event) {
                 },
               ],
             },
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
+                      },
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
           ],
           "Version": "2012-10-17",
         },
@@ -33924,6 +34191,18 @@ Object {
     },
     "AssetParameters05fc44b7067de3c7c80efc65857efbca626a669b107bc5169f68db4e8e98a39cS3VersionKeyEBF73F61": Object {
       "Description": "S3 key for asset version \\"05fc44b7067de3c7c80efc65857efbca626a669b107bc5169f68db4e8e98a39c\\"",
+      "Type": "String",
+    },
+    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440ArtifactHash87A9FF22": Object {
+      "Description": "Artifact hash for asset \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
+      "Type": "String",
+    },
+    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054": Object {
+      "Description": "S3 bucket for asset \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
+      "Type": "String",
+    },
+    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49": Object {
+      "Description": "S3 key for asset version \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
       "Type": "String",
     },
     "AssetParameters0c1f2823005f5fcc50c5090ef8f20982fe0437f1ab276dfb167e2001275b6572ArtifactHash62D2EC70": Object {
@@ -43618,6 +43897,9 @@ function handler(event) {
           Object {
             "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1",
           },
+          Object {
+            "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
+          },
         ],
         "SourceObjectKeys": Array [
           Object {
@@ -43645,6 +43927,39 @@ function handler(event) {
                         "||",
                         Object {
                           "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3VersionKeyBA1CB663",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            ],
+          },
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                Object {
+                  "Fn::Select": Array [
+                    0,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                Object {
+                  "Fn::Select": Array [
+                    1,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49",
                         },
                       ],
                     },
@@ -44720,6 +45035,47 @@ function handler(event) {
                 },
               ],
             },
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
+                      },
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
           ],
           "Version": "2012-10-17",
         },
@@ -45482,6 +45838,18 @@ Object {
     },
     "AssetParameters05fc44b7067de3c7c80efc65857efbca626a669b107bc5169f68db4e8e98a39cS3VersionKeyEBF73F61": Object {
       "Description": "S3 key for asset version \\"05fc44b7067de3c7c80efc65857efbca626a669b107bc5169f68db4e8e98a39c\\"",
+      "Type": "String",
+    },
+    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440ArtifactHash87A9FF22": Object {
+      "Description": "Artifact hash for asset \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
+      "Type": "String",
+    },
+    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054": Object {
+      "Description": "S3 bucket for asset \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
+      "Type": "String",
+    },
+    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49": Object {
+      "Description": "S3 key for asset version \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
       "Type": "String",
     },
     "AssetParameters0c1f2823005f5fcc50c5090ef8f20982fe0437f1ab276dfb167e2001275b6572ArtifactHash62D2EC70": Object {
@@ -56775,6 +57143,9 @@ function handler(event) {
           Object {
             "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1",
           },
+          Object {
+            "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
+          },
         ],
         "SourceObjectKeys": Array [
           Object {
@@ -56802,6 +57173,39 @@ function handler(event) {
                         "||",
                         Object {
                           "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3VersionKeyBA1CB663",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            ],
+          },
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                Object {
+                  "Fn::Select": Array [
+                    0,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                Object {
+                  "Fn::Select": Array [
+                    1,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49",
                         },
                       ],
                     },
@@ -58051,6 +58455,47 @@ function handler(event) {
                       ":s3:::",
                       Object {
                         "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
+                      },
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
                       },
                       "/*",
                     ],

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -5402,6 +5402,7 @@ Resources:
           - Arn
       SourceBucketNames:
         - Ref: AssetParameters219b0e6bde7859b1caead1a417b318db5db660d51d0e582d6a303062ee4eae16S3BucketA2579CB9
+        - Ref: AssetParametersd7eba45c105712349db08f8edd1c547cd768fb9c92dadc0bfd2403ecc4127f96S3BucketEBD7DE4E
       SourceObjectKeys:
         - Fn::Join:
             - ""
@@ -5415,6 +5416,18 @@ Resources:
                   - Fn::Split:
                       - "||"
                       - Ref: AssetParameters219b0e6bde7859b1caead1a417b318db5db660d51d0e582d6a303062ee4eae16S3VersionKey49CF574B
+        - Fn::Join:
+            - ""
+            - - Fn::Select:
+                  - 0
+                  - Fn::Split:
+                      - "||"
+                      - Ref: AssetParametersd7eba45c105712349db08f8edd1c547cd768fb9c92dadc0bfd2403ecc4127f96S3VersionKey2B839AE6
+              - Fn::Select:
+                  - 1
+                  - Fn::Split:
+                      - "||"
+                      - Ref: AssetParametersd7eba45c105712349db08f8edd1c547cd768fb9c92dadc0bfd2403ecc4127f96S3VersionKey2B839AE6
       DestinationBucketName:
         Ref: ConstructHubWebAppWebsiteBucket4B2B9DB2
       Prune: false
@@ -7199,6 +7212,25 @@ Resources:
                     - ":s3:::"
                     - Ref: AssetParameters219b0e6bde7859b1caead1a417b318db5db660d51d0e582d6a303062ee4eae16S3BucketA2579CB9
                     - /*
+          - Action:
+              - s3:GetObject*
+              - s3:GetBucket*
+              - s3:List*
+            Effect: Allow
+            Resource:
+              - Fn::Join:
+                  - ""
+                  - - "arn:"
+                    - Ref: AWS::Partition
+                    - ":s3:::"
+                    - Ref: AssetParametersd7eba45c105712349db08f8edd1c547cd768fb9c92dadc0bfd2403ecc4127f96S3BucketEBD7DE4E
+              - Fn::Join:
+                  - ""
+                  - - "arn:"
+                    - Ref: AWS::Partition
+                    - ":s3:::"
+                    - Ref: AssetParametersd7eba45c105712349db08f8edd1c547cd768fb9c92dadc0bfd2403ecc4127f96S3BucketEBD7DE4E
+                    - /*
         Version: 2012-10-17
       PolicyName: CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF
       Roles:
@@ -7946,6 +7978,18 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "219b0e6bde7859b1caead1a417b318db5db660d51d0e582d6a303062ee4eae16"
+  AssetParametersd7eba45c105712349db08f8edd1c547cd768fb9c92dadc0bfd2403ecc4127f96S3BucketEBD7DE4E:
+    Type: String
+    Description: S3 bucket for asset
+      "d7eba45c105712349db08f8edd1c547cd768fb9c92dadc0bfd2403ecc4127f96"
+  AssetParametersd7eba45c105712349db08f8edd1c547cd768fb9c92dadc0bfd2403ecc4127f96S3VersionKey2B839AE6:
+    Type: String
+    Description: S3 key for asset version
+      "d7eba45c105712349db08f8edd1c547cd768fb9c92dadc0bfd2403ecc4127f96"
+  AssetParametersd7eba45c105712349db08f8edd1c547cd768fb9c92dadc0bfd2403ecc4127f96ArtifactHashA9044145:
+    Type: String
+    Description: Artifact hash for asset
+      "d7eba45c105712349db08f8edd1c547cd768fb9c92dadc0bfd2403ecc4127f96"
   AssetParameters279fd2112714c5ff533229d87cd07cf180cd66497415bb8191cce00927a69290S3Bucket1654D5BE:
     Type: String
     Description: S3 bucket for asset

--- a/src/__tests__/devapp/dev-stack.ts
+++ b/src/__tests__/devapp/dev-stack.ts
@@ -61,6 +61,7 @@ export class DevStack extends Stack {
         { title: 'Category1', url: '/search?q=cat1' },
         { title: 'Category2', url: '/search?keywords=boom' },
       ],
+      preloadScript: 'console.log("This is a custom preloadScript")',
     });
   }
 }

--- a/src/backend/ingestion/index.ts
+++ b/src/backend/ingestion/index.ts
@@ -12,12 +12,12 @@ import { StateMachine, JsonPath, Choice, Succeed, Condition, Map, TaskInput, Int
 import { CallAwsService, LambdaInvoke, StepFunctionsStartExecution } from '@aws-cdk/aws-stepfunctions-tasks';
 import { Construct, Duration, Stack, ArnFormat } from '@aws-cdk/core';
 import { Repository } from '../../codeartifact/repository';
-import { ConfigFile } from '../../config-file';
 import { lambdaFunctionUrl, sqsQueueUrl } from '../../deep-link';
 import { Monitoring } from '../../monitoring';
 import { PackageTagConfig } from '../../package-tag';
 import { RUNBOOK_URL } from '../../runbook-url';
 import { S3StorageFactory } from '../../s3/storage';
+import { TempFile } from '../../temp-file';
 import type { PackageLinkConfig } from '../../webapp';
 import { gravitonLambdaIfAvailable } from '../_lambda-architecture';
 import { Orchestration } from '../orchestration';
@@ -123,7 +123,7 @@ export class Ingestion extends Construct implements IGrantable {
     });
 
     const configFilename = 'config.json';
-    const config = new ConfigFile(configFilename, JSON.stringify({
+    const config = new TempFile(configFilename, JSON.stringify({
       packageLinks: props.packageLinks ?? [],
       packageTags: props.packageTags ?? [],
     }));

--- a/src/construct-hub.ts
+++ b/src/construct-hub.ts
@@ -180,6 +180,11 @@ export interface ConstructHubProps {
    * @default []
    */
   readonly additionalDomains?: DomainRedirectSource[];
+
+  /**
+   * Defines source code for a preload.js script inserted at the top of the <head /> of the webapp
+   */
+  readonly preloadScript?: string;
 }
 
 /**
@@ -349,6 +354,7 @@ export class ConstructHub extends CoreConstruct implements iam.IGrantable {
       packageStats,
       featureFlags: props.featureFlags,
       categories: props.categories,
+      preloadScript: props.preloadScript,
     });
 
     const sources = new CoreConstruct(this, 'Sources');

--- a/src/temp-file.ts
+++ b/src/temp-file.ts
@@ -2,11 +2,11 @@ import { mkdtempSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
-export class ConfigFile {
+export class TempFile {
   public readonly path: string;
   public readonly dir: string;
   public constructor(filename: string, content: string) {
-    this.dir = mkdtempSync(join(tmpdir(), 'chconfigfile'));
+    this.dir = mkdtempSync(join(tmpdir(), 'chtempfile'));
     this.path = join(this.dir, filename);
     writeFileSync(this.path, content);
   }

--- a/src/webapp/config.ts
+++ b/src/webapp/config.ts
@@ -1,7 +1,7 @@
 import { join } from 'path';
 import { Category, FeaturedPackages, FeatureFlags, PackageLinkConfig } from '.';
-import { ConfigFile } from '../config-file';
 import { PackageTagConfig } from '../package-tag';
+import { TempFile } from '../temp-file';
 
 interface FrontendPackageLinkConfig {
   linkLabel: string;
@@ -84,9 +84,9 @@ export interface WebappConfigProps {
 }
 
 export class WebappConfig {
-  public readonly file: ConfigFile;
+  public readonly file: TempFile;
   public constructor(private readonly props: WebappConfigProps) {
-    this.file = new ConfigFile('config.json', JSON.stringify(this.frontendConfig));
+    this.file = new TempFile('config.json', JSON.stringify(this.frontendConfig));
   }
 
   private get frontendConfig(): FrontendConfig {

--- a/src/webapp/index.ts
+++ b/src/webapp/index.ts
@@ -13,6 +13,7 @@ import { CacheStrategy } from '../caching';
 import { MonitoredCertificate } from '../monitored-certificate';
 import { Monitoring } from '../monitoring';
 import { S3StorageFactory } from '../s3/storage';
+import { TempFile } from '../temp-file';
 import { WebappConfig, WebappConfigProps } from './config';
 import { ResponseFunction } from './response-function';
 
@@ -140,6 +141,11 @@ export interface WebAppProps extends WebappConfigProps {
    * Manages the `stats.json` file object.
    */
   readonly packageStats?: PackageStats;
+
+  /**
+   * JavaScript source code which will be served at the top of the webapp <head /> tag
+   */
+  readonly preloadScript?: string;
 }
 
 export class WebApp extends Construct {
@@ -246,8 +252,11 @@ export class WebApp extends Construct {
       categories: props.categories,
     });
 
+    // Generate preload.js
+    const preloadScript = new TempFile('preload.js', props.preloadScript ?? '');
+
     new s3deploy.BucketDeployment(this, 'DeployWebsiteConfig', {
-      sources: [s3deploy.Source.asset(config.file.dir)],
+      sources: [s3deploy.Source.asset(config.file.dir), s3deploy.Source.asset(preloadScript.dir)],
       destinationBucket: this.bucket,
       distribution: this.distribution,
       prune: false,


### PR DESCRIPTION
This pull request adds a new prop to the `ConstructHub` class to support a preload.js script on the webapp. This addition will allow us to remove our analytics script from our npm package, as well as allow construct hub instances to have their own javascript run before the webapp is served (if needed)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
