### PR TITLE
chore(deps): upgrade dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,13 +29,13 @@ jobs:
         run: npx projen build
       - name: Check self-mutation
         id: self_mutation
-        run: git diff --exit-code || echo "::set-output
+        run: git diff --staged --exit-code || echo "::set-output
           name=self_mutation_happened::true"
       - if: ${{ steps.self_mutation.outputs.self_mutation_happened }}
         name: Create Patch
         run: |-
           git add .
-          git diff --patch --staged > .repo.patch
+          git diff --staged --patch > .repo.patch
       - if: ${{ steps.self_mutation.outputs.self_mutation_happened }}
         name: Upload patch
         uses: actions/upload-artifact@v2
@@ -69,7 +69,7 @@ jobs:
         run: '[ -s ${{ runner.temp }}/.repo.patch ] && git apply ${{ runner.temp
           }}/.repo.patch || echo "Empty patch. Skipping."'
       - name: Found diff after build (update your branch)
-        run: git diff --exit-code
+        run: git diff --staged --exit-code
   self-mutation:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -24,19 +24,17 @@ jobs:
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
         run: npx projen upgrade
-      - name: Verify language bindings
-        run: npx projen package-all
       - name: Create Patch
         run: |-
           git add .
-          git diff --patch --staged > .repo.patch
+          git diff --staged --patch > .repo.patch
       - name: Upload patch
         uses: actions/upload-artifact@v2
         with:
           name: .repo.patch
           path: .repo.patch
     container:
-      image: jsii/superchain:1-buster-slim-node14
+      image: jsii/superchain
   pr:
     name: Create Pull Request
     needs: upgrade

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -894,7 +894,7 @@
           "spawn": "unbump"
         },
         {
-          "exec": "git diff --ignore-space-at-eol --exit-code"
+          "exec": "git diff --staged --ignore-space-at-eol --exit-code"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "JSONStream": "^1.3.5",
     "normalize-registry-metadata": "^1.1.2",
     "npm-check-updates": "^12",
-    "projen": "^0.47.0",
+    "projen": "^0.47.2",
     "semver": "^7.3.5",
     "spdx-license-list": "^6.4.0",
     "standard-version": "^9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12352,10 +12352,10 @@ progress@^2.0.0, progress@^2.0.3:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
-projen@^0.47.0:
-  version "0.47.0"
-  resolved "https://registry.yarnpkg.com/projen/-/projen-0.47.0.tgz#f64fee11a7b2bbff59bbaef548e4b6f7edf32db9"
-  integrity sha512-gaGdu3ppTfwlQgqNcao1Q4A7yfY/qOYZRzTQOiX1gNu4NhWFr7KF0m++bfETbWJY0JuK7KaQ/j0CMdZSMo3hIA==
+projen@^0.47.2:
+  version "0.47.2"
+  resolved "https://registry.yarnpkg.com/projen/-/projen-0.47.2.tgz#3b3deff41227012cf4a9601133e0044c42444c67"
+  integrity sha512-wsjMdU4pP067Ylu3gSG19qPQXW56JdSjIO9mjmFz+NI3RB9MEUJaHN4tye+jJmD40258hGsTGBix2iewRU1jzA==
   dependencies:
     "@iarna/toml" "^2.2.5"
     case "^1.6.3"


### PR DESCRIPTION
The upgrade PR is failing because the packaging tasks have changed, and can no longer be executed in the upgrade workflow. 

https://github.com/cdklabs/construct-hub/runs/4659375512?check_suite_focus=true

```console
package-all » package:js | jsii_version=$(node -p "JSON.parse(fs.readFileSync('.jsii')).jsiiVersion.split(' ')[0]")
internal/fs/utils.js:312
    throw err;
    ^

Error: ENOENT: no such file or directory, open '.jsii'
    at Object.openSync (fs.js:498:3)
    at Object.readFileSync (fs.js:394:
```

This will be resolved after this upgrade because we won't run these commands anymore.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*