### PR TITLE
fix(docs): public Construct Hub is GA, not Dev Preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ instance with personalized configuration.
 
 > :warning: Disclaimer
 >
-> The [public instance of ConstructHub](https://constructs.dev) is currently in
-> *Developer Preview*.
+> The [public instance of ConstructHub](https://constructs.dev) is Generally Available.
 >
 > Self-hosted ConstructHub instances are however in active development and
 > should be considered *experimental*. Breaking changes to the public API of


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*