### PR TITLE
fix: daily reprocess job interferes with NPM follower

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -141,40 +141,28 @@ Object {
     },
   },
   "Parameters": Object {
-    "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6ArtifactHashF2EEEBFF": Object {
-      "Description": "Artifact hash for asset \\"04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6\\"",
+    "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeArtifactHash322D47B8": Object {
+      "Description": "Artifact hash for asset \\"0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9ae\\"",
       "Type": "String",
     },
-    "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3Bucket86412295": Object {
-      "Description": "S3 bucket for asset \\"04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6\\"",
+    "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3Bucket635A0AFA": Object {
+      "Description": "S3 bucket for asset \\"0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9ae\\"",
       "Type": "String",
     },
-    "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3VersionKeyE42DDF01": Object {
-      "Description": "S3 key for asset version \\"04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6\\"",
+    "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3VersionKeyBB104177": Object {
+      "Description": "S3 key for asset version \\"0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9ae\\"",
       "Type": "String",
     },
-    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440ArtifactHash87A9FF22": Object {
-      "Description": "Artifact hash for asset \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
+    "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadArtifactHash3158CABD": Object {
+      "Description": "Artifact hash for asset \\"0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362ead\\"",
       "Type": "String",
     },
-    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054": Object {
-      "Description": "S3 bucket for asset \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
+    "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3Bucket288D5551": Object {
+      "Description": "S3 bucket for asset \\"0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362ead\\"",
       "Type": "String",
     },
-    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49": Object {
-      "Description": "S3 key for asset version \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
-      "Type": "String",
-    },
-    "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aArtifactHash82449A4A": Object {
-      "Description": "Artifact hash for asset \\"0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4a\\"",
-      "Type": "String",
-    },
-    "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3Bucket789CA701": Object {
-      "Description": "S3 bucket for asset \\"0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4a\\"",
-      "Type": "String",
-    },
-    "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3VersionKey0222399F": Object {
-      "Description": "S3 key for asset version \\"0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4a\\"",
+    "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3VersionKey4638DF79": Object {
+      "Description": "S3 key for asset version \\"0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362ead\\"",
       "Type": "String",
     },
     "AssetParameters0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9ArtifactHashB9E3BF29": Object {
@@ -189,6 +177,42 @@ Object {
       "Description": "S3 key for asset version \\"0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9\\"",
       "Type": "String",
     },
+    "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67ArtifactHashCF96E147": Object {
+      "Description": "Artifact hash for asset \\"1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67\\"",
+      "Type": "String",
+    },
+    "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3BucketFFA964C8": Object {
+      "Description": "S3 bucket for asset \\"1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67\\"",
+      "Type": "String",
+    },
+    "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3VersionKeyA62CD84A": Object {
+      "Description": "S3 key for asset version \\"1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67\\"",
+      "Type": "String",
+    },
+    "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3ArtifactHashA3981DF8": Object {
+      "Description": "Artifact hash for asset \\"1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3\\"",
+      "Type": "String",
+    },
+    "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1": Object {
+      "Description": "S3 bucket for asset \\"1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3\\"",
+      "Type": "String",
+    },
+    "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3VersionKeyBA1CB663": Object {
+      "Description": "S3 key for asset version \\"1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3\\"",
+      "Type": "String",
+    },
+    "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeArtifactHashD1A9CF6A": Object {
+      "Description": "Artifact hash for asset \\"1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33ae\\"",
+      "Type": "String",
+    },
+    "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3Bucket901B95EB": Object {
+      "Description": "S3 bucket for asset \\"1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33ae\\"",
+      "Type": "String",
+    },
+    "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3VersionKeyC6FBD6BD": Object {
+      "Description": "S3 key for asset version \\"1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33ae\\"",
+      "Type": "String",
+    },
     "AssetParameters1f7e277bd526ebce1983fa1e7a84a5281ec533d9187caaebb773681bbf7bf4c1ArtifactHash0128B949": Object {
       "Description": "Artifact hash for asset \\"1f7e277bd526ebce1983fa1e7a84a5281ec533d9187caaebb773681bbf7bf4c1\\"",
       "Type": "String",
@@ -201,88 +225,112 @@ Object {
       "Description": "S3 key for asset version \\"1f7e277bd526ebce1983fa1e7a84a5281ec533d9187caaebb773681bbf7bf4c1\\"",
       "Type": "String",
     },
-    "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5ArtifactHash0AFE0939": Object {
-      "Description": "Artifact hash for asset \\"37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5\\"",
+    "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cArtifactHash8D005B5F": Object {
+      "Description": "Artifact hash for asset \\"205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612c\\"",
       "Type": "String",
     },
-    "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3Bucket722FE70B": Object {
-      "Description": "S3 bucket for asset \\"37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5\\"",
+    "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3Bucket95F679AA": Object {
+      "Description": "S3 bucket for asset \\"205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612c\\"",
       "Type": "String",
     },
-    "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3VersionKey8082F3BC": Object {
-      "Description": "S3 key for asset version \\"37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5\\"",
+    "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3VersionKeyE7A4EEDD": Object {
+      "Description": "S3 key for asset version \\"205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612c\\"",
       "Type": "String",
     },
-    "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5ArtifactHash499F6DFF": Object {
-      "Description": "Artifact hash for asset \\"3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5\\"",
+    "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534ArtifactHash89381734": Object {
+      "Description": "Artifact hash for asset \\"25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534\\"",
       "Type": "String",
     },
-    "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3Bucket37F2908E": Object {
-      "Description": "S3 bucket for asset \\"3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5\\"",
+    "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3Bucket8AFE0D2F": Object {
+      "Description": "S3 bucket for asset \\"25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534\\"",
       "Type": "String",
     },
-    "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3VersionKey2C992F11": Object {
-      "Description": "S3 key for asset version \\"3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5\\"",
+    "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3VersionKey39383E8E": Object {
+      "Description": "S3 key for asset version \\"25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534\\"",
       "Type": "String",
     },
-    "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dArtifactHash3B82A2B3": Object {
-      "Description": "Artifact hash for asset \\"3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880d\\"",
+    "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bArtifactHash270470CC": Object {
+      "Description": "Artifact hash for asset \\"3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934b\\"",
       "Type": "String",
     },
-    "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3BucketCBEF8050": Object {
-      "Description": "S3 bucket for asset \\"3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880d\\"",
+    "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3Bucket2D6D8F86": Object {
+      "Description": "S3 bucket for asset \\"3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934b\\"",
       "Type": "String",
     },
-    "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3VersionKey57968381": Object {
-      "Description": "S3 key for asset version \\"3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880d\\"",
+    "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3VersionKey0ECB40A6": Object {
+      "Description": "S3 key for asset version \\"3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934b\\"",
       "Type": "String",
     },
-    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afArtifactHash7F8A76FC": Object {
-      "Description": "Artifact hash for asset \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
+    "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0ArtifactHash6F14CF3C": Object {
+      "Description": "Artifact hash for asset \\"55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0\\"",
       "Type": "String",
     },
-    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3Bucket5515214C": Object {
-      "Description": "S3 bucket for asset \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
+    "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3BucketE35D2278": Object {
+      "Description": "S3 bucket for asset \\"55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0\\"",
       "Type": "String",
     },
-    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED": Object {
-      "Description": "S3 key for asset version \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
+    "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3VersionKey88FA0AFA": Object {
+      "Description": "S3 key for asset version \\"55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0\\"",
       "Type": "String",
     },
-    "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bArtifactHash5ABBFB9B": Object {
-      "Description": "Artifact hash for asset \\"42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2b\\"",
+    "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420ArtifactHashC847AA8D": Object {
+      "Description": "Artifact hash for asset \\"6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420\\"",
       "Type": "String",
     },
-    "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3Bucket8AF0E263": Object {
-      "Description": "S3 bucket for asset \\"42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2b\\"",
+    "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3Bucket649728C0": Object {
+      "Description": "S3 bucket for asset \\"6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420\\"",
       "Type": "String",
     },
-    "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3VersionKey5280D545": Object {
-      "Description": "S3 key for asset version \\"42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2b\\"",
+    "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3VersionKey592D485B": Object {
+      "Description": "S3 key for asset version \\"6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420\\"",
       "Type": "String",
     },
-    "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeArtifactHash3FAC57D3": Object {
-      "Description": "Artifact hash for asset \\"4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeee\\"",
+    "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cArtifactHashD2B94368": Object {
+      "Description": "Artifact hash for asset \\"73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06c\\"",
       "Type": "String",
     },
-    "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3Bucket6F376B71": Object {
-      "Description": "S3 bucket for asset \\"4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeee\\"",
+    "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3Bucket19B71C5A": Object {
+      "Description": "S3 bucket for asset \\"73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06c\\"",
       "Type": "String",
     },
-    "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3VersionKey7F6E5804": Object {
-      "Description": "S3 key for asset version \\"4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeee\\"",
+    "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3VersionKeyDF73A6F0": Object {
+      "Description": "S3 key for asset version \\"73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06c\\"",
       "Type": "String",
     },
-    "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680ArtifactHash316B2926": Object {
-      "Description": "Artifact hash for asset \\"864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680\\"",
+    "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fArtifactHash2005F882": Object {
+      "Description": "Artifact hash for asset \\"778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6f\\"",
       "Type": "String",
     },
-    "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3BucketF13820EA": Object {
-      "Description": "S3 bucket for asset \\"864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680\\"",
+    "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22": Object {
+      "Description": "S3 bucket for asset \\"778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6f\\"",
       "Type": "String",
     },
-    "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3VersionKey52B24F16": Object {
-      "Description": "S3 key for asset version \\"864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680\\"",
+    "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3VersionKeyCE5C5D3B": Object {
+      "Description": "S3 key for asset version \\"778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6f\\"",
+      "Type": "String",
+    },
+    "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0ArtifactHashF4B56B1E": Object {
+      "Description": "Artifact hash for asset \\"782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0\\"",
+      "Type": "String",
+    },
+    "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3Bucket1090210F": Object {
+      "Description": "S3 bucket for asset \\"782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0\\"",
+      "Type": "String",
+    },
+    "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3VersionKeyD738CD6B": Object {
+      "Description": "S3 key for asset version \\"782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0\\"",
+      "Type": "String",
+    },
+    "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965ArtifactHashD4D3C5A6": Object {
+      "Description": "Artifact hash for asset \\"7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965\\"",
+      "Type": "String",
+    },
+    "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3Bucket0A90D6D3": Object {
+      "Description": "S3 bucket for asset \\"7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965\\"",
+      "Type": "String",
+    },
+    "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3VersionKeyA116EF05": Object {
+      "Description": "S3 key for asset version \\"7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965\\"",
       "Type": "String",
     },
     "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900ArtifactHash121EF458": Object {
@@ -297,18 +345,6 @@ Object {
       "Description": "S3 key for asset version \\"8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900\\"",
       "Type": "String",
     },
-    "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9ArtifactHash694505BF": Object {
-      "Description": "Artifact hash for asset \\"8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9\\"",
-      "Type": "String",
-    },
-    "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3BucketED9FB7B0": Object {
-      "Description": "S3 bucket for asset \\"8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9\\"",
-      "Type": "String",
-    },
-    "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3VersionKeyCFEDA3D4": Object {
-      "Description": "S3 key for asset version \\"8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9\\"",
-      "Type": "String",
-    },
     "AssetParameters8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064ArtifactHashEA963870": Object {
       "Description": "Artifact hash for asset \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
@@ -321,16 +357,16 @@ Object {
       "Description": "S3 key for asset version \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
     },
-    "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4ArtifactHash660A50B8": Object {
-      "Description": "Artifact hash for asset \\"98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4\\"",
+    "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8ArtifactHash8DC0C383": Object {
+      "Description": "Artifact hash for asset \\"9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8\\"",
       "Type": "String",
     },
-    "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3BucketE78A0203": Object {
-      "Description": "S3 bucket for asset \\"98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4\\"",
+    "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3Bucket1B95B117": Object {
+      "Description": "S3 bucket for asset \\"9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8\\"",
       "Type": "String",
     },
-    "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3VersionKey598098A7": Object {
-      "Description": "S3 key for asset version \\"98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4\\"",
+    "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3VersionKey75D92238": Object {
+      "Description": "S3 key for asset version \\"9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8\\"",
       "Type": "String",
     },
     "AssetParametersa3058ccb468d757ebb89df5363a1c20f5307c6911136f29d00e1a68c9b2aa7e8ArtifactHash238275D6": Object {
@@ -345,16 +381,16 @@ Object {
       "Description": "S3 key for asset version \\"a3058ccb468d757ebb89df5363a1c20f5307c6911136f29d00e1a68c9b2aa7e8\\"",
       "Type": "String",
     },
-    "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaArtifactHash8CCAA809": Object {
-      "Description": "Artifact hash for asset \\"af643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfba\\"",
+    "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdArtifactHash22ECD1BE": Object {
+      "Description": "Artifact hash for asset \\"adb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbd\\"",
       "Type": "String",
     },
-    "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2": Object {
-      "Description": "S3 bucket for asset \\"af643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfba\\"",
+    "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3BucketF9AF3C9C": Object {
+      "Description": "S3 bucket for asset \\"adb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbd\\"",
       "Type": "String",
     },
-    "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3VersionKeyEC7E3301": Object {
-      "Description": "S3 key for asset version \\"af643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfba\\"",
+    "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3VersionKey09B12EB1": Object {
+      "Description": "S3 key for asset version \\"adb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbd\\"",
       "Type": "String",
     },
     "AssetParametersb120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827ArtifactHash1355580A": Object {
@@ -369,40 +405,16 @@ Object {
       "Description": "S3 key for asset version \\"b120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827\\"",
       "Type": "String",
     },
-    "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04ArtifactHash394183E9": Object {
-      "Description": "Artifact hash for asset \\"b55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04\\"",
+    "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8ArtifactHashBB72DCC8": Object {
+      "Description": "Artifact hash for asset \\"c8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8\\"",
       "Type": "String",
     },
-    "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3BucketE7A02ACD": Object {
-      "Description": "S3 bucket for asset \\"b55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04\\"",
+    "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3Bucket86DBA113": Object {
+      "Description": "S3 bucket for asset \\"c8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8\\"",
       "Type": "String",
     },
-    "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3VersionKeyCC994D9E": Object {
-      "Description": "S3 key for asset version \\"b55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04\\"",
-      "Type": "String",
-    },
-    "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcArtifactHash4E26EEC4": Object {
-      "Description": "Artifact hash for asset \\"c62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafc\\"",
-      "Type": "String",
-    },
-    "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3Bucket5255533F": Object {
-      "Description": "S3 bucket for asset \\"c62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafc\\"",
-      "Type": "String",
-    },
-    "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3VersionKey7909F675": Object {
-      "Description": "S3 key for asset version \\"c62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafc\\"",
-      "Type": "String",
-    },
-    "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aArtifactHash0386B8EC": Object {
-      "Description": "Artifact hash for asset \\"da314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17a\\"",
-      "Type": "String",
-    },
-    "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3BucketAE80D773": Object {
-      "Description": "S3 bucket for asset \\"da314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17a\\"",
-      "Type": "String",
-    },
-    "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3VersionKey662F0E6F": Object {
-      "Description": "S3 key for asset version \\"da314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17a\\"",
+    "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3VersionKeyF547CFB5": Object {
+      "Description": "S3 key for asset version \\"c8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8\\"",
       "Type": "String",
     },
     "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68ArtifactHashD9A515C3": Object {
@@ -415,30 +427,6 @@ Object {
     },
     "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3VersionKeyE415415F": Object {
       "Description": "S3 key for asset version \\"e9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68\\"",
-      "Type": "String",
-    },
-    "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3ArtifactHash11DB5971": Object {
-      "Description": "Artifact hash for asset \\"f48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3\\"",
-      "Type": "String",
-    },
-    "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3BucketAC5DE359": Object {
-      "Description": "S3 bucket for asset \\"f48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3\\"",
-      "Type": "String",
-    },
-    "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3VersionKey503D22DC": Object {
-      "Description": "S3 key for asset version \\"f48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3\\"",
-      "Type": "String",
-    },
-    "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5ArtifactHash185A4671": Object {
-      "Description": "Artifact hash for asset \\"fbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5\\"",
-      "Type": "String",
-    },
-    "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3Bucket024B3DC6": Object {
-      "Description": "S3 bucket for asset \\"fbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5\\"",
-      "Type": "String",
-    },
-    "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3VersionKeyEEA56859": Object {
-      "Description": "S3 key for asset version \\"fbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5\\"",
       "Type": "String",
     },
   },
@@ -1687,7 +1675,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3BucketAE80D773",
+            "Ref": "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3Bucket288D5551",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -1700,7 +1688,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3VersionKey662F0E6F",
+                          "Ref": "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3VersionKey4638DF79",
                         },
                       ],
                     },
@@ -1713,7 +1701,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3VersionKey662F0E6F",
+                          "Ref": "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3VersionKey4638DF79",
                         },
                       ],
                     },
@@ -1896,7 +1884,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3BucketAC5DE359",
+            "Ref": "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3Bucket95F679AA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -1909,7 +1897,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3VersionKey503D22DC",
+                          "Ref": "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3VersionKeyE7A4EEDD",
                         },
                       ],
                     },
@@ -1922,7 +1910,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3VersionKey503D22DC",
+                          "Ref": "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3VersionKeyE7A4EEDD",
                         },
                       ],
                     },
@@ -2162,7 +2150,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3BucketF13820EA",
+            "Ref": "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3Bucket8AFE0D2F",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -2175,7 +2163,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3VersionKey52B24F16",
+                          "Ref": "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3VersionKey39383E8E",
                         },
                       ],
                     },
@@ -2188,7 +2176,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3VersionKey52B24F16",
+                          "Ref": "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3VersionKey39383E8E",
                         },
                       ],
                     },
@@ -2675,7 +2663,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3Bucket5255533F",
+            "Ref": "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3Bucket0A90D6D3",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -2688,7 +2676,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3VersionKey7909F675",
+                          "Ref": "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3VersionKeyA116EF05",
                         },
                       ],
                     },
@@ -2701,7 +2689,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3VersionKey7909F675",
+                          "Ref": "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3VersionKeyA116EF05",
                         },
                       ],
                     },
@@ -3350,7 +3338,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3Bucket5515214C",
+            "Ref": "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3Bucket649728C0",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -3363,7 +3351,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED",
+                          "Ref": "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3VersionKey592D485B",
                         },
                       ],
                     },
@@ -3376,7 +3364,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED",
+                          "Ref": "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3VersionKey592D485B",
                         },
                       ],
                     },
@@ -4405,7 +4393,7 @@ Direct link to function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3BucketE7A02ACD",
+            "Ref": "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3Bucket635A0AFA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -4418,7 +4406,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3VersionKeyCC994D9E",
+                          "Ref": "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3VersionKeyBB104177",
                         },
                       ],
                     },
@@ -4431,7 +4419,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3VersionKeyCC994D9E",
+                          "Ref": "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3VersionKeyBB104177",
                         },
                       ],
                     },
@@ -4563,7 +4551,7 @@ Direct link to function: /lambda/home#/functions/",
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"StartAt\\":\\"Track Execution Infos\\",\\"States\\":{\\"Track Execution Infos\\":{\\"Type\\":\\"Pass\\",\\"ResultPath\\":\\"$.$TaskExecution\\",\\"InputPath\\":\\"$$.Execution\\",\\"Parameters\\":{\\"Id.$\\":\\"$.Id\\",\\"Name.$\\":\\"$.Name\\",\\"RoleArn.$\\":\\"$.RoleArn\\",\\"StartTime.$\\":\\"$.StartTime\\"},\\"Next\\":\\"Prepare doc-gen ECS Command\\"},\\"Prepare doc-gen ECS Command\\":{\\"Type\\":\\"Pass\\",\\"ResultPath\\":\\"$.docGen\\",\\"Parameters\\":{\\"command.$\\":\\"States.Array(States.JsonToString($))\\"},\\"Next\\":\\"Generate docs\\"},\\"Generate docs\\":{\\"Next\\":\\"Check whether catalog needs udpating\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"jsii-docgen.NoSpaceLeftOnDevice\\"],\\"MaxAttempts\\":0},{\\"ErrorEquals\\":[\\"ECS.AmazonECSException\\",\\"ECS.InvalidParameterException\\",\\"jsii-docgen.NpmError.E429\\",\\"jsii-codgen.NpmError.EPROTO\\"],\\"IntervalSeconds\\":120,\\"MaxAttempts\\":200,\\"BackoffRate\\":1},{\\"ErrorEquals\\":[\\"jsii-docgen.NpmError.ETARGET\\"],\\"IntervalSeconds\\":300,\\"MaxAttempts\\":3,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"MaxAttempts\\":3}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"UnprocessablePackageError\\"],\\"Next\\":\\"Ignore\\"},{\\"ErrorEquals\\":[\\"States.Timeout\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"ECS.AmazonECSException\\",\\"ECS.InvalidParameterException\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Type\\":\\"Task\\",\\"TimeoutSeconds\\":7200,\\"HeartbeatSeconds\\":300,\\"InputPath\\":\\"$.docGen.command\\",\\"ResultPath\\":\\"$.docGenOutput\\",\\"Resource\\":\\"arn:",
+              "{\\"StartAt\\":\\"Track Execution Infos\\",\\"States\\":{\\"Track Execution Infos\\":{\\"Type\\":\\"Pass\\",\\"ResultPath\\":\\"$.$TaskExecution\\",\\"InputPath\\":\\"$$.Execution\\",\\"Parameters\\":{\\"Id.$\\":\\"$.Id\\",\\"Name.$\\":\\"$.Name\\",\\"RoleArn.$\\":\\"$.RoleArn\\",\\"StartTime.$\\":\\"$.StartTime\\"},\\"Next\\":\\"Prepare doc-gen ECS Command\\"},\\"Prepare doc-gen ECS Command\\":{\\"Type\\":\\"Pass\\",\\"ResultPath\\":\\"$.docGen\\",\\"Parameters\\":{\\"command.$\\":\\"States.Array(States.JsonToString($))\\"},\\"Next\\":\\"Generate docs\\"},\\"Generate docs\\":{\\"Next\\":\\"Check whether catalog needs udpating\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"jsii-docgen.NoSpaceLeftOnDevice\\"],\\"MaxAttempts\\":0},{\\"ErrorEquals\\":[\\"ECS.AmazonECSException\\",\\"ECS.InvalidParameterException\\",\\"jsii-docgen.NpmError.E429\\",\\"jsii-codgen.NpmError.EPROTO\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":30,\\"BackoffRate\\":1.1},{\\"ErrorEquals\\":[\\"jsii-docgen.NpmError.ETARGET\\"],\\"IntervalSeconds\\":300,\\"MaxAttempts\\":3,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"MaxAttempts\\":3}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"UnprocessablePackageError\\"],\\"Next\\":\\"Ignore\\"},{\\"ErrorEquals\\":[\\"States.Timeout\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"ECS.AmazonECSException\\",\\"ECS.InvalidParameterException\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Type\\":\\"Task\\",\\"TimeoutSeconds\\":3600,\\"HeartbeatSeconds\\":300,\\"InputPath\\":\\"$.docGen.command\\",\\"ResultPath\\":\\"$.docGenOutput\\",\\"Resource\\":\\"arn:",
               Object {
                 "Ref": "AWS::Partition",
               },
@@ -4589,7 +4577,7 @@ Direct link to function: /lambda/home#/functions/",
                   "GroupId",
                 ],
               },
-              "\\"]}},\\"Overrides\\":{\\"ContainerOverrides\\":[{\\"Name\\":\\"Resource\\",\\"Command.$\\":\\"$\\",\\"Environment\\":[{\\"Name\\":\\"SFN_TASK_TOKEN\\",\\"Value.$\\":\\"$$.Task.Token\\"}]}]},\\"LaunchType\\":\\"FARGATE\\",\\"PlatformVersion\\":\\"1.4.0\\"}},\\"Check whether catalog needs udpating\\":{\\"Next\\":\\"Is catalog update needed?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"Lambda.ServiceException\\",\\"Lambda.AWSLambdaException\\",\\"Lambda.SdkClientException\\"],\\"IntervalSeconds\\":2,\\"MaxAttempts\\":6,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\",\\"Lambda.Unknown\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":30,\\"BackoffRate\\":1.1}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\",\\"Lambda.Unknown\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.catalogNeedsUpdating\\",\\"Resource\\":\\"",
+              "\\"]}},\\"Overrides\\":{\\"ContainerOverrides\\":[{\\"Name\\":\\"Resource\\",\\"Command.$\\":\\"$\\",\\"Environment\\":[{\\"Name\\":\\"SFN_TASK_TOKEN\\",\\"Value.$\\":\\"$$.Task.Token\\"}]}]},\\"LaunchType\\":\\"FARGATE\\",\\"PlatformVersion\\":\\"1.4.0\\"}},\\"Check whether catalog needs udpating\\":{\\"Next\\":\\"Is catalog update needed?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"Lambda.ServiceException\\",\\"Lambda.AWSLambdaException\\",\\"Lambda.SdkClientException\\"],\\"IntervalSeconds\\":2,\\"MaxAttempts\\":6,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":30,\\"BackoffRate\\":1.1}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.catalogNeedsUpdating\\",\\"Resource\\":\\"",
               Object {
                 "Fn::GetAtt": Array [
                   "ConstructHubOrchestrationNeedsCatalogUpdate5D7370DC",
@@ -4640,7 +4628,7 @@ Direct link to function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3Bucket722FE70B",
+            "Ref": "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3Bucket2D6D8F86",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -4653,7 +4641,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3VersionKey8082F3BC",
+                          "Ref": "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3VersionKey0ECB40A6",
                         },
                       ],
                     },
@@ -4666,7 +4654,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3VersionKey8082F3BC",
+                          "Ref": "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3VersionKey0ECB40A6",
                         },
                       ],
                     },
@@ -5468,7 +5456,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3BucketE78A0203",
+            "Ref": "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3Bucket19B71C5A",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -5481,7 +5469,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3VersionKey598098A7",
+                          "Ref": "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3VersionKeyDF73A6F0",
                         },
                       ],
                     },
@@ -5494,7 +5482,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3VersionKey598098A7",
+                          "Ref": "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3VersionKeyDF73A6F0",
                         },
                       ],
                     },
@@ -5652,7 +5640,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3Bucket6F376B71",
+            "Ref": "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3Bucket1090210F",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -5665,7 +5653,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3VersionKey7F6E5804",
+                          "Ref": "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3VersionKeyD738CD6B",
                         },
                       ],
                     },
@@ -5678,7 +5666,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3VersionKey7F6E5804",
+                          "Ref": "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3VersionKeyD738CD6B",
                         },
                       ],
                     },
@@ -6456,7 +6444,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                   Object {
                     "Ref": "AWS::URLSuffix",
                   },
-                  "/aws-cdk/assets:89c6683e392b08bdb9bfd8e456f82a156b228534eed332191232b4aa0beec4f2",
+                  "/aws-cdk/assets:5fa39a328f34360df81ad2f478b29e7f72b6625d60d6ca775401e69a3b2c0faf",
                 ],
               ],
             },
@@ -6738,7 +6726,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.*",
+                      "/data/*/docs-typescript.md",
                     ],
                   ],
                 },
@@ -6768,7 +6756,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.*",
+                      "/data/*/docs-*-typescript.md",
                     ],
                   ],
                 },
@@ -6798,7 +6786,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.*.not-supported",
+                      "/data/*/docs-typescript.md.not-supported",
                     ],
                   ],
                 },
@@ -6828,7 +6816,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.*.not-supported",
+                      "/data/*/docs-*-typescript.md.not-supported",
                     ],
                   ],
                 },
@@ -6858,7 +6846,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.*.corruptassembly",
+                      "/data/*/docs-typescript.md.corruptassembly",
                     ],
                   ],
                 },
@@ -6888,7 +6876,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.*.corruptassembly",
+                      "/data/*/docs-*-typescript.md.corruptassembly",
                     ],
                   ],
                 },
@@ -6907,7 +6895,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-typescript.*.corruptassembly",
+                    "/data/*/docs-typescript.md.corruptassembly",
                   ],
                 ],
               },
@@ -6925,223 +6913,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-typescript.*.corruptassembly",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.*.not-supported",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.*.not-supported",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.*.corruptassembly",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.*.corruptassembly",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": "s3:DeleteObject*",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "ConstructHubPackageDataDC5EF35E",
-                        "Arn",
-                      ],
-                    },
-                    "/data/*/docs-python.*.corruptassembly",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": "s3:DeleteObject*",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "ConstructHubPackageDataDC5EF35E",
-                        "Arn",
-                      ],
-                    },
-                    "/data/*/docs-*-python.*.corruptassembly",
+                    "/data/*/docs-*-typescript.md.corruptassembly",
                   ],
                 ],
               },
@@ -7170,7 +6942,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.*",
+                      "/data/*/docs-python.md",
                     ],
                   ],
                 },
@@ -7200,7 +6972,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.*",
+                      "/data/*/docs-*-python.md",
                     ],
                   ],
                 },
@@ -7230,7 +7002,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.*.not-supported",
+                      "/data/*/docs-python.md.not-supported",
                     ],
                   ],
                 },
@@ -7260,7 +7032,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.*.not-supported",
+                      "/data/*/docs-*-python.md.not-supported",
                     ],
                   ],
                 },
@@ -7290,7 +7062,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.*.corruptassembly",
+                      "/data/*/docs-python.md.corruptassembly",
                     ],
                   ],
                 },
@@ -7320,7 +7092,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.*.corruptassembly",
+                      "/data/*/docs-*-python.md.corruptassembly",
                     ],
                   ],
                 },
@@ -7339,7 +7111,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-java.*.corruptassembly",
+                    "/data/*/docs-python.md.corruptassembly",
                   ],
                 ],
               },
@@ -7357,7 +7129,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-java.*.corruptassembly",
+                    "/data/*/docs-*-python.md.corruptassembly",
                   ],
                 ],
               },
@@ -7386,7 +7158,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.*",
+                      "/data/*/docs-java.md",
                     ],
                   ],
                 },
@@ -7416,7 +7188,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.*",
+                      "/data/*/docs-*-java.md",
                     ],
                   ],
                 },
@@ -7446,7 +7218,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.*.not-supported",
+                      "/data/*/docs-java.md.not-supported",
                     ],
                   ],
                 },
@@ -7476,7 +7248,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.*.not-supported",
+                      "/data/*/docs-*-java.md.not-supported",
                     ],
                   ],
                 },
@@ -7506,7 +7278,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.*.corruptassembly",
+                      "/data/*/docs-java.md.corruptassembly",
                     ],
                   ],
                 },
@@ -7536,7 +7308,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.*.corruptassembly",
+                      "/data/*/docs-*-java.md.corruptassembly",
                     ],
                   ],
                 },
@@ -7555,7 +7327,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-csharp.*.corruptassembly",
+                    "/data/*/docs-java.md.corruptassembly",
                   ],
                 ],
               },
@@ -7573,7 +7345,223 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-csharp.*.corruptassembly",
+                    "/data/*/docs-*-java.md.corruptassembly",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.md",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.md",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.md.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.md.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.md.corruptassembly",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.md.corruptassembly",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": "s3:DeleteObject*",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "ConstructHubPackageDataDC5EF35E",
+                        "Arn",
+                      ],
+                    },
+                    "/data/*/docs-csharp.md.corruptassembly",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:DeleteObject*",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "ConstructHubPackageDataDC5EF35E",
+                        "Arn",
+                      ],
+                    },
+                    "/data/*/docs-*-csharp.md.corruptassembly",
                   ],
                 ],
               },
@@ -7839,7 +7827,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3Bucket024B3DC6",
+            "Ref": "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3Bucket901B95EB",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -7852,7 +7840,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3VersionKeyEEA56859",
+                          "Ref": "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3VersionKeyC6FBD6BD",
                         },
                       ],
                     },
@@ -7865,7 +7853,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3VersionKeyEEA56859",
+                          "Ref": "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3VersionKeyC6FBD6BD",
                         },
                       ],
                     },
@@ -7922,7 +7910,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3Bucket37F2908E",
+            "Ref": "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3Bucket86DBA113",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -7935,7 +7923,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3VersionKey2C992F11",
+                          "Ref": "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3VersionKeyF547CFB5",
                         },
                       ],
                     },
@@ -7948,7 +7936,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3VersionKey2C992F11",
+                          "Ref": "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3VersionKeyF547CFB5",
                         },
                       ],
                     },
@@ -8511,7 +8499,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3Bucket8AF0E263",
+            "Ref": "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3BucketFFA964C8",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -8524,7 +8512,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3VersionKey5280D545",
+                          "Ref": "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3VersionKeyA62CD84A",
                         },
                       ],
                     },
@@ -8537,7 +8525,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3VersionKey5280D545",
+                          "Ref": "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3VersionKeyA62CD84A",
                         },
                       ],
                     },
@@ -8947,7 +8935,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3Bucket789CA701",
+            "Ref": "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3BucketE35D2278",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -8960,7 +8948,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3VersionKey0222399F",
+                          "Ref": "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3VersionKey88FA0AFA",
                         },
                       ],
                     },
@@ -8973,7 +8961,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3VersionKey0222399F",
+                          "Ref": "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3VersionKey88FA0AFA",
                         },
                       ],
                     },
@@ -9179,7 +9167,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3Bucket86412295",
+            "Ref": "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3BucketF9AF3C9C",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -9192,7 +9180,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3VersionKeyE42DDF01",
+                          "Ref": "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3VersionKey09B12EB1",
                         },
                       ],
                     },
@@ -9205,7 +9193,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3VersionKeyE42DDF01",
+                          "Ref": "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3VersionKey09B12EB1",
                         },
                       ],
                     },
@@ -9621,10 +9609,7 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3BucketED9FB7B0",
-          },
-          Object {
-            "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
+            "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1",
           },
         ],
         "SourceObjectKeys": Array [
@@ -9639,7 +9624,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3VersionKeyCFEDA3D4",
+                          "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3VersionKeyBA1CB663",
                         },
                       ],
                     },
@@ -9652,40 +9637,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3VersionKeyCFEDA3D4",
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            ],
-          },
-          Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                Object {
-                  "Fn::Select": Array [
-                    0,
-                    Object {
-                      "Fn::Split": Array [
-                        "||",
-                        Object {
-                          "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49",
-                        },
-                      ],
-                    },
-                  ],
-                },
-                Object {
-                  "Fn::Select": Array [
-                    1,
-                    Object {
-                      "Fn::Split": Array [
-                        "||",
-                        Object {
-                          "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49",
+                          "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3VersionKeyBA1CB663",
                         },
                       ],
                     },
@@ -9720,7 +9672,7 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2",
+            "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22",
           },
         ],
         "SourceObjectKeys": Array [
@@ -9735,7 +9687,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3VersionKeyEC7E3301",
+                          "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3VersionKeyCE5C5D3B",
                         },
                       ],
                     },
@@ -9748,7 +9700,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3VersionKeyEC7E3301",
+                          "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3VersionKeyCE5C5D3B",
                         },
                       ],
                     },
@@ -10429,7 +10381,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2",
+                        "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22",
                       },
                     ],
                   ],
@@ -10444,7 +10396,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2",
+                        "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22",
                       },
                       "/*",
                     ],
@@ -10511,7 +10463,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3BucketED9FB7B0",
+                        "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1",
                       },
                     ],
                   ],
@@ -10526,48 +10478,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3BucketED9FB7B0",
-                      },
-                      "/*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:GetObject*",
-                "s3:GetBucket*",
-                "s3:List*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":s3:::",
-                      Object {
-                        "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
-                      },
-                    ],
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":s3:::",
-                      Object {
-                        "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
+                        "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1",
                       },
                       "/*",
                     ],
@@ -10795,7 +10706,7 @@ function handler(event) {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3BucketCBEF8050",
+            "Ref": "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3Bucket1B95B117",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -10808,7 +10719,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3VersionKey57968381",
+                          "Ref": "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3VersionKey75D92238",
                         },
                       ],
                     },
@@ -10821,7 +10732,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3VersionKey57968381",
+                          "Ref": "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3VersionKey75D92238",
                         },
                       ],
                     },
@@ -11327,40 +11238,28 @@ Object {
     },
   },
   "Parameters": Object {
-    "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6ArtifactHashF2EEEBFF": Object {
-      "Description": "Artifact hash for asset \\"04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6\\"",
+    "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeArtifactHash322D47B8": Object {
+      "Description": "Artifact hash for asset \\"0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9ae\\"",
       "Type": "String",
     },
-    "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3Bucket86412295": Object {
-      "Description": "S3 bucket for asset \\"04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6\\"",
+    "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3Bucket635A0AFA": Object {
+      "Description": "S3 bucket for asset \\"0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9ae\\"",
       "Type": "String",
     },
-    "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3VersionKeyE42DDF01": Object {
-      "Description": "S3 key for asset version \\"04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6\\"",
+    "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3VersionKeyBB104177": Object {
+      "Description": "S3 key for asset version \\"0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9ae\\"",
       "Type": "String",
     },
-    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440ArtifactHash87A9FF22": Object {
-      "Description": "Artifact hash for asset \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
+    "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadArtifactHash3158CABD": Object {
+      "Description": "Artifact hash for asset \\"0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362ead\\"",
       "Type": "String",
     },
-    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054": Object {
-      "Description": "S3 bucket for asset \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
+    "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3Bucket288D5551": Object {
+      "Description": "S3 bucket for asset \\"0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362ead\\"",
       "Type": "String",
     },
-    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49": Object {
-      "Description": "S3 key for asset version \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
-      "Type": "String",
-    },
-    "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aArtifactHash82449A4A": Object {
-      "Description": "Artifact hash for asset \\"0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4a\\"",
-      "Type": "String",
-    },
-    "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3Bucket789CA701": Object {
-      "Description": "S3 bucket for asset \\"0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4a\\"",
-      "Type": "String",
-    },
-    "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3VersionKey0222399F": Object {
-      "Description": "S3 key for asset version \\"0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4a\\"",
+    "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3VersionKey4638DF79": Object {
+      "Description": "S3 key for asset version \\"0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362ead\\"",
       "Type": "String",
     },
     "AssetParameters0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9ArtifactHashB9E3BF29": Object {
@@ -11375,6 +11274,42 @@ Object {
       "Description": "S3 key for asset version \\"0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9\\"",
       "Type": "String",
     },
+    "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67ArtifactHashCF96E147": Object {
+      "Description": "Artifact hash for asset \\"1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67\\"",
+      "Type": "String",
+    },
+    "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3BucketFFA964C8": Object {
+      "Description": "S3 bucket for asset \\"1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67\\"",
+      "Type": "String",
+    },
+    "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3VersionKeyA62CD84A": Object {
+      "Description": "S3 key for asset version \\"1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67\\"",
+      "Type": "String",
+    },
+    "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3ArtifactHashA3981DF8": Object {
+      "Description": "Artifact hash for asset \\"1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3\\"",
+      "Type": "String",
+    },
+    "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1": Object {
+      "Description": "S3 bucket for asset \\"1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3\\"",
+      "Type": "String",
+    },
+    "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3VersionKeyBA1CB663": Object {
+      "Description": "S3 key for asset version \\"1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3\\"",
+      "Type": "String",
+    },
+    "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeArtifactHashD1A9CF6A": Object {
+      "Description": "Artifact hash for asset \\"1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33ae\\"",
+      "Type": "String",
+    },
+    "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3Bucket901B95EB": Object {
+      "Description": "S3 bucket for asset \\"1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33ae\\"",
+      "Type": "String",
+    },
+    "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3VersionKeyC6FBD6BD": Object {
+      "Description": "S3 key for asset version \\"1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33ae\\"",
+      "Type": "String",
+    },
     "AssetParameters1f7e277bd526ebce1983fa1e7a84a5281ec533d9187caaebb773681bbf7bf4c1ArtifactHash0128B949": Object {
       "Description": "Artifact hash for asset \\"1f7e277bd526ebce1983fa1e7a84a5281ec533d9187caaebb773681bbf7bf4c1\\"",
       "Type": "String",
@@ -11387,52 +11322,40 @@ Object {
       "Description": "S3 key for asset version \\"1f7e277bd526ebce1983fa1e7a84a5281ec533d9187caaebb773681bbf7bf4c1\\"",
       "Type": "String",
     },
-    "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5ArtifactHash0AFE0939": Object {
-      "Description": "Artifact hash for asset \\"37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5\\"",
+    "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cArtifactHash8D005B5F": Object {
+      "Description": "Artifact hash for asset \\"205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612c\\"",
       "Type": "String",
     },
-    "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3Bucket722FE70B": Object {
-      "Description": "S3 bucket for asset \\"37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5\\"",
+    "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3Bucket95F679AA": Object {
+      "Description": "S3 bucket for asset \\"205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612c\\"",
       "Type": "String",
     },
-    "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3VersionKey8082F3BC": Object {
-      "Description": "S3 key for asset version \\"37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5\\"",
+    "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3VersionKeyE7A4EEDD": Object {
+      "Description": "S3 key for asset version \\"205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612c\\"",
       "Type": "String",
     },
-    "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5ArtifactHash499F6DFF": Object {
-      "Description": "Artifact hash for asset \\"3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5\\"",
+    "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534ArtifactHash89381734": Object {
+      "Description": "Artifact hash for asset \\"25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534\\"",
       "Type": "String",
     },
-    "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3Bucket37F2908E": Object {
-      "Description": "S3 bucket for asset \\"3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5\\"",
+    "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3Bucket8AFE0D2F": Object {
+      "Description": "S3 bucket for asset \\"25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534\\"",
       "Type": "String",
     },
-    "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3VersionKey2C992F11": Object {
-      "Description": "S3 key for asset version \\"3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5\\"",
+    "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3VersionKey39383E8E": Object {
+      "Description": "S3 key for asset version \\"25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534\\"",
       "Type": "String",
     },
-    "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dArtifactHash3B82A2B3": Object {
-      "Description": "Artifact hash for asset \\"3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880d\\"",
+    "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bArtifactHash270470CC": Object {
+      "Description": "Artifact hash for asset \\"3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934b\\"",
       "Type": "String",
     },
-    "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3BucketCBEF8050": Object {
-      "Description": "S3 bucket for asset \\"3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880d\\"",
+    "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3Bucket2D6D8F86": Object {
+      "Description": "S3 bucket for asset \\"3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934b\\"",
       "Type": "String",
     },
-    "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3VersionKey57968381": Object {
-      "Description": "S3 key for asset version \\"3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880d\\"",
-      "Type": "String",
-    },
-    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afArtifactHash7F8A76FC": Object {
-      "Description": "Artifact hash for asset \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
-      "Type": "String",
-    },
-    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3Bucket5515214C": Object {
-      "Description": "S3 bucket for asset \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
-      "Type": "String",
-    },
-    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED": Object {
-      "Description": "S3 key for asset version \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
+    "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3VersionKey0ECB40A6": Object {
+      "Description": "S3 key for asset version \\"3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934b\\"",
       "Type": "String",
     },
     "AssetParameters4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbcArtifactHashF236251A": Object {
@@ -11447,40 +11370,76 @@ Object {
       "Description": "S3 key for asset version \\"4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbc\\"",
       "Type": "String",
     },
-    "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bArtifactHash5ABBFB9B": Object {
-      "Description": "Artifact hash for asset \\"42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2b\\"",
+    "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0ArtifactHash6F14CF3C": Object {
+      "Description": "Artifact hash for asset \\"55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0\\"",
       "Type": "String",
     },
-    "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3Bucket8AF0E263": Object {
-      "Description": "S3 bucket for asset \\"42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2b\\"",
+    "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3BucketE35D2278": Object {
+      "Description": "S3 bucket for asset \\"55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0\\"",
       "Type": "String",
     },
-    "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3VersionKey5280D545": Object {
-      "Description": "S3 key for asset version \\"42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2b\\"",
+    "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3VersionKey88FA0AFA": Object {
+      "Description": "S3 key for asset version \\"55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0\\"",
       "Type": "String",
     },
-    "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeArtifactHash3FAC57D3": Object {
-      "Description": "Artifact hash for asset \\"4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeee\\"",
+    "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420ArtifactHashC847AA8D": Object {
+      "Description": "Artifact hash for asset \\"6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420\\"",
       "Type": "String",
     },
-    "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3Bucket6F376B71": Object {
-      "Description": "S3 bucket for asset \\"4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeee\\"",
+    "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3Bucket649728C0": Object {
+      "Description": "S3 bucket for asset \\"6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420\\"",
       "Type": "String",
     },
-    "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3VersionKey7F6E5804": Object {
-      "Description": "S3 key for asset version \\"4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeee\\"",
+    "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3VersionKey592D485B": Object {
+      "Description": "S3 key for asset version \\"6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420\\"",
       "Type": "String",
     },
-    "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680ArtifactHash316B2926": Object {
-      "Description": "Artifact hash for asset \\"864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680\\"",
+    "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cArtifactHashD2B94368": Object {
+      "Description": "Artifact hash for asset \\"73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06c\\"",
       "Type": "String",
     },
-    "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3BucketF13820EA": Object {
-      "Description": "S3 bucket for asset \\"864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680\\"",
+    "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3Bucket19B71C5A": Object {
+      "Description": "S3 bucket for asset \\"73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06c\\"",
       "Type": "String",
     },
-    "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3VersionKey52B24F16": Object {
-      "Description": "S3 key for asset version \\"864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680\\"",
+    "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3VersionKeyDF73A6F0": Object {
+      "Description": "S3 key for asset version \\"73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06c\\"",
+      "Type": "String",
+    },
+    "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fArtifactHash2005F882": Object {
+      "Description": "Artifact hash for asset \\"778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6f\\"",
+      "Type": "String",
+    },
+    "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22": Object {
+      "Description": "S3 bucket for asset \\"778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6f\\"",
+      "Type": "String",
+    },
+    "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3VersionKeyCE5C5D3B": Object {
+      "Description": "S3 key for asset version \\"778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6f\\"",
+      "Type": "String",
+    },
+    "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0ArtifactHashF4B56B1E": Object {
+      "Description": "Artifact hash for asset \\"782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0\\"",
+      "Type": "String",
+    },
+    "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3Bucket1090210F": Object {
+      "Description": "S3 bucket for asset \\"782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0\\"",
+      "Type": "String",
+    },
+    "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3VersionKeyD738CD6B": Object {
+      "Description": "S3 key for asset version \\"782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0\\"",
+      "Type": "String",
+    },
+    "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965ArtifactHashD4D3C5A6": Object {
+      "Description": "Artifact hash for asset \\"7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965\\"",
+      "Type": "String",
+    },
+    "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3Bucket0A90D6D3": Object {
+      "Description": "S3 bucket for asset \\"7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965\\"",
+      "Type": "String",
+    },
+    "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3VersionKeyA116EF05": Object {
+      "Description": "S3 key for asset version \\"7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965\\"",
       "Type": "String",
     },
     "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900ArtifactHash121EF458": Object {
@@ -11495,18 +11454,6 @@ Object {
       "Description": "S3 key for asset version \\"8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900\\"",
       "Type": "String",
     },
-    "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9ArtifactHash694505BF": Object {
-      "Description": "Artifact hash for asset \\"8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9\\"",
-      "Type": "String",
-    },
-    "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3BucketED9FB7B0": Object {
-      "Description": "S3 bucket for asset \\"8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9\\"",
-      "Type": "String",
-    },
-    "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3VersionKeyCFEDA3D4": Object {
-      "Description": "S3 key for asset version \\"8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9\\"",
-      "Type": "String",
-    },
     "AssetParameters8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064ArtifactHashEA963870": Object {
       "Description": "Artifact hash for asset \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
@@ -11519,16 +11466,16 @@ Object {
       "Description": "S3 key for asset version \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
     },
-    "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4ArtifactHash660A50B8": Object {
-      "Description": "Artifact hash for asset \\"98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4\\"",
+    "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8ArtifactHash8DC0C383": Object {
+      "Description": "Artifact hash for asset \\"9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8\\"",
       "Type": "String",
     },
-    "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3BucketE78A0203": Object {
-      "Description": "S3 bucket for asset \\"98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4\\"",
+    "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3Bucket1B95B117": Object {
+      "Description": "S3 bucket for asset \\"9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8\\"",
       "Type": "String",
     },
-    "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3VersionKey598098A7": Object {
-      "Description": "S3 key for asset version \\"98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4\\"",
+    "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3VersionKey75D92238": Object {
+      "Description": "S3 key for asset version \\"9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8\\"",
       "Type": "String",
     },
     "AssetParametersa3058ccb468d757ebb89df5363a1c20f5307c6911136f29d00e1a68c9b2aa7e8ArtifactHash238275D6": Object {
@@ -11543,16 +11490,16 @@ Object {
       "Description": "S3 key for asset version \\"a3058ccb468d757ebb89df5363a1c20f5307c6911136f29d00e1a68c9b2aa7e8\\"",
       "Type": "String",
     },
-    "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaArtifactHash8CCAA809": Object {
-      "Description": "Artifact hash for asset \\"af643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfba\\"",
+    "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdArtifactHash22ECD1BE": Object {
+      "Description": "Artifact hash for asset \\"adb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbd\\"",
       "Type": "String",
     },
-    "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2": Object {
-      "Description": "S3 bucket for asset \\"af643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfba\\"",
+    "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3BucketF9AF3C9C": Object {
+      "Description": "S3 bucket for asset \\"adb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbd\\"",
       "Type": "String",
     },
-    "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3VersionKeyEC7E3301": Object {
-      "Description": "S3 key for asset version \\"af643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfba\\"",
+    "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3VersionKey09B12EB1": Object {
+      "Description": "S3 key for asset version \\"adb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbd\\"",
       "Type": "String",
     },
     "AssetParametersb120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827ArtifactHash1355580A": Object {
@@ -11567,40 +11514,16 @@ Object {
       "Description": "S3 key for asset version \\"b120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827\\"",
       "Type": "String",
     },
-    "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04ArtifactHash394183E9": Object {
-      "Description": "Artifact hash for asset \\"b55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04\\"",
+    "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8ArtifactHashBB72DCC8": Object {
+      "Description": "Artifact hash for asset \\"c8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8\\"",
       "Type": "String",
     },
-    "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3BucketE7A02ACD": Object {
-      "Description": "S3 bucket for asset \\"b55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04\\"",
+    "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3Bucket86DBA113": Object {
+      "Description": "S3 bucket for asset \\"c8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8\\"",
       "Type": "String",
     },
-    "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3VersionKeyCC994D9E": Object {
-      "Description": "S3 key for asset version \\"b55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04\\"",
-      "Type": "String",
-    },
-    "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcArtifactHash4E26EEC4": Object {
-      "Description": "Artifact hash for asset \\"c62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafc\\"",
-      "Type": "String",
-    },
-    "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3Bucket5255533F": Object {
-      "Description": "S3 bucket for asset \\"c62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafc\\"",
-      "Type": "String",
-    },
-    "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3VersionKey7909F675": Object {
-      "Description": "S3 key for asset version \\"c62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafc\\"",
-      "Type": "String",
-    },
-    "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aArtifactHash0386B8EC": Object {
-      "Description": "Artifact hash for asset \\"da314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17a\\"",
-      "Type": "String",
-    },
-    "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3BucketAE80D773": Object {
-      "Description": "S3 bucket for asset \\"da314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17a\\"",
-      "Type": "String",
-    },
-    "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3VersionKey662F0E6F": Object {
-      "Description": "S3 key for asset version \\"da314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17a\\"",
+    "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3VersionKeyF547CFB5": Object {
+      "Description": "S3 key for asset version \\"c8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8\\"",
       "Type": "String",
     },
     "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68ArtifactHashD9A515C3": Object {
@@ -11613,30 +11536,6 @@ Object {
     },
     "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3VersionKeyE415415F": Object {
       "Description": "S3 key for asset version \\"e9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68\\"",
-      "Type": "String",
-    },
-    "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3ArtifactHash11DB5971": Object {
-      "Description": "Artifact hash for asset \\"f48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3\\"",
-      "Type": "String",
-    },
-    "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3BucketAC5DE359": Object {
-      "Description": "S3 bucket for asset \\"f48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3\\"",
-      "Type": "String",
-    },
-    "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3VersionKey503D22DC": Object {
-      "Description": "S3 key for asset version \\"f48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3\\"",
-      "Type": "String",
-    },
-    "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5ArtifactHash185A4671": Object {
-      "Description": "Artifact hash for asset \\"fbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5\\"",
-      "Type": "String",
-    },
-    "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3Bucket024B3DC6": Object {
-      "Description": "S3 bucket for asset \\"fbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5\\"",
-      "Type": "String",
-    },
-    "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3VersionKeyEEA56859": Object {
-      "Description": "S3 key for asset version \\"fbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5\\"",
       "Type": "String",
     },
   },
@@ -13174,7 +13073,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3BucketAE80D773",
+            "Ref": "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3Bucket288D5551",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -13187,7 +13086,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3VersionKey662F0E6F",
+                          "Ref": "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3VersionKey4638DF79",
                         },
                       ],
                     },
@@ -13200,7 +13099,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3VersionKey662F0E6F",
+                          "Ref": "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3VersionKey4638DF79",
                         },
                       ],
                     },
@@ -13383,7 +13282,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3BucketAC5DE359",
+            "Ref": "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3Bucket95F679AA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -13396,7 +13295,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3VersionKey503D22DC",
+                          "Ref": "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3VersionKeyE7A4EEDD",
                         },
                       ],
                     },
@@ -13409,7 +13308,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3VersionKey503D22DC",
+                          "Ref": "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3VersionKeyE7A4EEDD",
                         },
                       ],
                     },
@@ -13649,7 +13548,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3BucketF13820EA",
+            "Ref": "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3Bucket8AFE0D2F",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -13662,7 +13561,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3VersionKey52B24F16",
+                          "Ref": "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3VersionKey39383E8E",
                         },
                       ],
                     },
@@ -13675,7 +13574,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3VersionKey52B24F16",
+                          "Ref": "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3VersionKey39383E8E",
                         },
                       ],
                     },
@@ -14180,7 +14079,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3Bucket5255533F",
+            "Ref": "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3Bucket0A90D6D3",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -14193,7 +14092,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3VersionKey7909F675",
+                          "Ref": "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3VersionKeyA116EF05",
                         },
                       ],
                     },
@@ -14206,7 +14105,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3VersionKey7909F675",
+                          "Ref": "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3VersionKeyA116EF05",
                         },
                       ],
                     },
@@ -14935,7 +14834,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3Bucket5515214C",
+            "Ref": "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3Bucket649728C0",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -14948,7 +14847,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED",
+                          "Ref": "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3VersionKey592D485B",
                         },
                       ],
                     },
@@ -14961,7 +14860,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED",
+                          "Ref": "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3VersionKey592D485B",
                         },
                       ],
                     },
@@ -15990,7 +15889,7 @@ Direct link to function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3BucketE7A02ACD",
+            "Ref": "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3Bucket635A0AFA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -16003,7 +15902,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3VersionKeyCC994D9E",
+                          "Ref": "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3VersionKeyBB104177",
                         },
                       ],
                     },
@@ -16016,7 +15915,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3VersionKeyCC994D9E",
+                          "Ref": "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3VersionKeyBB104177",
                         },
                       ],
                     },
@@ -16148,7 +16047,7 @@ Direct link to function: /lambda/home#/functions/",
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"StartAt\\":\\"Track Execution Infos\\",\\"States\\":{\\"Track Execution Infos\\":{\\"Type\\":\\"Pass\\",\\"ResultPath\\":\\"$.$TaskExecution\\",\\"InputPath\\":\\"$$.Execution\\",\\"Parameters\\":{\\"Id.$\\":\\"$.Id\\",\\"Name.$\\":\\"$.Name\\",\\"RoleArn.$\\":\\"$.RoleArn\\",\\"StartTime.$\\":\\"$.StartTime\\"},\\"Next\\":\\"Prepare doc-gen ECS Command\\"},\\"Prepare doc-gen ECS Command\\":{\\"Type\\":\\"Pass\\",\\"ResultPath\\":\\"$.docGen\\",\\"Parameters\\":{\\"command.$\\":\\"States.Array(States.JsonToString($))\\"},\\"Next\\":\\"Generate docs\\"},\\"Generate docs\\":{\\"Next\\":\\"Check whether catalog needs udpating\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"jsii-docgen.NoSpaceLeftOnDevice\\"],\\"MaxAttempts\\":0},{\\"ErrorEquals\\":[\\"ECS.AmazonECSException\\",\\"ECS.InvalidParameterException\\",\\"jsii-docgen.NpmError.E429\\",\\"jsii-codgen.NpmError.EPROTO\\"],\\"IntervalSeconds\\":120,\\"MaxAttempts\\":200,\\"BackoffRate\\":1},{\\"ErrorEquals\\":[\\"jsii-docgen.NpmError.ETARGET\\"],\\"IntervalSeconds\\":300,\\"MaxAttempts\\":3,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"MaxAttempts\\":3}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"UnprocessablePackageError\\"],\\"Next\\":\\"Ignore\\"},{\\"ErrorEquals\\":[\\"States.Timeout\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"ECS.AmazonECSException\\",\\"ECS.InvalidParameterException\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Type\\":\\"Task\\",\\"TimeoutSeconds\\":7200,\\"HeartbeatSeconds\\":300,\\"InputPath\\":\\"$.docGen.command\\",\\"ResultPath\\":\\"$.docGenOutput\\",\\"Resource\\":\\"arn:",
+              "{\\"StartAt\\":\\"Track Execution Infos\\",\\"States\\":{\\"Track Execution Infos\\":{\\"Type\\":\\"Pass\\",\\"ResultPath\\":\\"$.$TaskExecution\\",\\"InputPath\\":\\"$$.Execution\\",\\"Parameters\\":{\\"Id.$\\":\\"$.Id\\",\\"Name.$\\":\\"$.Name\\",\\"RoleArn.$\\":\\"$.RoleArn\\",\\"StartTime.$\\":\\"$.StartTime\\"},\\"Next\\":\\"Prepare doc-gen ECS Command\\"},\\"Prepare doc-gen ECS Command\\":{\\"Type\\":\\"Pass\\",\\"ResultPath\\":\\"$.docGen\\",\\"Parameters\\":{\\"command.$\\":\\"States.Array(States.JsonToString($))\\"},\\"Next\\":\\"Generate docs\\"},\\"Generate docs\\":{\\"Next\\":\\"Check whether catalog needs udpating\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"jsii-docgen.NoSpaceLeftOnDevice\\"],\\"MaxAttempts\\":0},{\\"ErrorEquals\\":[\\"ECS.AmazonECSException\\",\\"ECS.InvalidParameterException\\",\\"jsii-docgen.NpmError.E429\\",\\"jsii-codgen.NpmError.EPROTO\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":30,\\"BackoffRate\\":1.1},{\\"ErrorEquals\\":[\\"jsii-docgen.NpmError.ETARGET\\"],\\"IntervalSeconds\\":300,\\"MaxAttempts\\":3,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"MaxAttempts\\":3}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"UnprocessablePackageError\\"],\\"Next\\":\\"Ignore\\"},{\\"ErrorEquals\\":[\\"States.Timeout\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"ECS.AmazonECSException\\",\\"ECS.InvalidParameterException\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Type\\":\\"Task\\",\\"TimeoutSeconds\\":3600,\\"HeartbeatSeconds\\":300,\\"InputPath\\":\\"$.docGen.command\\",\\"ResultPath\\":\\"$.docGenOutput\\",\\"Resource\\":\\"arn:",
               Object {
                 "Ref": "AWS::Partition",
               },
@@ -16174,7 +16073,7 @@ Direct link to function: /lambda/home#/functions/",
                   "GroupId",
                 ],
               },
-              "\\"]}},\\"Overrides\\":{\\"ContainerOverrides\\":[{\\"Name\\":\\"Resource\\",\\"Command.$\\":\\"$\\",\\"Environment\\":[{\\"Name\\":\\"SFN_TASK_TOKEN\\",\\"Value.$\\":\\"$$.Task.Token\\"}]}]},\\"LaunchType\\":\\"FARGATE\\",\\"PlatformVersion\\":\\"1.4.0\\"}},\\"Check whether catalog needs udpating\\":{\\"Next\\":\\"Is catalog update needed?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"Lambda.ServiceException\\",\\"Lambda.AWSLambdaException\\",\\"Lambda.SdkClientException\\"],\\"IntervalSeconds\\":2,\\"MaxAttempts\\":6,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\",\\"Lambda.Unknown\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":30,\\"BackoffRate\\":1.1}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\",\\"Lambda.Unknown\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.catalogNeedsUpdating\\",\\"Resource\\":\\"",
+              "\\"]}},\\"Overrides\\":{\\"ContainerOverrides\\":[{\\"Name\\":\\"Resource\\",\\"Command.$\\":\\"$\\",\\"Environment\\":[{\\"Name\\":\\"SFN_TASK_TOKEN\\",\\"Value.$\\":\\"$$.Task.Token\\"}]}]},\\"LaunchType\\":\\"FARGATE\\",\\"PlatformVersion\\":\\"1.4.0\\"}},\\"Check whether catalog needs udpating\\":{\\"Next\\":\\"Is catalog update needed?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"Lambda.ServiceException\\",\\"Lambda.AWSLambdaException\\",\\"Lambda.SdkClientException\\"],\\"IntervalSeconds\\":2,\\"MaxAttempts\\":6,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":30,\\"BackoffRate\\":1.1}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.catalogNeedsUpdating\\",\\"Resource\\":\\"",
               Object {
                 "Fn::GetAtt": Array [
                   "ConstructHubOrchestrationNeedsCatalogUpdate5D7370DC",
@@ -16225,7 +16124,7 @@ Direct link to function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3Bucket722FE70B",
+            "Ref": "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3Bucket2D6D8F86",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -16238,7 +16137,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3VersionKey8082F3BC",
+                          "Ref": "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3VersionKey0ECB40A6",
                         },
                       ],
                     },
@@ -16251,7 +16150,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3VersionKey8082F3BC",
+                          "Ref": "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3VersionKey0ECB40A6",
                         },
                       ],
                     },
@@ -17053,7 +16952,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3BucketE78A0203",
+            "Ref": "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3Bucket19B71C5A",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -17066,7 +16965,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3VersionKey598098A7",
+                          "Ref": "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3VersionKeyDF73A6F0",
                         },
                       ],
                     },
@@ -17079,7 +16978,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3VersionKey598098A7",
+                          "Ref": "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3VersionKeyDF73A6F0",
                         },
                       ],
                     },
@@ -17237,7 +17136,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3Bucket6F376B71",
+            "Ref": "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3Bucket1090210F",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -17250,7 +17149,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3VersionKey7F6E5804",
+                          "Ref": "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3VersionKeyD738CD6B",
                         },
                       ],
                     },
@@ -17263,7 +17162,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3VersionKey7F6E5804",
+                          "Ref": "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3VersionKeyD738CD6B",
                         },
                       ],
                     },
@@ -18068,7 +17967,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                   Object {
                     "Ref": "AWS::URLSuffix",
                   },
-                  "/aws-cdk/assets:89c6683e392b08bdb9bfd8e456f82a156b228534eed332191232b4aa0beec4f2",
+                  "/aws-cdk/assets:5fa39a328f34360df81ad2f478b29e7f72b6625d60d6ca775401e69a3b2c0faf",
                 ],
               ],
             },
@@ -18396,7 +18295,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.*",
+                      "/data/*/docs-typescript.md",
                     ],
                   ],
                 },
@@ -18426,7 +18325,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.*",
+                      "/data/*/docs-*-typescript.md",
                     ],
                   ],
                 },
@@ -18456,7 +18355,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.*.not-supported",
+                      "/data/*/docs-typescript.md.not-supported",
                     ],
                   ],
                 },
@@ -18486,7 +18385,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.*.not-supported",
+                      "/data/*/docs-*-typescript.md.not-supported",
                     ],
                   ],
                 },
@@ -18516,7 +18415,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.*.corruptassembly",
+                      "/data/*/docs-typescript.md.corruptassembly",
                     ],
                   ],
                 },
@@ -18546,7 +18445,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.*.corruptassembly",
+                      "/data/*/docs-*-typescript.md.corruptassembly",
                     ],
                   ],
                 },
@@ -18565,7 +18464,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-typescript.*.corruptassembly",
+                    "/data/*/docs-typescript.md.corruptassembly",
                   ],
                 ],
               },
@@ -18583,223 +18482,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-typescript.*.corruptassembly",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.*.not-supported",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.*.not-supported",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.*.corruptassembly",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.*.corruptassembly",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": "s3:DeleteObject*",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "ConstructHubPackageDataDC5EF35E",
-                        "Arn",
-                      ],
-                    },
-                    "/data/*/docs-python.*.corruptassembly",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": "s3:DeleteObject*",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "ConstructHubPackageDataDC5EF35E",
-                        "Arn",
-                      ],
-                    },
-                    "/data/*/docs-*-python.*.corruptassembly",
+                    "/data/*/docs-*-typescript.md.corruptassembly",
                   ],
                 ],
               },
@@ -18828,7 +18511,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.*",
+                      "/data/*/docs-python.md",
                     ],
                   ],
                 },
@@ -18858,7 +18541,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.*",
+                      "/data/*/docs-*-python.md",
                     ],
                   ],
                 },
@@ -18888,7 +18571,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.*.not-supported",
+                      "/data/*/docs-python.md.not-supported",
                     ],
                   ],
                 },
@@ -18918,7 +18601,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.*.not-supported",
+                      "/data/*/docs-*-python.md.not-supported",
                     ],
                   ],
                 },
@@ -18948,7 +18631,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.*.corruptassembly",
+                      "/data/*/docs-python.md.corruptassembly",
                     ],
                   ],
                 },
@@ -18978,7 +18661,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.*.corruptassembly",
+                      "/data/*/docs-*-python.md.corruptassembly",
                     ],
                   ],
                 },
@@ -18997,7 +18680,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-java.*.corruptassembly",
+                    "/data/*/docs-python.md.corruptassembly",
                   ],
                 ],
               },
@@ -19015,7 +18698,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-java.*.corruptassembly",
+                    "/data/*/docs-*-python.md.corruptassembly",
                   ],
                 ],
               },
@@ -19044,7 +18727,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.*",
+                      "/data/*/docs-java.md",
                     ],
                   ],
                 },
@@ -19074,7 +18757,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.*",
+                      "/data/*/docs-*-java.md",
                     ],
                   ],
                 },
@@ -19104,7 +18787,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.*.not-supported",
+                      "/data/*/docs-java.md.not-supported",
                     ],
                   ],
                 },
@@ -19134,7 +18817,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.*.not-supported",
+                      "/data/*/docs-*-java.md.not-supported",
                     ],
                   ],
                 },
@@ -19164,7 +18847,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.*.corruptassembly",
+                      "/data/*/docs-java.md.corruptassembly",
                     ],
                   ],
                 },
@@ -19194,7 +18877,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.*.corruptassembly",
+                      "/data/*/docs-*-java.md.corruptassembly",
                     ],
                   ],
                 },
@@ -19213,7 +18896,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-csharp.*.corruptassembly",
+                    "/data/*/docs-java.md.corruptassembly",
                   ],
                 ],
               },
@@ -19231,7 +18914,223 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-csharp.*.corruptassembly",
+                    "/data/*/docs-*-java.md.corruptassembly",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.md",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.md",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.md.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.md.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.md.corruptassembly",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.md.corruptassembly",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": "s3:DeleteObject*",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "ConstructHubPackageDataDC5EF35E",
+                        "Arn",
+                      ],
+                    },
+                    "/data/*/docs-csharp.md.corruptassembly",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:DeleteObject*",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "ConstructHubPackageDataDC5EF35E",
+                        "Arn",
+                      ],
+                    },
+                    "/data/*/docs-*-csharp.md.corruptassembly",
                   ],
                 ],
               },
@@ -19497,7 +19396,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3Bucket024B3DC6",
+            "Ref": "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3Bucket901B95EB",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -19510,7 +19409,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3VersionKeyEEA56859",
+                          "Ref": "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3VersionKeyC6FBD6BD",
                         },
                       ],
                     },
@@ -19523,7 +19422,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3VersionKeyEEA56859",
+                          "Ref": "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3VersionKeyC6FBD6BD",
                         },
                       ],
                     },
@@ -19580,7 +19479,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3Bucket37F2908E",
+            "Ref": "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3Bucket86DBA113",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -19593,7 +19492,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3VersionKey2C992F11",
+                          "Ref": "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3VersionKeyF547CFB5",
                         },
                       ],
                     },
@@ -19606,7 +19505,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3VersionKey2C992F11",
+                          "Ref": "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3VersionKeyF547CFB5",
                         },
                       ],
                     },
@@ -20169,7 +20068,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3Bucket8AF0E263",
+            "Ref": "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3BucketFFA964C8",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -20182,7 +20081,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3VersionKey5280D545",
+                          "Ref": "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3VersionKeyA62CD84A",
                         },
                       ],
                     },
@@ -20195,7 +20094,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3VersionKey5280D545",
+                          "Ref": "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3VersionKeyA62CD84A",
                         },
                       ],
                     },
@@ -20605,7 +20504,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3Bucket789CA701",
+            "Ref": "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3BucketE35D2278",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -20618,7 +20517,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3VersionKey0222399F",
+                          "Ref": "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3VersionKey88FA0AFA",
                         },
                       ],
                     },
@@ -20631,7 +20530,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3VersionKey0222399F",
+                          "Ref": "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3VersionKey88FA0AFA",
                         },
                       ],
                     },
@@ -20837,7 +20736,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3Bucket86412295",
+            "Ref": "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3BucketF9AF3C9C",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -20850,7 +20749,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3VersionKeyE42DDF01",
+                          "Ref": "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3VersionKey09B12EB1",
                         },
                       ],
                     },
@@ -20863,7 +20762,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3VersionKeyE42DDF01",
+                          "Ref": "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3VersionKey09B12EB1",
                         },
                       ],
                     },
@@ -21279,10 +21178,7 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3BucketED9FB7B0",
-          },
-          Object {
-            "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
+            "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1",
           },
         ],
         "SourceObjectKeys": Array [
@@ -21297,7 +21193,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3VersionKeyCFEDA3D4",
+                          "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3VersionKeyBA1CB663",
                         },
                       ],
                     },
@@ -21310,40 +21206,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3VersionKeyCFEDA3D4",
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            ],
-          },
-          Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                Object {
-                  "Fn::Select": Array [
-                    0,
-                    Object {
-                      "Fn::Split": Array [
-                        "||",
-                        Object {
-                          "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49",
-                        },
-                      ],
-                    },
-                  ],
-                },
-                Object {
-                  "Fn::Select": Array [
-                    1,
-                    Object {
-                      "Fn::Split": Array [
-                        "||",
-                        Object {
-                          "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49",
+                          "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3VersionKeyBA1CB663",
                         },
                       ],
                     },
@@ -21378,7 +21241,7 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2",
+            "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22",
           },
         ],
         "SourceObjectKeys": Array [
@@ -21393,7 +21256,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3VersionKeyEC7E3301",
+                          "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3VersionKeyCE5C5D3B",
                         },
                       ],
                     },
@@ -21406,7 +21269,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3VersionKeyEC7E3301",
+                          "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3VersionKeyCE5C5D3B",
                         },
                       ],
                     },
@@ -22087,7 +21950,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2",
+                        "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22",
                       },
                     ],
                   ],
@@ -22102,7 +21965,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2",
+                        "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22",
                       },
                       "/*",
                     ],
@@ -22169,7 +22032,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3BucketED9FB7B0",
+                        "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1",
                       },
                     ],
                   ],
@@ -22184,48 +22047,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3BucketED9FB7B0",
-                      },
-                      "/*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:GetObject*",
-                "s3:GetBucket*",
-                "s3:List*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":s3:::",
-                      Object {
-                        "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
-                      },
-                    ],
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":s3:::",
-                      Object {
-                        "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
+                        "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1",
                       },
                       "/*",
                     ],
@@ -22453,7 +22275,7 @@ function handler(event) {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3BucketCBEF8050",
+            "Ref": "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3Bucket1B95B117",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -22466,7 +22288,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3VersionKey57968381",
+                          "Ref": "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3VersionKey75D92238",
                         },
                       ],
                     },
@@ -22479,7 +22301,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3VersionKey57968381",
+                          "Ref": "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3VersionKey75D92238",
                         },
                       ],
                     },
@@ -22985,40 +22807,28 @@ Object {
     },
   },
   "Parameters": Object {
-    "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6ArtifactHashF2EEEBFF": Object {
-      "Description": "Artifact hash for asset \\"04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6\\"",
+    "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeArtifactHash322D47B8": Object {
+      "Description": "Artifact hash for asset \\"0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9ae\\"",
       "Type": "String",
     },
-    "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3Bucket86412295": Object {
-      "Description": "S3 bucket for asset \\"04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6\\"",
+    "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3Bucket635A0AFA": Object {
+      "Description": "S3 bucket for asset \\"0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9ae\\"",
       "Type": "String",
     },
-    "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3VersionKeyE42DDF01": Object {
-      "Description": "S3 key for asset version \\"04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6\\"",
+    "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3VersionKeyBB104177": Object {
+      "Description": "S3 key for asset version \\"0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9ae\\"",
       "Type": "String",
     },
-    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440ArtifactHash87A9FF22": Object {
-      "Description": "Artifact hash for asset \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
+    "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadArtifactHash3158CABD": Object {
+      "Description": "Artifact hash for asset \\"0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362ead\\"",
       "Type": "String",
     },
-    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054": Object {
-      "Description": "S3 bucket for asset \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
+    "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3Bucket288D5551": Object {
+      "Description": "S3 bucket for asset \\"0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362ead\\"",
       "Type": "String",
     },
-    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49": Object {
-      "Description": "S3 key for asset version \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
-      "Type": "String",
-    },
-    "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aArtifactHash82449A4A": Object {
-      "Description": "Artifact hash for asset \\"0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4a\\"",
-      "Type": "String",
-    },
-    "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3Bucket789CA701": Object {
-      "Description": "S3 bucket for asset \\"0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4a\\"",
-      "Type": "String",
-    },
-    "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3VersionKey0222399F": Object {
-      "Description": "S3 key for asset version \\"0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4a\\"",
+    "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3VersionKey4638DF79": Object {
+      "Description": "S3 key for asset version \\"0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362ead\\"",
       "Type": "String",
     },
     "AssetParameters0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9ArtifactHashB9E3BF29": Object {
@@ -23033,6 +22843,42 @@ Object {
       "Description": "S3 key for asset version \\"0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9\\"",
       "Type": "String",
     },
+    "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67ArtifactHashCF96E147": Object {
+      "Description": "Artifact hash for asset \\"1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67\\"",
+      "Type": "String",
+    },
+    "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3BucketFFA964C8": Object {
+      "Description": "S3 bucket for asset \\"1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67\\"",
+      "Type": "String",
+    },
+    "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3VersionKeyA62CD84A": Object {
+      "Description": "S3 key for asset version \\"1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67\\"",
+      "Type": "String",
+    },
+    "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3ArtifactHashA3981DF8": Object {
+      "Description": "Artifact hash for asset \\"1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3\\"",
+      "Type": "String",
+    },
+    "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1": Object {
+      "Description": "S3 bucket for asset \\"1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3\\"",
+      "Type": "String",
+    },
+    "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3VersionKeyBA1CB663": Object {
+      "Description": "S3 key for asset version \\"1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3\\"",
+      "Type": "String",
+    },
+    "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeArtifactHashD1A9CF6A": Object {
+      "Description": "Artifact hash for asset \\"1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33ae\\"",
+      "Type": "String",
+    },
+    "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3Bucket901B95EB": Object {
+      "Description": "S3 bucket for asset \\"1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33ae\\"",
+      "Type": "String",
+    },
+    "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3VersionKeyC6FBD6BD": Object {
+      "Description": "S3 key for asset version \\"1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33ae\\"",
+      "Type": "String",
+    },
     "AssetParameters1f7e277bd526ebce1983fa1e7a84a5281ec533d9187caaebb773681bbf7bf4c1ArtifactHash0128B949": Object {
       "Description": "Artifact hash for asset \\"1f7e277bd526ebce1983fa1e7a84a5281ec533d9187caaebb773681bbf7bf4c1\\"",
       "Type": "String",
@@ -23045,88 +22891,112 @@ Object {
       "Description": "S3 key for asset version \\"1f7e277bd526ebce1983fa1e7a84a5281ec533d9187caaebb773681bbf7bf4c1\\"",
       "Type": "String",
     },
-    "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5ArtifactHash0AFE0939": Object {
-      "Description": "Artifact hash for asset \\"37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5\\"",
+    "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cArtifactHash8D005B5F": Object {
+      "Description": "Artifact hash for asset \\"205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612c\\"",
       "Type": "String",
     },
-    "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3Bucket722FE70B": Object {
-      "Description": "S3 bucket for asset \\"37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5\\"",
+    "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3Bucket95F679AA": Object {
+      "Description": "S3 bucket for asset \\"205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612c\\"",
       "Type": "String",
     },
-    "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3VersionKey8082F3BC": Object {
-      "Description": "S3 key for asset version \\"37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5\\"",
+    "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3VersionKeyE7A4EEDD": Object {
+      "Description": "S3 key for asset version \\"205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612c\\"",
       "Type": "String",
     },
-    "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5ArtifactHash499F6DFF": Object {
-      "Description": "Artifact hash for asset \\"3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5\\"",
+    "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534ArtifactHash89381734": Object {
+      "Description": "Artifact hash for asset \\"25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534\\"",
       "Type": "String",
     },
-    "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3Bucket37F2908E": Object {
-      "Description": "S3 bucket for asset \\"3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5\\"",
+    "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3Bucket8AFE0D2F": Object {
+      "Description": "S3 bucket for asset \\"25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534\\"",
       "Type": "String",
     },
-    "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3VersionKey2C992F11": Object {
-      "Description": "S3 key for asset version \\"3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5\\"",
+    "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3VersionKey39383E8E": Object {
+      "Description": "S3 key for asset version \\"25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534\\"",
       "Type": "String",
     },
-    "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dArtifactHash3B82A2B3": Object {
-      "Description": "Artifact hash for asset \\"3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880d\\"",
+    "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bArtifactHash270470CC": Object {
+      "Description": "Artifact hash for asset \\"3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934b\\"",
       "Type": "String",
     },
-    "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3BucketCBEF8050": Object {
-      "Description": "S3 bucket for asset \\"3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880d\\"",
+    "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3Bucket2D6D8F86": Object {
+      "Description": "S3 bucket for asset \\"3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934b\\"",
       "Type": "String",
     },
-    "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3VersionKey57968381": Object {
-      "Description": "S3 key for asset version \\"3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880d\\"",
+    "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3VersionKey0ECB40A6": Object {
+      "Description": "S3 key for asset version \\"3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934b\\"",
       "Type": "String",
     },
-    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afArtifactHash7F8A76FC": Object {
-      "Description": "Artifact hash for asset \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
+    "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0ArtifactHash6F14CF3C": Object {
+      "Description": "Artifact hash for asset \\"55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0\\"",
       "Type": "String",
     },
-    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3Bucket5515214C": Object {
-      "Description": "S3 bucket for asset \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
+    "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3BucketE35D2278": Object {
+      "Description": "S3 bucket for asset \\"55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0\\"",
       "Type": "String",
     },
-    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED": Object {
-      "Description": "S3 key for asset version \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
+    "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3VersionKey88FA0AFA": Object {
+      "Description": "S3 key for asset version \\"55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0\\"",
       "Type": "String",
     },
-    "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bArtifactHash5ABBFB9B": Object {
-      "Description": "Artifact hash for asset \\"42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2b\\"",
+    "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420ArtifactHashC847AA8D": Object {
+      "Description": "Artifact hash for asset \\"6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420\\"",
       "Type": "String",
     },
-    "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3Bucket8AF0E263": Object {
-      "Description": "S3 bucket for asset \\"42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2b\\"",
+    "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3Bucket649728C0": Object {
+      "Description": "S3 bucket for asset \\"6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420\\"",
       "Type": "String",
     },
-    "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3VersionKey5280D545": Object {
-      "Description": "S3 key for asset version \\"42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2b\\"",
+    "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3VersionKey592D485B": Object {
+      "Description": "S3 key for asset version \\"6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420\\"",
       "Type": "String",
     },
-    "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeArtifactHash3FAC57D3": Object {
-      "Description": "Artifact hash for asset \\"4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeee\\"",
+    "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cArtifactHashD2B94368": Object {
+      "Description": "Artifact hash for asset \\"73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06c\\"",
       "Type": "String",
     },
-    "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3Bucket6F376B71": Object {
-      "Description": "S3 bucket for asset \\"4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeee\\"",
+    "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3Bucket19B71C5A": Object {
+      "Description": "S3 bucket for asset \\"73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06c\\"",
       "Type": "String",
     },
-    "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3VersionKey7F6E5804": Object {
-      "Description": "S3 key for asset version \\"4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeee\\"",
+    "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3VersionKeyDF73A6F0": Object {
+      "Description": "S3 key for asset version \\"73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06c\\"",
       "Type": "String",
     },
-    "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680ArtifactHash316B2926": Object {
-      "Description": "Artifact hash for asset \\"864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680\\"",
+    "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fArtifactHash2005F882": Object {
+      "Description": "Artifact hash for asset \\"778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6f\\"",
       "Type": "String",
     },
-    "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3BucketF13820EA": Object {
-      "Description": "S3 bucket for asset \\"864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680\\"",
+    "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22": Object {
+      "Description": "S3 bucket for asset \\"778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6f\\"",
       "Type": "String",
     },
-    "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3VersionKey52B24F16": Object {
-      "Description": "S3 key for asset version \\"864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680\\"",
+    "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3VersionKeyCE5C5D3B": Object {
+      "Description": "S3 key for asset version \\"778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6f\\"",
+      "Type": "String",
+    },
+    "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0ArtifactHashF4B56B1E": Object {
+      "Description": "Artifact hash for asset \\"782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0\\"",
+      "Type": "String",
+    },
+    "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3Bucket1090210F": Object {
+      "Description": "S3 bucket for asset \\"782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0\\"",
+      "Type": "String",
+    },
+    "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3VersionKeyD738CD6B": Object {
+      "Description": "S3 key for asset version \\"782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0\\"",
+      "Type": "String",
+    },
+    "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965ArtifactHashD4D3C5A6": Object {
+      "Description": "Artifact hash for asset \\"7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965\\"",
+      "Type": "String",
+    },
+    "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3Bucket0A90D6D3": Object {
+      "Description": "S3 bucket for asset \\"7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965\\"",
+      "Type": "String",
+    },
+    "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3VersionKeyA116EF05": Object {
+      "Description": "S3 key for asset version \\"7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965\\"",
       "Type": "String",
     },
     "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900ArtifactHash121EF458": Object {
@@ -23141,18 +23011,6 @@ Object {
       "Description": "S3 key for asset version \\"8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900\\"",
       "Type": "String",
     },
-    "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9ArtifactHash694505BF": Object {
-      "Description": "Artifact hash for asset \\"8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9\\"",
-      "Type": "String",
-    },
-    "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3BucketED9FB7B0": Object {
-      "Description": "S3 bucket for asset \\"8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9\\"",
-      "Type": "String",
-    },
-    "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3VersionKeyCFEDA3D4": Object {
-      "Description": "S3 key for asset version \\"8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9\\"",
-      "Type": "String",
-    },
     "AssetParameters8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064ArtifactHashEA963870": Object {
       "Description": "Artifact hash for asset \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
@@ -23165,16 +23023,16 @@ Object {
       "Description": "S3 key for asset version \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
     },
-    "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4ArtifactHash660A50B8": Object {
-      "Description": "Artifact hash for asset \\"98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4\\"",
+    "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8ArtifactHash8DC0C383": Object {
+      "Description": "Artifact hash for asset \\"9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8\\"",
       "Type": "String",
     },
-    "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3BucketE78A0203": Object {
-      "Description": "S3 bucket for asset \\"98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4\\"",
+    "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3Bucket1B95B117": Object {
+      "Description": "S3 bucket for asset \\"9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8\\"",
       "Type": "String",
     },
-    "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3VersionKey598098A7": Object {
-      "Description": "S3 key for asset version \\"98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4\\"",
+    "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3VersionKey75D92238": Object {
+      "Description": "S3 key for asset version \\"9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8\\"",
       "Type": "String",
     },
     "AssetParametersa3058ccb468d757ebb89df5363a1c20f5307c6911136f29d00e1a68c9b2aa7e8ArtifactHash238275D6": Object {
@@ -23189,16 +23047,16 @@ Object {
       "Description": "S3 key for asset version \\"a3058ccb468d757ebb89df5363a1c20f5307c6911136f29d00e1a68c9b2aa7e8\\"",
       "Type": "String",
     },
-    "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaArtifactHash8CCAA809": Object {
-      "Description": "Artifact hash for asset \\"af643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfba\\"",
+    "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdArtifactHash22ECD1BE": Object {
+      "Description": "Artifact hash for asset \\"adb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbd\\"",
       "Type": "String",
     },
-    "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2": Object {
-      "Description": "S3 bucket for asset \\"af643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfba\\"",
+    "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3BucketF9AF3C9C": Object {
+      "Description": "S3 bucket for asset \\"adb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbd\\"",
       "Type": "String",
     },
-    "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3VersionKeyEC7E3301": Object {
-      "Description": "S3 key for asset version \\"af643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfba\\"",
+    "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3VersionKey09B12EB1": Object {
+      "Description": "S3 key for asset version \\"adb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbd\\"",
       "Type": "String",
     },
     "AssetParametersb120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827ArtifactHash1355580A": Object {
@@ -23213,40 +23071,16 @@ Object {
       "Description": "S3 key for asset version \\"b120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827\\"",
       "Type": "String",
     },
-    "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04ArtifactHash394183E9": Object {
-      "Description": "Artifact hash for asset \\"b55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04\\"",
+    "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8ArtifactHashBB72DCC8": Object {
+      "Description": "Artifact hash for asset \\"c8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8\\"",
       "Type": "String",
     },
-    "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3BucketE7A02ACD": Object {
-      "Description": "S3 bucket for asset \\"b55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04\\"",
+    "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3Bucket86DBA113": Object {
+      "Description": "S3 bucket for asset \\"c8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8\\"",
       "Type": "String",
     },
-    "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3VersionKeyCC994D9E": Object {
-      "Description": "S3 key for asset version \\"b55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04\\"",
-      "Type": "String",
-    },
-    "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcArtifactHash4E26EEC4": Object {
-      "Description": "Artifact hash for asset \\"c62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafc\\"",
-      "Type": "String",
-    },
-    "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3Bucket5255533F": Object {
-      "Description": "S3 bucket for asset \\"c62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafc\\"",
-      "Type": "String",
-    },
-    "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3VersionKey7909F675": Object {
-      "Description": "S3 key for asset version \\"c62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafc\\"",
-      "Type": "String",
-    },
-    "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aArtifactHash0386B8EC": Object {
-      "Description": "Artifact hash for asset \\"da314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17a\\"",
-      "Type": "String",
-    },
-    "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3BucketAE80D773": Object {
-      "Description": "S3 bucket for asset \\"da314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17a\\"",
-      "Type": "String",
-    },
-    "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3VersionKey662F0E6F": Object {
-      "Description": "S3 key for asset version \\"da314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17a\\"",
+    "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3VersionKeyF547CFB5": Object {
+      "Description": "S3 key for asset version \\"c8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8\\"",
       "Type": "String",
     },
     "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68ArtifactHashD9A515C3": Object {
@@ -23259,30 +23093,6 @@ Object {
     },
     "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3VersionKeyE415415F": Object {
       "Description": "S3 key for asset version \\"e9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68\\"",
-      "Type": "String",
-    },
-    "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3ArtifactHash11DB5971": Object {
-      "Description": "Artifact hash for asset \\"f48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3\\"",
-      "Type": "String",
-    },
-    "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3BucketAC5DE359": Object {
-      "Description": "S3 bucket for asset \\"f48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3\\"",
-      "Type": "String",
-    },
-    "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3VersionKey503D22DC": Object {
-      "Description": "S3 key for asset version \\"f48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3\\"",
-      "Type": "String",
-    },
-    "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5ArtifactHash185A4671": Object {
-      "Description": "Artifact hash for asset \\"fbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5\\"",
-      "Type": "String",
-    },
-    "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3Bucket024B3DC6": Object {
-      "Description": "S3 bucket for asset \\"fbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5\\"",
-      "Type": "String",
-    },
-    "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3VersionKeyEEA56859": Object {
-      "Description": "S3 key for asset version \\"fbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5\\"",
       "Type": "String",
     },
   },
@@ -24531,7 +24341,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3BucketAE80D773",
+            "Ref": "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3Bucket288D5551",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -24544,7 +24354,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3VersionKey662F0E6F",
+                          "Ref": "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3VersionKey4638DF79",
                         },
                       ],
                     },
@@ -24557,7 +24367,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3VersionKey662F0E6F",
+                          "Ref": "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3VersionKey4638DF79",
                         },
                       ],
                     },
@@ -24740,7 +24550,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3BucketAC5DE359",
+            "Ref": "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3Bucket95F679AA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -24753,7 +24563,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3VersionKey503D22DC",
+                          "Ref": "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3VersionKeyE7A4EEDD",
                         },
                       ],
                     },
@@ -24766,7 +24576,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3VersionKey503D22DC",
+                          "Ref": "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3VersionKeyE7A4EEDD",
                         },
                       ],
                     },
@@ -25006,7 +24816,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3BucketF13820EA",
+            "Ref": "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3Bucket8AFE0D2F",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -25019,7 +24829,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3VersionKey52B24F16",
+                          "Ref": "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3VersionKey39383E8E",
                         },
                       ],
                     },
@@ -25032,7 +24842,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3VersionKey52B24F16",
+                          "Ref": "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3VersionKey39383E8E",
                         },
                       ],
                     },
@@ -25519,7 +25329,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3Bucket5255533F",
+            "Ref": "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3Bucket0A90D6D3",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -25532,7 +25342,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3VersionKey7909F675",
+                          "Ref": "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3VersionKeyA116EF05",
                         },
                       ],
                     },
@@ -25545,7 +25355,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3VersionKey7909F675",
+                          "Ref": "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3VersionKeyA116EF05",
                         },
                       ],
                     },
@@ -26194,7 +26004,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3Bucket5515214C",
+            "Ref": "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3Bucket649728C0",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -26207,7 +26017,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED",
+                          "Ref": "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3VersionKey592D485B",
                         },
                       ],
                     },
@@ -26220,7 +26030,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED",
+                          "Ref": "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3VersionKey592D485B",
                         },
                       ],
                     },
@@ -27249,7 +27059,7 @@ Direct link to function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3BucketE7A02ACD",
+            "Ref": "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3Bucket635A0AFA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -27262,7 +27072,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3VersionKeyCC994D9E",
+                          "Ref": "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3VersionKeyBB104177",
                         },
                       ],
                     },
@@ -27275,7 +27085,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3VersionKeyCC994D9E",
+                          "Ref": "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3VersionKeyBB104177",
                         },
                       ],
                     },
@@ -27407,7 +27217,7 @@ Direct link to function: /lambda/home#/functions/",
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"StartAt\\":\\"Track Execution Infos\\",\\"States\\":{\\"Track Execution Infos\\":{\\"Type\\":\\"Pass\\",\\"ResultPath\\":\\"$.$TaskExecution\\",\\"InputPath\\":\\"$$.Execution\\",\\"Parameters\\":{\\"Id.$\\":\\"$.Id\\",\\"Name.$\\":\\"$.Name\\",\\"RoleArn.$\\":\\"$.RoleArn\\",\\"StartTime.$\\":\\"$.StartTime\\"},\\"Next\\":\\"Prepare doc-gen ECS Command\\"},\\"Prepare doc-gen ECS Command\\":{\\"Type\\":\\"Pass\\",\\"ResultPath\\":\\"$.docGen\\",\\"Parameters\\":{\\"command.$\\":\\"States.Array(States.JsonToString($))\\"},\\"Next\\":\\"Generate docs\\"},\\"Generate docs\\":{\\"Next\\":\\"Check whether catalog needs udpating\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"jsii-docgen.NoSpaceLeftOnDevice\\"],\\"MaxAttempts\\":0},{\\"ErrorEquals\\":[\\"ECS.AmazonECSException\\",\\"ECS.InvalidParameterException\\",\\"jsii-docgen.NpmError.E429\\",\\"jsii-codgen.NpmError.EPROTO\\"],\\"IntervalSeconds\\":120,\\"MaxAttempts\\":200,\\"BackoffRate\\":1},{\\"ErrorEquals\\":[\\"jsii-docgen.NpmError.ETARGET\\"],\\"IntervalSeconds\\":300,\\"MaxAttempts\\":3,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"MaxAttempts\\":3}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"UnprocessablePackageError\\"],\\"Next\\":\\"Ignore\\"},{\\"ErrorEquals\\":[\\"States.Timeout\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"ECS.AmazonECSException\\",\\"ECS.InvalidParameterException\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Type\\":\\"Task\\",\\"TimeoutSeconds\\":7200,\\"HeartbeatSeconds\\":300,\\"InputPath\\":\\"$.docGen.command\\",\\"ResultPath\\":\\"$.docGenOutput\\",\\"Resource\\":\\"arn:",
+              "{\\"StartAt\\":\\"Track Execution Infos\\",\\"States\\":{\\"Track Execution Infos\\":{\\"Type\\":\\"Pass\\",\\"ResultPath\\":\\"$.$TaskExecution\\",\\"InputPath\\":\\"$$.Execution\\",\\"Parameters\\":{\\"Id.$\\":\\"$.Id\\",\\"Name.$\\":\\"$.Name\\",\\"RoleArn.$\\":\\"$.RoleArn\\",\\"StartTime.$\\":\\"$.StartTime\\"},\\"Next\\":\\"Prepare doc-gen ECS Command\\"},\\"Prepare doc-gen ECS Command\\":{\\"Type\\":\\"Pass\\",\\"ResultPath\\":\\"$.docGen\\",\\"Parameters\\":{\\"command.$\\":\\"States.Array(States.JsonToString($))\\"},\\"Next\\":\\"Generate docs\\"},\\"Generate docs\\":{\\"Next\\":\\"Check whether catalog needs udpating\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"jsii-docgen.NoSpaceLeftOnDevice\\"],\\"MaxAttempts\\":0},{\\"ErrorEquals\\":[\\"ECS.AmazonECSException\\",\\"ECS.InvalidParameterException\\",\\"jsii-docgen.NpmError.E429\\",\\"jsii-codgen.NpmError.EPROTO\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":30,\\"BackoffRate\\":1.1},{\\"ErrorEquals\\":[\\"jsii-docgen.NpmError.ETARGET\\"],\\"IntervalSeconds\\":300,\\"MaxAttempts\\":3,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"MaxAttempts\\":3}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"UnprocessablePackageError\\"],\\"Next\\":\\"Ignore\\"},{\\"ErrorEquals\\":[\\"States.Timeout\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"ECS.AmazonECSException\\",\\"ECS.InvalidParameterException\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Type\\":\\"Task\\",\\"TimeoutSeconds\\":3600,\\"HeartbeatSeconds\\":300,\\"InputPath\\":\\"$.docGen.command\\",\\"ResultPath\\":\\"$.docGenOutput\\",\\"Resource\\":\\"arn:",
               Object {
                 "Ref": "AWS::Partition",
               },
@@ -27433,7 +27243,7 @@ Direct link to function: /lambda/home#/functions/",
                   "GroupId",
                 ],
               },
-              "\\"]}},\\"Overrides\\":{\\"ContainerOverrides\\":[{\\"Name\\":\\"Resource\\",\\"Command.$\\":\\"$\\",\\"Environment\\":[{\\"Name\\":\\"SFN_TASK_TOKEN\\",\\"Value.$\\":\\"$$.Task.Token\\"}]}]},\\"LaunchType\\":\\"FARGATE\\",\\"PlatformVersion\\":\\"1.4.0\\"}},\\"Check whether catalog needs udpating\\":{\\"Next\\":\\"Is catalog update needed?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"Lambda.ServiceException\\",\\"Lambda.AWSLambdaException\\",\\"Lambda.SdkClientException\\"],\\"IntervalSeconds\\":2,\\"MaxAttempts\\":6,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\",\\"Lambda.Unknown\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":30,\\"BackoffRate\\":1.1}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\",\\"Lambda.Unknown\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.catalogNeedsUpdating\\",\\"Resource\\":\\"",
+              "\\"]}},\\"Overrides\\":{\\"ContainerOverrides\\":[{\\"Name\\":\\"Resource\\",\\"Command.$\\":\\"$\\",\\"Environment\\":[{\\"Name\\":\\"SFN_TASK_TOKEN\\",\\"Value.$\\":\\"$$.Task.Token\\"}]}]},\\"LaunchType\\":\\"FARGATE\\",\\"PlatformVersion\\":\\"1.4.0\\"}},\\"Check whether catalog needs udpating\\":{\\"Next\\":\\"Is catalog update needed?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"Lambda.ServiceException\\",\\"Lambda.AWSLambdaException\\",\\"Lambda.SdkClientException\\"],\\"IntervalSeconds\\":2,\\"MaxAttempts\\":6,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":30,\\"BackoffRate\\":1.1}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.catalogNeedsUpdating\\",\\"Resource\\":\\"",
               Object {
                 "Fn::GetAtt": Array [
                   "ConstructHubOrchestrationNeedsCatalogUpdate5D7370DC",
@@ -27484,7 +27294,7 @@ Direct link to function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3Bucket722FE70B",
+            "Ref": "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3Bucket2D6D8F86",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -27497,7 +27307,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3VersionKey8082F3BC",
+                          "Ref": "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3VersionKey0ECB40A6",
                         },
                       ],
                     },
@@ -27510,7 +27320,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3VersionKey8082F3BC",
+                          "Ref": "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3VersionKey0ECB40A6",
                         },
                       ],
                     },
@@ -28312,7 +28122,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3BucketE78A0203",
+            "Ref": "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3Bucket19B71C5A",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -28325,7 +28135,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3VersionKey598098A7",
+                          "Ref": "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3VersionKeyDF73A6F0",
                         },
                       ],
                     },
@@ -28338,7 +28148,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3VersionKey598098A7",
+                          "Ref": "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3VersionKeyDF73A6F0",
                         },
                       ],
                     },
@@ -28496,7 +28306,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3Bucket6F376B71",
+            "Ref": "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3Bucket1090210F",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -28509,7 +28319,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3VersionKey7F6E5804",
+                          "Ref": "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3VersionKeyD738CD6B",
                         },
                       ],
                     },
@@ -28522,7 +28332,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3VersionKey7F6E5804",
+                          "Ref": "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3VersionKeyD738CD6B",
                         },
                       ],
                     },
@@ -29300,7 +29110,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                   Object {
                     "Ref": "AWS::URLSuffix",
                   },
-                  "/aws-cdk/assets:89c6683e392b08bdb9bfd8e456f82a156b228534eed332191232b4aa0beec4f2",
+                  "/aws-cdk/assets:5fa39a328f34360df81ad2f478b29e7f72b6625d60d6ca775401e69a3b2c0faf",
                 ],
               ],
             },
@@ -29582,7 +29392,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.*",
+                      "/data/*/docs-typescript.md",
                     ],
                   ],
                 },
@@ -29612,7 +29422,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.*",
+                      "/data/*/docs-*-typescript.md",
                     ],
                   ],
                 },
@@ -29642,7 +29452,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.*.not-supported",
+                      "/data/*/docs-typescript.md.not-supported",
                     ],
                   ],
                 },
@@ -29672,7 +29482,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.*.not-supported",
+                      "/data/*/docs-*-typescript.md.not-supported",
                     ],
                   ],
                 },
@@ -29702,7 +29512,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.*.corruptassembly",
+                      "/data/*/docs-typescript.md.corruptassembly",
                     ],
                   ],
                 },
@@ -29732,7 +29542,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.*.corruptassembly",
+                      "/data/*/docs-*-typescript.md.corruptassembly",
                     ],
                   ],
                 },
@@ -29751,7 +29561,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-typescript.*.corruptassembly",
+                    "/data/*/docs-typescript.md.corruptassembly",
                   ],
                 ],
               },
@@ -29769,223 +29579,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-typescript.*.corruptassembly",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.*.not-supported",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.*.not-supported",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.*.corruptassembly",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.*.corruptassembly",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": "s3:DeleteObject*",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "ConstructHubPackageDataDC5EF35E",
-                        "Arn",
-                      ],
-                    },
-                    "/data/*/docs-python.*.corruptassembly",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": "s3:DeleteObject*",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "ConstructHubPackageDataDC5EF35E",
-                        "Arn",
-                      ],
-                    },
-                    "/data/*/docs-*-python.*.corruptassembly",
+                    "/data/*/docs-*-typescript.md.corruptassembly",
                   ],
                 ],
               },
@@ -30014,7 +29608,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.*",
+                      "/data/*/docs-python.md",
                     ],
                   ],
                 },
@@ -30044,7 +29638,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.*",
+                      "/data/*/docs-*-python.md",
                     ],
                   ],
                 },
@@ -30074,7 +29668,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.*.not-supported",
+                      "/data/*/docs-python.md.not-supported",
                     ],
                   ],
                 },
@@ -30104,7 +29698,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.*.not-supported",
+                      "/data/*/docs-*-python.md.not-supported",
                     ],
                   ],
                 },
@@ -30134,7 +29728,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.*.corruptassembly",
+                      "/data/*/docs-python.md.corruptassembly",
                     ],
                   ],
                 },
@@ -30164,7 +29758,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.*.corruptassembly",
+                      "/data/*/docs-*-python.md.corruptassembly",
                     ],
                   ],
                 },
@@ -30183,7 +29777,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-java.*.corruptassembly",
+                    "/data/*/docs-python.md.corruptassembly",
                   ],
                 ],
               },
@@ -30201,7 +29795,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-java.*.corruptassembly",
+                    "/data/*/docs-*-python.md.corruptassembly",
                   ],
                 ],
               },
@@ -30230,7 +29824,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.*",
+                      "/data/*/docs-java.md",
                     ],
                   ],
                 },
@@ -30260,7 +29854,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.*",
+                      "/data/*/docs-*-java.md",
                     ],
                   ],
                 },
@@ -30290,7 +29884,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.*.not-supported",
+                      "/data/*/docs-java.md.not-supported",
                     ],
                   ],
                 },
@@ -30320,7 +29914,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.*.not-supported",
+                      "/data/*/docs-*-java.md.not-supported",
                     ],
                   ],
                 },
@@ -30350,7 +29944,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.*.corruptassembly",
+                      "/data/*/docs-java.md.corruptassembly",
                     ],
                   ],
                 },
@@ -30380,7 +29974,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.*.corruptassembly",
+                      "/data/*/docs-*-java.md.corruptassembly",
                     ],
                   ],
                 },
@@ -30399,7 +29993,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-csharp.*.corruptassembly",
+                    "/data/*/docs-java.md.corruptassembly",
                   ],
                 ],
               },
@@ -30417,7 +30011,223 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-csharp.*.corruptassembly",
+                    "/data/*/docs-*-java.md.corruptassembly",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.md",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.md",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.md.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.md.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.md.corruptassembly",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.md.corruptassembly",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": "s3:DeleteObject*",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "ConstructHubPackageDataDC5EF35E",
+                        "Arn",
+                      ],
+                    },
+                    "/data/*/docs-csharp.md.corruptassembly",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:DeleteObject*",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "ConstructHubPackageDataDC5EF35E",
+                        "Arn",
+                      ],
+                    },
+                    "/data/*/docs-*-csharp.md.corruptassembly",
                   ],
                 ],
               },
@@ -30683,7 +30493,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3Bucket024B3DC6",
+            "Ref": "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3Bucket901B95EB",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -30696,7 +30506,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3VersionKeyEEA56859",
+                          "Ref": "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3VersionKeyC6FBD6BD",
                         },
                       ],
                     },
@@ -30709,7 +30519,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3VersionKeyEEA56859",
+                          "Ref": "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3VersionKeyC6FBD6BD",
                         },
                       ],
                     },
@@ -30766,7 +30576,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3Bucket37F2908E",
+            "Ref": "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3Bucket86DBA113",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -30779,7 +30589,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3VersionKey2C992F11",
+                          "Ref": "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3VersionKeyF547CFB5",
                         },
                       ],
                     },
@@ -30792,7 +30602,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3VersionKey2C992F11",
+                          "Ref": "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3VersionKeyF547CFB5",
                         },
                       ],
                     },
@@ -31355,7 +31165,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3Bucket8AF0E263",
+            "Ref": "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3BucketFFA964C8",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -31368,7 +31178,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3VersionKey5280D545",
+                          "Ref": "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3VersionKeyA62CD84A",
                         },
                       ],
                     },
@@ -31381,7 +31191,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3VersionKey5280D545",
+                          "Ref": "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3VersionKeyA62CD84A",
                         },
                       ],
                     },
@@ -31791,7 +31601,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3Bucket789CA701",
+            "Ref": "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3BucketE35D2278",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -31804,7 +31614,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3VersionKey0222399F",
+                          "Ref": "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3VersionKey88FA0AFA",
                         },
                       ],
                     },
@@ -31817,7 +31627,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3VersionKey0222399F",
+                          "Ref": "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3VersionKey88FA0AFA",
                         },
                       ],
                     },
@@ -32023,7 +31833,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3Bucket86412295",
+            "Ref": "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3BucketF9AF3C9C",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -32036,7 +31846,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3VersionKeyE42DDF01",
+                          "Ref": "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3VersionKey09B12EB1",
                         },
                       ],
                     },
@@ -32049,7 +31859,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3VersionKeyE42DDF01",
+                          "Ref": "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3VersionKey09B12EB1",
                         },
                       ],
                     },
@@ -32465,10 +32275,7 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3BucketED9FB7B0",
-          },
-          Object {
-            "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
+            "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1",
           },
         ],
         "SourceObjectKeys": Array [
@@ -32483,7 +32290,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3VersionKeyCFEDA3D4",
+                          "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3VersionKeyBA1CB663",
                         },
                       ],
                     },
@@ -32496,40 +32303,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3VersionKeyCFEDA3D4",
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            ],
-          },
-          Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                Object {
-                  "Fn::Select": Array [
-                    0,
-                    Object {
-                      "Fn::Split": Array [
-                        "||",
-                        Object {
-                          "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49",
-                        },
-                      ],
-                    },
-                  ],
-                },
-                Object {
-                  "Fn::Select": Array [
-                    1,
-                    Object {
-                      "Fn::Split": Array [
-                        "||",
-                        Object {
-                          "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49",
+                          "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3VersionKeyBA1CB663",
                         },
                       ],
                     },
@@ -32564,7 +32338,7 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2",
+            "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22",
           },
         ],
         "SourceObjectKeys": Array [
@@ -32579,7 +32353,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3VersionKeyEC7E3301",
+                          "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3VersionKeyCE5C5D3B",
                         },
                       ],
                     },
@@ -32592,7 +32366,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3VersionKeyEC7E3301",
+                          "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3VersionKeyCE5C5D3B",
                         },
                       ],
                     },
@@ -33273,7 +33047,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2",
+                        "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22",
                       },
                     ],
                   ],
@@ -33288,7 +33062,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2",
+                        "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22",
                       },
                       "/*",
                     ],
@@ -33355,7 +33129,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3BucketED9FB7B0",
+                        "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1",
                       },
                     ],
                   ],
@@ -33370,48 +33144,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3BucketED9FB7B0",
-                      },
-                      "/*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:GetObject*",
-                "s3:GetBucket*",
-                "s3:List*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":s3:::",
-                      Object {
-                        "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
-                      },
-                    ],
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":s3:::",
-                      Object {
-                        "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
+                        "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1",
                       },
                       "/*",
                     ],
@@ -33639,7 +33372,7 @@ function handler(event) {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3BucketCBEF8050",
+            "Ref": "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3Bucket1B95B117",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -33652,7 +33385,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3VersionKey57968381",
+                          "Ref": "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3VersionKey75D92238",
                         },
                       ],
                     },
@@ -33665,7 +33398,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3VersionKey57968381",
+                          "Ref": "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3VersionKey75D92238",
                         },
                       ],
                     },
@@ -34181,52 +33914,28 @@ Object {
     },
   },
   "Parameters": Object {
-    "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6ArtifactHashF2EEEBFF": Object {
-      "Description": "Artifact hash for asset \\"04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6\\"",
+    "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeArtifactHash322D47B8": Object {
+      "Description": "Artifact hash for asset \\"0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9ae\\"",
       "Type": "String",
     },
-    "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3Bucket86412295": Object {
-      "Description": "S3 bucket for asset \\"04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6\\"",
+    "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3Bucket635A0AFA": Object {
+      "Description": "S3 bucket for asset \\"0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9ae\\"",
       "Type": "String",
     },
-    "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3VersionKeyE42DDF01": Object {
-      "Description": "S3 key for asset version \\"04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6\\"",
+    "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3VersionKeyBB104177": Object {
+      "Description": "S3 key for asset version \\"0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9ae\\"",
       "Type": "String",
     },
-    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440ArtifactHash87A9FF22": Object {
-      "Description": "Artifact hash for asset \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
+    "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadArtifactHash3158CABD": Object {
+      "Description": "Artifact hash for asset \\"0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362ead\\"",
       "Type": "String",
     },
-    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054": Object {
-      "Description": "S3 bucket for asset \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
+    "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3Bucket288D5551": Object {
+      "Description": "S3 bucket for asset \\"0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362ead\\"",
       "Type": "String",
     },
-    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49": Object {
-      "Description": "S3 key for asset version \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
-      "Type": "String",
-    },
-    "AssetParameters069043dc5c067ee8fba8c04a297886c3ecb0c208f06ea32fc40bb0761e8c9a99ArtifactHash3971F0E0": Object {
-      "Description": "Artifact hash for asset \\"069043dc5c067ee8fba8c04a297886c3ecb0c208f06ea32fc40bb0761e8c9a99\\"",
-      "Type": "String",
-    },
-    "AssetParameters069043dc5c067ee8fba8c04a297886c3ecb0c208f06ea32fc40bb0761e8c9a99S3Bucket7FED7AFC": Object {
-      "Description": "S3 bucket for asset \\"069043dc5c067ee8fba8c04a297886c3ecb0c208f06ea32fc40bb0761e8c9a99\\"",
-      "Type": "String",
-    },
-    "AssetParameters069043dc5c067ee8fba8c04a297886c3ecb0c208f06ea32fc40bb0761e8c9a99S3VersionKey4EDE2DC8": Object {
-      "Description": "S3 key for asset version \\"069043dc5c067ee8fba8c04a297886c3ecb0c208f06ea32fc40bb0761e8c9a99\\"",
-      "Type": "String",
-    },
-    "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aArtifactHash82449A4A": Object {
-      "Description": "Artifact hash for asset \\"0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4a\\"",
-      "Type": "String",
-    },
-    "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3Bucket789CA701": Object {
-      "Description": "S3 bucket for asset \\"0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4a\\"",
-      "Type": "String",
-    },
-    "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3VersionKey0222399F": Object {
-      "Description": "S3 key for asset version \\"0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4a\\"",
+    "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3VersionKey4638DF79": Object {
+      "Description": "S3 key for asset version \\"0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362ead\\"",
       "Type": "String",
     },
     "AssetParameters0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9ArtifactHashB9E3BF29": Object {
@@ -34241,6 +33950,42 @@ Object {
       "Description": "S3 key for asset version \\"0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9\\"",
       "Type": "String",
     },
+    "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67ArtifactHashCF96E147": Object {
+      "Description": "Artifact hash for asset \\"1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67\\"",
+      "Type": "String",
+    },
+    "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3BucketFFA964C8": Object {
+      "Description": "S3 bucket for asset \\"1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67\\"",
+      "Type": "String",
+    },
+    "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3VersionKeyA62CD84A": Object {
+      "Description": "S3 key for asset version \\"1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67\\"",
+      "Type": "String",
+    },
+    "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3ArtifactHashA3981DF8": Object {
+      "Description": "Artifact hash for asset \\"1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3\\"",
+      "Type": "String",
+    },
+    "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1": Object {
+      "Description": "S3 bucket for asset \\"1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3\\"",
+      "Type": "String",
+    },
+    "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3VersionKeyBA1CB663": Object {
+      "Description": "S3 key for asset version \\"1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3\\"",
+      "Type": "String",
+    },
+    "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeArtifactHashD1A9CF6A": Object {
+      "Description": "Artifact hash for asset \\"1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33ae\\"",
+      "Type": "String",
+    },
+    "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3Bucket901B95EB": Object {
+      "Description": "S3 bucket for asset \\"1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33ae\\"",
+      "Type": "String",
+    },
+    "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3VersionKeyC6FBD6BD": Object {
+      "Description": "S3 key for asset version \\"1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33ae\\"",
+      "Type": "String",
+    },
     "AssetParameters1f7e277bd526ebce1983fa1e7a84a5281ec533d9187caaebb773681bbf7bf4c1ArtifactHash0128B949": Object {
       "Description": "Artifact hash for asset \\"1f7e277bd526ebce1983fa1e7a84a5281ec533d9187caaebb773681bbf7bf4c1\\"",
       "Type": "String",
@@ -34253,76 +33998,112 @@ Object {
       "Description": "S3 key for asset version \\"1f7e277bd526ebce1983fa1e7a84a5281ec533d9187caaebb773681bbf7bf4c1\\"",
       "Type": "String",
     },
-    "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5ArtifactHash0AFE0939": Object {
-      "Description": "Artifact hash for asset \\"37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5\\"",
+    "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cArtifactHash8D005B5F": Object {
+      "Description": "Artifact hash for asset \\"205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612c\\"",
       "Type": "String",
     },
-    "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3Bucket722FE70B": Object {
-      "Description": "S3 bucket for asset \\"37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5\\"",
+    "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3Bucket95F679AA": Object {
+      "Description": "S3 bucket for asset \\"205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612c\\"",
       "Type": "String",
     },
-    "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3VersionKey8082F3BC": Object {
-      "Description": "S3 key for asset version \\"37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5\\"",
+    "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3VersionKeyE7A4EEDD": Object {
+      "Description": "S3 key for asset version \\"205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612c\\"",
       "Type": "String",
     },
-    "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5ArtifactHash499F6DFF": Object {
-      "Description": "Artifact hash for asset \\"3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5\\"",
+    "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534ArtifactHash89381734": Object {
+      "Description": "Artifact hash for asset \\"25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534\\"",
       "Type": "String",
     },
-    "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3Bucket37F2908E": Object {
-      "Description": "S3 bucket for asset \\"3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5\\"",
+    "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3Bucket8AFE0D2F": Object {
+      "Description": "S3 bucket for asset \\"25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534\\"",
       "Type": "String",
     },
-    "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3VersionKey2C992F11": Object {
-      "Description": "S3 key for asset version \\"3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5\\"",
+    "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3VersionKey39383E8E": Object {
+      "Description": "S3 key for asset version \\"25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534\\"",
       "Type": "String",
     },
-    "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dArtifactHash3B82A2B3": Object {
-      "Description": "Artifact hash for asset \\"3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880d\\"",
+    "AssetParameters2df718f41e56d9d22eaf2a5519630f8240755ba8b4c447afedb38b7a5cd3975aArtifactHashDAF3B2D1": Object {
+      "Description": "Artifact hash for asset \\"2df718f41e56d9d22eaf2a5519630f8240755ba8b4c447afedb38b7a5cd3975a\\"",
       "Type": "String",
     },
-    "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3BucketCBEF8050": Object {
-      "Description": "S3 bucket for asset \\"3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880d\\"",
+    "AssetParameters2df718f41e56d9d22eaf2a5519630f8240755ba8b4c447afedb38b7a5cd3975aS3BucketDDE27CEF": Object {
+      "Description": "S3 bucket for asset \\"2df718f41e56d9d22eaf2a5519630f8240755ba8b4c447afedb38b7a5cd3975a\\"",
       "Type": "String",
     },
-    "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3VersionKey57968381": Object {
-      "Description": "S3 key for asset version \\"3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880d\\"",
+    "AssetParameters2df718f41e56d9d22eaf2a5519630f8240755ba8b4c447afedb38b7a5cd3975aS3VersionKey9136CD97": Object {
+      "Description": "S3 key for asset version \\"2df718f41e56d9d22eaf2a5519630f8240755ba8b4c447afedb38b7a5cd3975a\\"",
       "Type": "String",
     },
-    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afArtifactHash7F8A76FC": Object {
-      "Description": "Artifact hash for asset \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
+    "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bArtifactHash270470CC": Object {
+      "Description": "Artifact hash for asset \\"3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934b\\"",
       "Type": "String",
     },
-    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3Bucket5515214C": Object {
-      "Description": "S3 bucket for asset \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
+    "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3Bucket2D6D8F86": Object {
+      "Description": "S3 bucket for asset \\"3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934b\\"",
       "Type": "String",
     },
-    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED": Object {
-      "Description": "S3 key for asset version \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
+    "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3VersionKey0ECB40A6": Object {
+      "Description": "S3 key for asset version \\"3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934b\\"",
       "Type": "String",
     },
-    "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bArtifactHash5ABBFB9B": Object {
-      "Description": "Artifact hash for asset \\"42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2b\\"",
+    "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0ArtifactHash6F14CF3C": Object {
+      "Description": "Artifact hash for asset \\"55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0\\"",
       "Type": "String",
     },
-    "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3Bucket8AF0E263": Object {
-      "Description": "S3 bucket for asset \\"42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2b\\"",
+    "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3BucketE35D2278": Object {
+      "Description": "S3 bucket for asset \\"55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0\\"",
       "Type": "String",
     },
-    "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3VersionKey5280D545": Object {
-      "Description": "S3 key for asset version \\"42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2b\\"",
+    "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3VersionKey88FA0AFA": Object {
+      "Description": "S3 key for asset version \\"55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0\\"",
       "Type": "String",
     },
-    "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeArtifactHash3FAC57D3": Object {
-      "Description": "Artifact hash for asset \\"4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeee\\"",
+    "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420ArtifactHashC847AA8D": Object {
+      "Description": "Artifact hash for asset \\"6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420\\"",
       "Type": "String",
     },
-    "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3Bucket6F376B71": Object {
-      "Description": "S3 bucket for asset \\"4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeee\\"",
+    "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3Bucket649728C0": Object {
+      "Description": "S3 bucket for asset \\"6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420\\"",
       "Type": "String",
     },
-    "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3VersionKey7F6E5804": Object {
-      "Description": "S3 key for asset version \\"4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeee\\"",
+    "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3VersionKey592D485B": Object {
+      "Description": "S3 key for asset version \\"6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420\\"",
+      "Type": "String",
+    },
+    "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cArtifactHashD2B94368": Object {
+      "Description": "Artifact hash for asset \\"73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06c\\"",
+      "Type": "String",
+    },
+    "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3Bucket19B71C5A": Object {
+      "Description": "S3 bucket for asset \\"73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06c\\"",
+      "Type": "String",
+    },
+    "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3VersionKeyDF73A6F0": Object {
+      "Description": "S3 key for asset version \\"73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06c\\"",
+      "Type": "String",
+    },
+    "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fArtifactHash2005F882": Object {
+      "Description": "Artifact hash for asset \\"778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6f\\"",
+      "Type": "String",
+    },
+    "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22": Object {
+      "Description": "S3 bucket for asset \\"778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6f\\"",
+      "Type": "String",
+    },
+    "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3VersionKeyCE5C5D3B": Object {
+      "Description": "S3 key for asset version \\"778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6f\\"",
+      "Type": "String",
+    },
+    "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0ArtifactHashF4B56B1E": Object {
+      "Description": "Artifact hash for asset \\"782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0\\"",
+      "Type": "String",
+    },
+    "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3Bucket1090210F": Object {
+      "Description": "S3 bucket for asset \\"782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0\\"",
+      "Type": "String",
+    },
+    "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3VersionKeyD738CD6B": Object {
+      "Description": "S3 key for asset version \\"782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0\\"",
       "Type": "String",
     },
     "AssetParameters7af6295e521fd55af94332393ceffb3e866aac4dc4956321f7918f21e72199e4ArtifactHash5E28809B": Object {
@@ -34337,16 +34118,16 @@ Object {
       "Description": "S3 key for asset version \\"7af6295e521fd55af94332393ceffb3e866aac4dc4956321f7918f21e72199e4\\"",
       "Type": "String",
     },
-    "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680ArtifactHash316B2926": Object {
-      "Description": "Artifact hash for asset \\"864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680\\"",
+    "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965ArtifactHashD4D3C5A6": Object {
+      "Description": "Artifact hash for asset \\"7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965\\"",
       "Type": "String",
     },
-    "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3BucketF13820EA": Object {
-      "Description": "S3 bucket for asset \\"864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680\\"",
+    "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3Bucket0A90D6D3": Object {
+      "Description": "S3 bucket for asset \\"7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965\\"",
       "Type": "String",
     },
-    "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3VersionKey52B24F16": Object {
-      "Description": "S3 key for asset version \\"864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680\\"",
+    "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3VersionKeyA116EF05": Object {
+      "Description": "S3 key for asset version \\"7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965\\"",
       "Type": "String",
     },
     "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900ArtifactHash121EF458": Object {
@@ -34361,18 +34142,6 @@ Object {
       "Description": "S3 key for asset version \\"8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900\\"",
       "Type": "String",
     },
-    "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9ArtifactHash694505BF": Object {
-      "Description": "Artifact hash for asset \\"8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9\\"",
-      "Type": "String",
-    },
-    "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3BucketED9FB7B0": Object {
-      "Description": "S3 bucket for asset \\"8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9\\"",
-      "Type": "String",
-    },
-    "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3VersionKeyCFEDA3D4": Object {
-      "Description": "S3 key for asset version \\"8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9\\"",
-      "Type": "String",
-    },
     "AssetParameters8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064ArtifactHashEA963870": Object {
       "Description": "Artifact hash for asset \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
@@ -34385,16 +34154,16 @@ Object {
       "Description": "S3 key for asset version \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
     },
-    "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4ArtifactHash660A50B8": Object {
-      "Description": "Artifact hash for asset \\"98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4\\"",
+    "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8ArtifactHash8DC0C383": Object {
+      "Description": "Artifact hash for asset \\"9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8\\"",
       "Type": "String",
     },
-    "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3BucketE78A0203": Object {
-      "Description": "S3 bucket for asset \\"98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4\\"",
+    "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3Bucket1B95B117": Object {
+      "Description": "S3 bucket for asset \\"9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8\\"",
       "Type": "String",
     },
-    "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3VersionKey598098A7": Object {
-      "Description": "S3 key for asset version \\"98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4\\"",
+    "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3VersionKey75D92238": Object {
+      "Description": "S3 key for asset version \\"9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8\\"",
       "Type": "String",
     },
     "AssetParametersa3058ccb468d757ebb89df5363a1c20f5307c6911136f29d00e1a68c9b2aa7e8ArtifactHash238275D6": Object {
@@ -34409,16 +34178,16 @@ Object {
       "Description": "S3 key for asset version \\"a3058ccb468d757ebb89df5363a1c20f5307c6911136f29d00e1a68c9b2aa7e8\\"",
       "Type": "String",
     },
-    "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaArtifactHash8CCAA809": Object {
-      "Description": "Artifact hash for asset \\"af643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfba\\"",
+    "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdArtifactHash22ECD1BE": Object {
+      "Description": "Artifact hash for asset \\"adb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbd\\"",
       "Type": "String",
     },
-    "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2": Object {
-      "Description": "S3 bucket for asset \\"af643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfba\\"",
+    "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3BucketF9AF3C9C": Object {
+      "Description": "S3 bucket for asset \\"adb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbd\\"",
       "Type": "String",
     },
-    "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3VersionKeyEC7E3301": Object {
-      "Description": "S3 key for asset version \\"af643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfba\\"",
+    "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3VersionKey09B12EB1": Object {
+      "Description": "S3 key for asset version \\"adb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbd\\"",
       "Type": "String",
     },
     "AssetParametersb120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827ArtifactHash1355580A": Object {
@@ -34433,40 +34202,16 @@ Object {
       "Description": "S3 key for asset version \\"b120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827\\"",
       "Type": "String",
     },
-    "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04ArtifactHash394183E9": Object {
-      "Description": "Artifact hash for asset \\"b55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04\\"",
+    "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8ArtifactHashBB72DCC8": Object {
+      "Description": "Artifact hash for asset \\"c8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8\\"",
       "Type": "String",
     },
-    "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3BucketE7A02ACD": Object {
-      "Description": "S3 bucket for asset \\"b55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04\\"",
+    "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3Bucket86DBA113": Object {
+      "Description": "S3 bucket for asset \\"c8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8\\"",
       "Type": "String",
     },
-    "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3VersionKeyCC994D9E": Object {
-      "Description": "S3 key for asset version \\"b55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04\\"",
-      "Type": "String",
-    },
-    "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcArtifactHash4E26EEC4": Object {
-      "Description": "Artifact hash for asset \\"c62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafc\\"",
-      "Type": "String",
-    },
-    "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3Bucket5255533F": Object {
-      "Description": "S3 bucket for asset \\"c62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafc\\"",
-      "Type": "String",
-    },
-    "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3VersionKey7909F675": Object {
-      "Description": "S3 key for asset version \\"c62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafc\\"",
-      "Type": "String",
-    },
-    "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aArtifactHash0386B8EC": Object {
-      "Description": "Artifact hash for asset \\"da314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17a\\"",
-      "Type": "String",
-    },
-    "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3BucketAE80D773": Object {
-      "Description": "S3 bucket for asset \\"da314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17a\\"",
-      "Type": "String",
-    },
-    "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3VersionKey662F0E6F": Object {
-      "Description": "S3 key for asset version \\"da314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17a\\"",
+    "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3VersionKeyF547CFB5": Object {
+      "Description": "S3 key for asset version \\"c8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8\\"",
       "Type": "String",
     },
     "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68ArtifactHashD9A515C3": Object {
@@ -34479,30 +34224,6 @@ Object {
     },
     "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3VersionKeyE415415F": Object {
       "Description": "S3 key for asset version \\"e9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68\\"",
-      "Type": "String",
-    },
-    "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3ArtifactHash11DB5971": Object {
-      "Description": "Artifact hash for asset \\"f48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3\\"",
-      "Type": "String",
-    },
-    "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3BucketAC5DE359": Object {
-      "Description": "S3 bucket for asset \\"f48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3\\"",
-      "Type": "String",
-    },
-    "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3VersionKey503D22DC": Object {
-      "Description": "S3 key for asset version \\"f48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3\\"",
-      "Type": "String",
-    },
-    "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5ArtifactHash185A4671": Object {
-      "Description": "Artifact hash for asset \\"fbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5\\"",
-      "Type": "String",
-    },
-    "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3Bucket024B3DC6": Object {
-      "Description": "S3 bucket for asset \\"fbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5\\"",
-      "Type": "String",
-    },
-    "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3VersionKeyEEA56859": Object {
-      "Description": "S3 key for asset version \\"fbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5\\"",
       "Type": "String",
     },
   },
@@ -35900,7 +35621,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3BucketAE80D773",
+            "Ref": "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3Bucket288D5551",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -35913,7 +35634,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3VersionKey662F0E6F",
+                          "Ref": "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3VersionKey4638DF79",
                         },
                       ],
                     },
@@ -35926,7 +35647,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3VersionKey662F0E6F",
+                          "Ref": "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3VersionKey4638DF79",
                         },
                       ],
                     },
@@ -36109,7 +35830,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3BucketAC5DE359",
+            "Ref": "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3Bucket95F679AA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -36122,7 +35843,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3VersionKey503D22DC",
+                          "Ref": "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3VersionKeyE7A4EEDD",
                         },
                       ],
                     },
@@ -36135,7 +35856,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3VersionKey503D22DC",
+                          "Ref": "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3VersionKeyE7A4EEDD",
                         },
                       ],
                     },
@@ -36375,7 +36096,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3BucketF13820EA",
+            "Ref": "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3Bucket8AFE0D2F",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -36388,7 +36109,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3VersionKey52B24F16",
+                          "Ref": "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3VersionKey39383E8E",
                         },
                       ],
                     },
@@ -36401,7 +36122,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3VersionKey52B24F16",
+                          "Ref": "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3VersionKey39383E8E",
                         },
                       ],
                     },
@@ -36888,7 +36609,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3Bucket5255533F",
+            "Ref": "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3Bucket0A90D6D3",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -36901,7 +36622,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3VersionKey7909F675",
+                          "Ref": "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3VersionKeyA116EF05",
                         },
                       ],
                     },
@@ -36914,7 +36635,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3VersionKey7909F675",
+                          "Ref": "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3VersionKeyA116EF05",
                         },
                       ],
                     },
@@ -37563,7 +37284,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3Bucket5515214C",
+            "Ref": "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3Bucket649728C0",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -37576,7 +37297,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED",
+                          "Ref": "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3VersionKey592D485B",
                         },
                       ],
                     },
@@ -37589,7 +37310,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED",
+                          "Ref": "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3VersionKey592D485B",
                         },
                       ],
                     },
@@ -38640,7 +38361,7 @@ Direct link to function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3BucketE7A02ACD",
+            "Ref": "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3Bucket635A0AFA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -38653,7 +38374,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3VersionKeyCC994D9E",
+                          "Ref": "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3VersionKeyBB104177",
                         },
                       ],
                     },
@@ -38666,7 +38387,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3VersionKeyCC994D9E",
+                          "Ref": "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3VersionKeyBB104177",
                         },
                       ],
                     },
@@ -38798,7 +38519,7 @@ Direct link to function: /lambda/home#/functions/",
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"StartAt\\":\\"Track Execution Infos\\",\\"States\\":{\\"Track Execution Infos\\":{\\"Type\\":\\"Pass\\",\\"ResultPath\\":\\"$.$TaskExecution\\",\\"InputPath\\":\\"$$.Execution\\",\\"Parameters\\":{\\"Id.$\\":\\"$.Id\\",\\"Name.$\\":\\"$.Name\\",\\"RoleArn.$\\":\\"$.RoleArn\\",\\"StartTime.$\\":\\"$.StartTime\\"},\\"Next\\":\\"Prepare doc-gen ECS Command\\"},\\"Prepare doc-gen ECS Command\\":{\\"Type\\":\\"Pass\\",\\"ResultPath\\":\\"$.docGen\\",\\"Parameters\\":{\\"command.$\\":\\"States.Array(States.JsonToString($))\\"},\\"Next\\":\\"Generate docs\\"},\\"Generate docs\\":{\\"Next\\":\\"Check whether catalog needs udpating\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"jsii-docgen.NoSpaceLeftOnDevice\\"],\\"MaxAttempts\\":0},{\\"ErrorEquals\\":[\\"ECS.AmazonECSException\\",\\"ECS.InvalidParameterException\\",\\"jsii-docgen.NpmError.E429\\",\\"jsii-codgen.NpmError.EPROTO\\"],\\"IntervalSeconds\\":120,\\"MaxAttempts\\":200,\\"BackoffRate\\":1},{\\"ErrorEquals\\":[\\"jsii-docgen.NpmError.ETARGET\\"],\\"IntervalSeconds\\":300,\\"MaxAttempts\\":3,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"MaxAttempts\\":3}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"UnprocessablePackageError\\"],\\"Next\\":\\"Ignore\\"},{\\"ErrorEquals\\":[\\"States.Timeout\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"ECS.AmazonECSException\\",\\"ECS.InvalidParameterException\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Type\\":\\"Task\\",\\"TimeoutSeconds\\":7200,\\"HeartbeatSeconds\\":300,\\"InputPath\\":\\"$.docGen.command\\",\\"ResultPath\\":\\"$.docGenOutput\\",\\"Resource\\":\\"arn:",
+              "{\\"StartAt\\":\\"Track Execution Infos\\",\\"States\\":{\\"Track Execution Infos\\":{\\"Type\\":\\"Pass\\",\\"ResultPath\\":\\"$.$TaskExecution\\",\\"InputPath\\":\\"$$.Execution\\",\\"Parameters\\":{\\"Id.$\\":\\"$.Id\\",\\"Name.$\\":\\"$.Name\\",\\"RoleArn.$\\":\\"$.RoleArn\\",\\"StartTime.$\\":\\"$.StartTime\\"},\\"Next\\":\\"Prepare doc-gen ECS Command\\"},\\"Prepare doc-gen ECS Command\\":{\\"Type\\":\\"Pass\\",\\"ResultPath\\":\\"$.docGen\\",\\"Parameters\\":{\\"command.$\\":\\"States.Array(States.JsonToString($))\\"},\\"Next\\":\\"Generate docs\\"},\\"Generate docs\\":{\\"Next\\":\\"Check whether catalog needs udpating\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"jsii-docgen.NoSpaceLeftOnDevice\\"],\\"MaxAttempts\\":0},{\\"ErrorEquals\\":[\\"ECS.AmazonECSException\\",\\"ECS.InvalidParameterException\\",\\"jsii-docgen.NpmError.E429\\",\\"jsii-codgen.NpmError.EPROTO\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":30,\\"BackoffRate\\":1.1},{\\"ErrorEquals\\":[\\"jsii-docgen.NpmError.ETARGET\\"],\\"IntervalSeconds\\":300,\\"MaxAttempts\\":3,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"MaxAttempts\\":3}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"UnprocessablePackageError\\"],\\"Next\\":\\"Ignore\\"},{\\"ErrorEquals\\":[\\"States.Timeout\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"ECS.AmazonECSException\\",\\"ECS.InvalidParameterException\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Type\\":\\"Task\\",\\"TimeoutSeconds\\":3600,\\"HeartbeatSeconds\\":300,\\"InputPath\\":\\"$.docGen.command\\",\\"ResultPath\\":\\"$.docGenOutput\\",\\"Resource\\":\\"arn:",
               Object {
                 "Ref": "AWS::Partition",
               },
@@ -38824,7 +38545,7 @@ Direct link to function: /lambda/home#/functions/",
                   "GroupId",
                 ],
               },
-              "\\"]}},\\"Overrides\\":{\\"ContainerOverrides\\":[{\\"Name\\":\\"Resource\\",\\"Command.$\\":\\"$\\",\\"Environment\\":[{\\"Name\\":\\"SFN_TASK_TOKEN\\",\\"Value.$\\":\\"$$.Task.Token\\"}]}]},\\"LaunchType\\":\\"FARGATE\\",\\"PlatformVersion\\":\\"1.4.0\\"}},\\"Check whether catalog needs udpating\\":{\\"Next\\":\\"Is catalog update needed?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"Lambda.ServiceException\\",\\"Lambda.AWSLambdaException\\",\\"Lambda.SdkClientException\\"],\\"IntervalSeconds\\":2,\\"MaxAttempts\\":6,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\",\\"Lambda.Unknown\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":30,\\"BackoffRate\\":1.1}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\",\\"Lambda.Unknown\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.catalogNeedsUpdating\\",\\"Resource\\":\\"",
+              "\\"]}},\\"Overrides\\":{\\"ContainerOverrides\\":[{\\"Name\\":\\"Resource\\",\\"Command.$\\":\\"$\\",\\"Environment\\":[{\\"Name\\":\\"SFN_TASK_TOKEN\\",\\"Value.$\\":\\"$$.Task.Token\\"}]}]},\\"LaunchType\\":\\"FARGATE\\",\\"PlatformVersion\\":\\"1.4.0\\"}},\\"Check whether catalog needs udpating\\":{\\"Next\\":\\"Is catalog update needed?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"Lambda.ServiceException\\",\\"Lambda.AWSLambdaException\\",\\"Lambda.SdkClientException\\"],\\"IntervalSeconds\\":2,\\"MaxAttempts\\":6,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":30,\\"BackoffRate\\":1.1}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.catalogNeedsUpdating\\",\\"Resource\\":\\"",
               Object {
                 "Fn::GetAtt": Array [
                   "ConstructHubOrchestrationNeedsCatalogUpdate5D7370DC",
@@ -38875,7 +38596,7 @@ Direct link to function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3Bucket722FE70B",
+            "Ref": "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3Bucket2D6D8F86",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -38888,7 +38609,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3VersionKey8082F3BC",
+                          "Ref": "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3VersionKey0ECB40A6",
                         },
                       ],
                     },
@@ -38901,7 +38622,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3VersionKey8082F3BC",
+                          "Ref": "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3VersionKey0ECB40A6",
                         },
                       ],
                     },
@@ -39703,7 +39424,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3BucketE78A0203",
+            "Ref": "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3Bucket19B71C5A",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -39716,7 +39437,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3VersionKey598098A7",
+                          "Ref": "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3VersionKeyDF73A6F0",
                         },
                       ],
                     },
@@ -39729,7 +39450,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3VersionKey598098A7",
+                          "Ref": "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3VersionKeyDF73A6F0",
                         },
                       ],
                     },
@@ -39887,7 +39608,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3Bucket6F376B71",
+            "Ref": "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3Bucket1090210F",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -39900,7 +39621,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3VersionKey7F6E5804",
+                          "Ref": "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3VersionKeyD738CD6B",
                         },
                       ],
                     },
@@ -39913,7 +39634,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3VersionKey7F6E5804",
+                          "Ref": "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3VersionKeyD738CD6B",
                         },
                       ],
                     },
@@ -40691,7 +40412,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                   Object {
                     "Ref": "AWS::URLSuffix",
                   },
-                  "/aws-cdk/assets:89c6683e392b08bdb9bfd8e456f82a156b228534eed332191232b4aa0beec4f2",
+                  "/aws-cdk/assets:5fa39a328f34360df81ad2f478b29e7f72b6625d60d6ca775401e69a3b2c0faf",
                 ],
               ],
             },
@@ -40973,7 +40694,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.*",
+                      "/data/*/docs-typescript.md",
                     ],
                   ],
                 },
@@ -41003,7 +40724,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.*",
+                      "/data/*/docs-*-typescript.md",
                     ],
                   ],
                 },
@@ -41033,7 +40754,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.*.not-supported",
+                      "/data/*/docs-typescript.md.not-supported",
                     ],
                   ],
                 },
@@ -41063,7 +40784,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.*.not-supported",
+                      "/data/*/docs-*-typescript.md.not-supported",
                     ],
                   ],
                 },
@@ -41093,7 +40814,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.*.corruptassembly",
+                      "/data/*/docs-typescript.md.corruptassembly",
                     ],
                   ],
                 },
@@ -41123,7 +40844,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.*.corruptassembly",
+                      "/data/*/docs-*-typescript.md.corruptassembly",
                     ],
                   ],
                 },
@@ -41142,7 +40863,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-typescript.*.corruptassembly",
+                    "/data/*/docs-typescript.md.corruptassembly",
                   ],
                 ],
               },
@@ -41160,223 +40881,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-typescript.*.corruptassembly",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.*.not-supported",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.*.not-supported",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.*.corruptassembly",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.*.corruptassembly",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": "s3:DeleteObject*",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "ConstructHubPackageDataDC5EF35E",
-                        "Arn",
-                      ],
-                    },
-                    "/data/*/docs-python.*.corruptassembly",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": "s3:DeleteObject*",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "ConstructHubPackageDataDC5EF35E",
-                        "Arn",
-                      ],
-                    },
-                    "/data/*/docs-*-python.*.corruptassembly",
+                    "/data/*/docs-*-typescript.md.corruptassembly",
                   ],
                 ],
               },
@@ -41405,7 +40910,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.*",
+                      "/data/*/docs-python.md",
                     ],
                   ],
                 },
@@ -41435,7 +40940,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.*",
+                      "/data/*/docs-*-python.md",
                     ],
                   ],
                 },
@@ -41465,7 +40970,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.*.not-supported",
+                      "/data/*/docs-python.md.not-supported",
                     ],
                   ],
                 },
@@ -41495,7 +41000,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.*.not-supported",
+                      "/data/*/docs-*-python.md.not-supported",
                     ],
                   ],
                 },
@@ -41525,7 +41030,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.*.corruptassembly",
+                      "/data/*/docs-python.md.corruptassembly",
                     ],
                   ],
                 },
@@ -41555,7 +41060,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.*.corruptassembly",
+                      "/data/*/docs-*-python.md.corruptassembly",
                     ],
                   ],
                 },
@@ -41574,7 +41079,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-java.*.corruptassembly",
+                    "/data/*/docs-python.md.corruptassembly",
                   ],
                 ],
               },
@@ -41592,7 +41097,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-java.*.corruptassembly",
+                    "/data/*/docs-*-python.md.corruptassembly",
                   ],
                 ],
               },
@@ -41621,7 +41126,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.*",
+                      "/data/*/docs-java.md",
                     ],
                   ],
                 },
@@ -41651,7 +41156,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.*",
+                      "/data/*/docs-*-java.md",
                     ],
                   ],
                 },
@@ -41681,7 +41186,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.*.not-supported",
+                      "/data/*/docs-java.md.not-supported",
                     ],
                   ],
                 },
@@ -41711,7 +41216,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.*.not-supported",
+                      "/data/*/docs-*-java.md.not-supported",
                     ],
                   ],
                 },
@@ -41741,7 +41246,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.*.corruptassembly",
+                      "/data/*/docs-java.md.corruptassembly",
                     ],
                   ],
                 },
@@ -41771,7 +41276,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.*.corruptassembly",
+                      "/data/*/docs-*-java.md.corruptassembly",
                     ],
                   ],
                 },
@@ -41790,7 +41295,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-csharp.*.corruptassembly",
+                    "/data/*/docs-java.md.corruptassembly",
                   ],
                 ],
               },
@@ -41808,7 +41313,223 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-csharp.*.corruptassembly",
+                    "/data/*/docs-*-java.md.corruptassembly",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.md",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.md",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.md.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.md.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.md.corruptassembly",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.md.corruptassembly",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": "s3:DeleteObject*",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "ConstructHubPackageDataDC5EF35E",
+                        "Arn",
+                      ],
+                    },
+                    "/data/*/docs-csharp.md.corruptassembly",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:DeleteObject*",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "ConstructHubPackageDataDC5EF35E",
+                        "Arn",
+                      ],
+                    },
+                    "/data/*/docs-*-csharp.md.corruptassembly",
                   ],
                 ],
               },
@@ -42074,7 +41795,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3Bucket024B3DC6",
+            "Ref": "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3Bucket901B95EB",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -42087,7 +41808,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3VersionKeyEEA56859",
+                          "Ref": "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3VersionKeyC6FBD6BD",
                         },
                       ],
                     },
@@ -42100,7 +41821,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3VersionKeyEEA56859",
+                          "Ref": "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3VersionKeyC6FBD6BD",
                         },
                       ],
                     },
@@ -42157,7 +41878,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3Bucket37F2908E",
+            "Ref": "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3Bucket86DBA113",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -42170,7 +41891,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3VersionKey2C992F11",
+                          "Ref": "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3VersionKeyF547CFB5",
                         },
                       ],
                     },
@@ -42183,7 +41904,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3VersionKey2C992F11",
+                          "Ref": "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3VersionKeyF547CFB5",
                         },
                       ],
                     },
@@ -42733,7 +42454,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3Bucket8AF0E263",
+            "Ref": "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3BucketFFA964C8",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -42746,7 +42467,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3VersionKey5280D545",
+                          "Ref": "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3VersionKeyA62CD84A",
                         },
                       ],
                     },
@@ -42759,7 +42480,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3VersionKey5280D545",
+                          "Ref": "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3VersionKeyA62CD84A",
                         },
                       ],
                     },
@@ -43169,7 +42890,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3Bucket789CA701",
+            "Ref": "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3BucketE35D2278",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -43182,7 +42903,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3VersionKey0222399F",
+                          "Ref": "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3VersionKey88FA0AFA",
                         },
                       ],
                     },
@@ -43195,7 +42916,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3VersionKey0222399F",
+                          "Ref": "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3VersionKey88FA0AFA",
                         },
                       ],
                     },
@@ -43401,7 +43122,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3Bucket86412295",
+            "Ref": "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3BucketF9AF3C9C",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -43414,7 +43135,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3VersionKeyE42DDF01",
+                          "Ref": "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3VersionKey09B12EB1",
                         },
                       ],
                     },
@@ -43427,7 +43148,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3VersionKeyE42DDF01",
+                          "Ref": "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3VersionKey09B12EB1",
                         },
                       ],
                     },
@@ -43895,10 +43616,7 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3BucketED9FB7B0",
-          },
-          Object {
-            "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
+            "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1",
           },
         ],
         "SourceObjectKeys": Array [
@@ -43913,7 +43631,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3VersionKeyCFEDA3D4",
+                          "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3VersionKeyBA1CB663",
                         },
                       ],
                     },
@@ -43926,40 +43644,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3VersionKeyCFEDA3D4",
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            ],
-          },
-          Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                Object {
-                  "Fn::Select": Array [
-                    0,
-                    Object {
-                      "Fn::Split": Array [
-                        "||",
-                        Object {
-                          "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49",
-                        },
-                      ],
-                    },
-                  ],
-                },
-                Object {
-                  "Fn::Select": Array [
-                    1,
-                    Object {
-                      "Fn::Split": Array [
-                        "||",
-                        Object {
-                          "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49",
+                          "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3VersionKeyBA1CB663",
                         },
                       ],
                     },
@@ -43994,7 +43679,7 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2",
+            "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22",
           },
         ],
         "SourceObjectKeys": Array [
@@ -44009,7 +43694,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3VersionKeyEC7E3301",
+                          "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3VersionKeyCE5C5D3B",
                         },
                       ],
                     },
@@ -44022,7 +43707,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3VersionKeyEC7E3301",
+                          "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3VersionKeyCE5C5D3B",
                         },
                       ],
                     },
@@ -44277,7 +43962,7 @@ function handler(event) {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters069043dc5c067ee8fba8c04a297886c3ecb0c208f06ea32fc40bb0761e8c9a99S3Bucket7FED7AFC",
+            "Ref": "AssetParameters2df718f41e56d9d22eaf2a5519630f8240755ba8b4c447afedb38b7a5cd3975aS3BucketDDE27CEF",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -44290,7 +43975,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters069043dc5c067ee8fba8c04a297886c3ecb0c208f06ea32fc40bb0761e8c9a99S3VersionKey4EDE2DC8",
+                          "Ref": "AssetParameters2df718f41e56d9d22eaf2a5519630f8240755ba8b4c447afedb38b7a5cd3975aS3VersionKey9136CD97",
                         },
                       ],
                     },
@@ -44303,7 +43988,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters069043dc5c067ee8fba8c04a297886c3ecb0c208f06ea32fc40bb0761e8c9a99S3VersionKey4EDE2DC8",
+                          "Ref": "AssetParameters2df718f41e56d9d22eaf2a5519630f8240755ba8b4c447afedb38b7a5cd3975aS3VersionKey9136CD97",
                         },
                       ],
                     },
@@ -44930,7 +44615,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2",
+                        "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22",
                       },
                     ],
                   ],
@@ -44945,7 +44630,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2",
+                        "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22",
                       },
                       "/*",
                     ],
@@ -45012,7 +44697,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3BucketED9FB7B0",
+                        "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1",
                       },
                     ],
                   ],
@@ -45027,48 +44712,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3BucketED9FB7B0",
-                      },
-                      "/*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:GetObject*",
-                "s3:GetBucket*",
-                "s3:List*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":s3:::",
-                      Object {
-                        "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
-                      },
-                    ],
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":s3:::",
-                      Object {
-                        "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
+                        "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1",
                       },
                       "/*",
                     ],
@@ -45296,7 +44940,7 @@ function handler(event) {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3BucketCBEF8050",
+            "Ref": "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3Bucket1B95B117",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -45309,7 +44953,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3VersionKey57968381",
+                          "Ref": "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3VersionKey75D92238",
                         },
                       ],
                     },
@@ -45322,7 +44966,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3VersionKey57968381",
+                          "Ref": "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3VersionKey75D92238",
                         },
                       ],
                     },
@@ -45828,40 +45472,28 @@ Object {
     },
   },
   "Parameters": Object {
-    "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6ArtifactHashF2EEEBFF": Object {
-      "Description": "Artifact hash for asset \\"04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6\\"",
+    "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeArtifactHash322D47B8": Object {
+      "Description": "Artifact hash for asset \\"0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9ae\\"",
       "Type": "String",
     },
-    "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3Bucket86412295": Object {
-      "Description": "S3 bucket for asset \\"04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6\\"",
+    "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3Bucket635A0AFA": Object {
+      "Description": "S3 bucket for asset \\"0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9ae\\"",
       "Type": "String",
     },
-    "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3VersionKeyE42DDF01": Object {
-      "Description": "S3 key for asset version \\"04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6\\"",
+    "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3VersionKeyBB104177": Object {
+      "Description": "S3 key for asset version \\"0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9ae\\"",
       "Type": "String",
     },
-    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440ArtifactHash87A9FF22": Object {
-      "Description": "Artifact hash for asset \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
+    "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadArtifactHash3158CABD": Object {
+      "Description": "Artifact hash for asset \\"0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362ead\\"",
       "Type": "String",
     },
-    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054": Object {
-      "Description": "S3 bucket for asset \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
+    "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3Bucket288D5551": Object {
+      "Description": "S3 bucket for asset \\"0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362ead\\"",
       "Type": "String",
     },
-    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49": Object {
-      "Description": "S3 key for asset version \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
-      "Type": "String",
-    },
-    "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aArtifactHash82449A4A": Object {
-      "Description": "Artifact hash for asset \\"0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4a\\"",
-      "Type": "String",
-    },
-    "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3Bucket789CA701": Object {
-      "Description": "S3 bucket for asset \\"0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4a\\"",
-      "Type": "String",
-    },
-    "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3VersionKey0222399F": Object {
-      "Description": "S3 key for asset version \\"0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4a\\"",
+    "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3VersionKey4638DF79": Object {
+      "Description": "S3 key for asset version \\"0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362ead\\"",
       "Type": "String",
     },
     "AssetParameters0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9ArtifactHashB9E3BF29": Object {
@@ -45876,6 +45508,42 @@ Object {
       "Description": "S3 key for asset version \\"0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9\\"",
       "Type": "String",
     },
+    "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67ArtifactHashCF96E147": Object {
+      "Description": "Artifact hash for asset \\"1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67\\"",
+      "Type": "String",
+    },
+    "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3BucketFFA964C8": Object {
+      "Description": "S3 bucket for asset \\"1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67\\"",
+      "Type": "String",
+    },
+    "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3VersionKeyA62CD84A": Object {
+      "Description": "S3 key for asset version \\"1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67\\"",
+      "Type": "String",
+    },
+    "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3ArtifactHashA3981DF8": Object {
+      "Description": "Artifact hash for asset \\"1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3\\"",
+      "Type": "String",
+    },
+    "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1": Object {
+      "Description": "S3 bucket for asset \\"1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3\\"",
+      "Type": "String",
+    },
+    "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3VersionKeyBA1CB663": Object {
+      "Description": "S3 key for asset version \\"1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3\\"",
+      "Type": "String",
+    },
+    "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeArtifactHashD1A9CF6A": Object {
+      "Description": "Artifact hash for asset \\"1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33ae\\"",
+      "Type": "String",
+    },
+    "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3Bucket901B95EB": Object {
+      "Description": "S3 bucket for asset \\"1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33ae\\"",
+      "Type": "String",
+    },
+    "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3VersionKeyC6FBD6BD": Object {
+      "Description": "S3 key for asset version \\"1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33ae\\"",
+      "Type": "String",
+    },
     "AssetParameters1f7e277bd526ebce1983fa1e7a84a5281ec533d9187caaebb773681bbf7bf4c1ArtifactHash0128B949": Object {
       "Description": "Artifact hash for asset \\"1f7e277bd526ebce1983fa1e7a84a5281ec533d9187caaebb773681bbf7bf4c1\\"",
       "Type": "String",
@@ -45888,52 +45556,40 @@ Object {
       "Description": "S3 key for asset version \\"1f7e277bd526ebce1983fa1e7a84a5281ec533d9187caaebb773681bbf7bf4c1\\"",
       "Type": "String",
     },
-    "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5ArtifactHash0AFE0939": Object {
-      "Description": "Artifact hash for asset \\"37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5\\"",
+    "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cArtifactHash8D005B5F": Object {
+      "Description": "Artifact hash for asset \\"205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612c\\"",
       "Type": "String",
     },
-    "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3Bucket722FE70B": Object {
-      "Description": "S3 bucket for asset \\"37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5\\"",
+    "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3Bucket95F679AA": Object {
+      "Description": "S3 bucket for asset \\"205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612c\\"",
       "Type": "String",
     },
-    "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3VersionKey8082F3BC": Object {
-      "Description": "S3 key for asset version \\"37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5\\"",
+    "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3VersionKeyE7A4EEDD": Object {
+      "Description": "S3 key for asset version \\"205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612c\\"",
       "Type": "String",
     },
-    "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5ArtifactHash499F6DFF": Object {
-      "Description": "Artifact hash for asset \\"3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5\\"",
+    "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534ArtifactHash89381734": Object {
+      "Description": "Artifact hash for asset \\"25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534\\"",
       "Type": "String",
     },
-    "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3Bucket37F2908E": Object {
-      "Description": "S3 bucket for asset \\"3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5\\"",
+    "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3Bucket8AFE0D2F": Object {
+      "Description": "S3 bucket for asset \\"25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534\\"",
       "Type": "String",
     },
-    "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3VersionKey2C992F11": Object {
-      "Description": "S3 key for asset version \\"3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5\\"",
+    "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3VersionKey39383E8E": Object {
+      "Description": "S3 key for asset version \\"25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534\\"",
       "Type": "String",
     },
-    "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dArtifactHash3B82A2B3": Object {
-      "Description": "Artifact hash for asset \\"3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880d\\"",
+    "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bArtifactHash270470CC": Object {
+      "Description": "Artifact hash for asset \\"3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934b\\"",
       "Type": "String",
     },
-    "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3BucketCBEF8050": Object {
-      "Description": "S3 bucket for asset \\"3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880d\\"",
+    "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3Bucket2D6D8F86": Object {
+      "Description": "S3 bucket for asset \\"3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934b\\"",
       "Type": "String",
     },
-    "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3VersionKey57968381": Object {
-      "Description": "S3 key for asset version \\"3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880d\\"",
-      "Type": "String",
-    },
-    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afArtifactHash7F8A76FC": Object {
-      "Description": "Artifact hash for asset \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
-      "Type": "String",
-    },
-    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3Bucket5515214C": Object {
-      "Description": "S3 bucket for asset \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
-      "Type": "String",
-    },
-    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED": Object {
-      "Description": "S3 key for asset version \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
+    "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3VersionKey0ECB40A6": Object {
+      "Description": "S3 key for asset version \\"3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934b\\"",
       "Type": "String",
     },
     "AssetParameters4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbcArtifactHashF236251A": Object {
@@ -45948,40 +45604,76 @@ Object {
       "Description": "S3 key for asset version \\"4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbc\\"",
       "Type": "String",
     },
-    "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bArtifactHash5ABBFB9B": Object {
-      "Description": "Artifact hash for asset \\"42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2b\\"",
+    "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0ArtifactHash6F14CF3C": Object {
+      "Description": "Artifact hash for asset \\"55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0\\"",
       "Type": "String",
     },
-    "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3Bucket8AF0E263": Object {
-      "Description": "S3 bucket for asset \\"42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2b\\"",
+    "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3BucketE35D2278": Object {
+      "Description": "S3 bucket for asset \\"55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0\\"",
       "Type": "String",
     },
-    "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3VersionKey5280D545": Object {
-      "Description": "S3 key for asset version \\"42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2b\\"",
+    "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3VersionKey88FA0AFA": Object {
+      "Description": "S3 key for asset version \\"55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0\\"",
       "Type": "String",
     },
-    "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeArtifactHash3FAC57D3": Object {
-      "Description": "Artifact hash for asset \\"4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeee\\"",
+    "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420ArtifactHashC847AA8D": Object {
+      "Description": "Artifact hash for asset \\"6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420\\"",
       "Type": "String",
     },
-    "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3Bucket6F376B71": Object {
-      "Description": "S3 bucket for asset \\"4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeee\\"",
+    "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3Bucket649728C0": Object {
+      "Description": "S3 bucket for asset \\"6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420\\"",
       "Type": "String",
     },
-    "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3VersionKey7F6E5804": Object {
-      "Description": "S3 key for asset version \\"4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeee\\"",
+    "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3VersionKey592D485B": Object {
+      "Description": "S3 key for asset version \\"6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420\\"",
       "Type": "String",
     },
-    "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680ArtifactHash316B2926": Object {
-      "Description": "Artifact hash for asset \\"864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680\\"",
+    "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cArtifactHashD2B94368": Object {
+      "Description": "Artifact hash for asset \\"73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06c\\"",
       "Type": "String",
     },
-    "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3BucketF13820EA": Object {
-      "Description": "S3 bucket for asset \\"864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680\\"",
+    "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3Bucket19B71C5A": Object {
+      "Description": "S3 bucket for asset \\"73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06c\\"",
       "Type": "String",
     },
-    "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3VersionKey52B24F16": Object {
-      "Description": "S3 key for asset version \\"864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680\\"",
+    "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3VersionKeyDF73A6F0": Object {
+      "Description": "S3 key for asset version \\"73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06c\\"",
+      "Type": "String",
+    },
+    "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fArtifactHash2005F882": Object {
+      "Description": "Artifact hash for asset \\"778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6f\\"",
+      "Type": "String",
+    },
+    "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22": Object {
+      "Description": "S3 bucket for asset \\"778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6f\\"",
+      "Type": "String",
+    },
+    "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3VersionKeyCE5C5D3B": Object {
+      "Description": "S3 key for asset version \\"778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6f\\"",
+      "Type": "String",
+    },
+    "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0ArtifactHashF4B56B1E": Object {
+      "Description": "Artifact hash for asset \\"782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0\\"",
+      "Type": "String",
+    },
+    "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3Bucket1090210F": Object {
+      "Description": "S3 bucket for asset \\"782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0\\"",
+      "Type": "String",
+    },
+    "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3VersionKeyD738CD6B": Object {
+      "Description": "S3 key for asset version \\"782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0\\"",
+      "Type": "String",
+    },
+    "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965ArtifactHashD4D3C5A6": Object {
+      "Description": "Artifact hash for asset \\"7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965\\"",
+      "Type": "String",
+    },
+    "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3Bucket0A90D6D3": Object {
+      "Description": "S3 bucket for asset \\"7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965\\"",
+      "Type": "String",
+    },
+    "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3VersionKeyA116EF05": Object {
+      "Description": "S3 key for asset version \\"7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965\\"",
       "Type": "String",
     },
     "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900ArtifactHash121EF458": Object {
@@ -45996,18 +45688,6 @@ Object {
       "Description": "S3 key for asset version \\"8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900\\"",
       "Type": "String",
     },
-    "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9ArtifactHash694505BF": Object {
-      "Description": "Artifact hash for asset \\"8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9\\"",
-      "Type": "String",
-    },
-    "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3BucketED9FB7B0": Object {
-      "Description": "S3 bucket for asset \\"8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9\\"",
-      "Type": "String",
-    },
-    "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3VersionKeyCFEDA3D4": Object {
-      "Description": "S3 key for asset version \\"8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9\\"",
-      "Type": "String",
-    },
     "AssetParameters8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064ArtifactHashEA963870": Object {
       "Description": "Artifact hash for asset \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
@@ -46020,16 +45700,16 @@ Object {
       "Description": "S3 key for asset version \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
     },
-    "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4ArtifactHash660A50B8": Object {
-      "Description": "Artifact hash for asset \\"98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4\\"",
+    "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8ArtifactHash8DC0C383": Object {
+      "Description": "Artifact hash for asset \\"9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8\\"",
       "Type": "String",
     },
-    "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3BucketE78A0203": Object {
-      "Description": "S3 bucket for asset \\"98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4\\"",
+    "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3Bucket1B95B117": Object {
+      "Description": "S3 bucket for asset \\"9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8\\"",
       "Type": "String",
     },
-    "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3VersionKey598098A7": Object {
-      "Description": "S3 key for asset version \\"98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4\\"",
+    "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3VersionKey75D92238": Object {
+      "Description": "S3 key for asset version \\"9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8\\"",
       "Type": "String",
     },
     "AssetParametersa3058ccb468d757ebb89df5363a1c20f5307c6911136f29d00e1a68c9b2aa7e8ArtifactHash238275D6": Object {
@@ -46044,16 +45724,16 @@ Object {
       "Description": "S3 key for asset version \\"a3058ccb468d757ebb89df5363a1c20f5307c6911136f29d00e1a68c9b2aa7e8\\"",
       "Type": "String",
     },
-    "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaArtifactHash8CCAA809": Object {
-      "Description": "Artifact hash for asset \\"af643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfba\\"",
+    "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdArtifactHash22ECD1BE": Object {
+      "Description": "Artifact hash for asset \\"adb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbd\\"",
       "Type": "String",
     },
-    "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2": Object {
-      "Description": "S3 bucket for asset \\"af643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfba\\"",
+    "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3BucketF9AF3C9C": Object {
+      "Description": "S3 bucket for asset \\"adb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbd\\"",
       "Type": "String",
     },
-    "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3VersionKeyEC7E3301": Object {
-      "Description": "S3 key for asset version \\"af643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfba\\"",
+    "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3VersionKey09B12EB1": Object {
+      "Description": "S3 key for asset version \\"adb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbd\\"",
       "Type": "String",
     },
     "AssetParametersb120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827ArtifactHash1355580A": Object {
@@ -46068,40 +45748,16 @@ Object {
       "Description": "S3 key for asset version \\"b120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827\\"",
       "Type": "String",
     },
-    "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04ArtifactHash394183E9": Object {
-      "Description": "Artifact hash for asset \\"b55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04\\"",
+    "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8ArtifactHashBB72DCC8": Object {
+      "Description": "Artifact hash for asset \\"c8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8\\"",
       "Type": "String",
     },
-    "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3BucketE7A02ACD": Object {
-      "Description": "S3 bucket for asset \\"b55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04\\"",
+    "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3Bucket86DBA113": Object {
+      "Description": "S3 bucket for asset \\"c8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8\\"",
       "Type": "String",
     },
-    "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3VersionKeyCC994D9E": Object {
-      "Description": "S3 key for asset version \\"b55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04\\"",
-      "Type": "String",
-    },
-    "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcArtifactHash4E26EEC4": Object {
-      "Description": "Artifact hash for asset \\"c62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafc\\"",
-      "Type": "String",
-    },
-    "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3Bucket5255533F": Object {
-      "Description": "S3 bucket for asset \\"c62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafc\\"",
-      "Type": "String",
-    },
-    "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3VersionKey7909F675": Object {
-      "Description": "S3 key for asset version \\"c62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafc\\"",
-      "Type": "String",
-    },
-    "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aArtifactHash0386B8EC": Object {
-      "Description": "Artifact hash for asset \\"da314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17a\\"",
-      "Type": "String",
-    },
-    "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3BucketAE80D773": Object {
-      "Description": "S3 bucket for asset \\"da314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17a\\"",
-      "Type": "String",
-    },
-    "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3VersionKey662F0E6F": Object {
-      "Description": "S3 key for asset version \\"da314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17a\\"",
+    "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3VersionKeyF547CFB5": Object {
+      "Description": "S3 key for asset version \\"c8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8\\"",
       "Type": "String",
     },
     "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68ArtifactHashD9A515C3": Object {
@@ -46114,30 +45770,6 @@ Object {
     },
     "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3VersionKeyE415415F": Object {
       "Description": "S3 key for asset version \\"e9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68\\"",
-      "Type": "String",
-    },
-    "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3ArtifactHash11DB5971": Object {
-      "Description": "Artifact hash for asset \\"f48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3\\"",
-      "Type": "String",
-    },
-    "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3BucketAC5DE359": Object {
-      "Description": "S3 bucket for asset \\"f48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3\\"",
-      "Type": "String",
-    },
-    "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3VersionKey503D22DC": Object {
-      "Description": "S3 key for asset version \\"f48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3\\"",
-      "Type": "String",
-    },
-    "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5ArtifactHash185A4671": Object {
-      "Description": "Artifact hash for asset \\"fbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5\\"",
-      "Type": "String",
-    },
-    "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3Bucket024B3DC6": Object {
-      "Description": "S3 bucket for asset \\"fbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5\\"",
-      "Type": "String",
-    },
-    "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3VersionKeyEEA56859": Object {
-      "Description": "S3 key for asset version \\"fbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5\\"",
       "Type": "String",
     },
   },
@@ -47495,7 +47127,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3BucketAE80D773",
+            "Ref": "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3Bucket288D5551",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -47508,7 +47140,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3VersionKey662F0E6F",
+                          "Ref": "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3VersionKey4638DF79",
                         },
                       ],
                     },
@@ -47521,7 +47153,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3VersionKey662F0E6F",
+                          "Ref": "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3VersionKey4638DF79",
                         },
                       ],
                     },
@@ -47704,7 +47336,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3BucketAC5DE359",
+            "Ref": "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3Bucket95F679AA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -47717,7 +47349,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3VersionKey503D22DC",
+                          "Ref": "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3VersionKeyE7A4EEDD",
                         },
                       ],
                     },
@@ -47730,7 +47362,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3VersionKey503D22DC",
+                          "Ref": "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3VersionKeyE7A4EEDD",
                         },
                       ],
                     },
@@ -47970,7 +47602,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3BucketF13820EA",
+            "Ref": "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3Bucket8AFE0D2F",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -47983,7 +47615,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3VersionKey52B24F16",
+                          "Ref": "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3VersionKey39383E8E",
                         },
                       ],
                     },
@@ -47996,7 +47628,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3VersionKey52B24F16",
+                          "Ref": "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3VersionKey39383E8E",
                         },
                       ],
                     },
@@ -48483,7 +48115,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3Bucket5255533F",
+            "Ref": "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3Bucket0A90D6D3",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -48496,7 +48128,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3VersionKey7909F675",
+                          "Ref": "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3VersionKeyA116EF05",
                         },
                       ],
                     },
@@ -48509,7 +48141,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3VersionKey7909F675",
+                          "Ref": "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3VersionKeyA116EF05",
                         },
                       ],
                     },
@@ -49284,7 +48916,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3Bucket5515214C",
+            "Ref": "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3Bucket649728C0",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -49297,7 +48929,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED",
+                          "Ref": "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3VersionKey592D485B",
                         },
                       ],
                     },
@@ -49310,7 +48942,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED",
+                          "Ref": "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3VersionKey592D485B",
                         },
                       ],
                     },
@@ -50339,7 +49971,7 @@ Direct link to function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3BucketE7A02ACD",
+            "Ref": "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3Bucket635A0AFA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -50352,7 +49984,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3VersionKeyCC994D9E",
+                          "Ref": "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3VersionKeyBB104177",
                         },
                       ],
                     },
@@ -50365,7 +49997,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3VersionKeyCC994D9E",
+                          "Ref": "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3VersionKeyBB104177",
                         },
                       ],
                     },
@@ -50498,7 +50130,7 @@ Direct link to function: /lambda/home#/functions/",
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"StartAt\\":\\"Track Execution Infos\\",\\"States\\":{\\"Track Execution Infos\\":{\\"Type\\":\\"Pass\\",\\"ResultPath\\":\\"$.$TaskExecution\\",\\"InputPath\\":\\"$$.Execution\\",\\"Parameters\\":{\\"Id.$\\":\\"$.Id\\",\\"Name.$\\":\\"$.Name\\",\\"RoleArn.$\\":\\"$.RoleArn\\",\\"StartTime.$\\":\\"$.StartTime\\"},\\"Next\\":\\"Prepare doc-gen ECS Command\\"},\\"Prepare doc-gen ECS Command\\":{\\"Type\\":\\"Pass\\",\\"ResultPath\\":\\"$.docGen\\",\\"Parameters\\":{\\"command.$\\":\\"States.Array(States.JsonToString($))\\"},\\"Next\\":\\"Generate docs\\"},\\"Generate docs\\":{\\"Next\\":\\"Check whether catalog needs udpating\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"jsii-docgen.NoSpaceLeftOnDevice\\"],\\"MaxAttempts\\":0},{\\"ErrorEquals\\":[\\"ECS.AmazonECSException\\",\\"ECS.InvalidParameterException\\",\\"jsii-docgen.NpmError.E429\\",\\"jsii-codgen.NpmError.EPROTO\\"],\\"IntervalSeconds\\":120,\\"MaxAttempts\\":200,\\"BackoffRate\\":1},{\\"ErrorEquals\\":[\\"jsii-docgen.NpmError.ETARGET\\"],\\"IntervalSeconds\\":300,\\"MaxAttempts\\":3,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"MaxAttempts\\":3}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"UnprocessablePackageError\\"],\\"Next\\":\\"Ignore\\"},{\\"ErrorEquals\\":[\\"States.Timeout\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"ECS.AmazonECSException\\",\\"ECS.InvalidParameterException\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Type\\":\\"Task\\",\\"TimeoutSeconds\\":7200,\\"HeartbeatSeconds\\":300,\\"InputPath\\":\\"$.docGen.command\\",\\"ResultPath\\":\\"$.docGenOutput\\",\\"Resource\\":\\"arn:",
+              "{\\"StartAt\\":\\"Track Execution Infos\\",\\"States\\":{\\"Track Execution Infos\\":{\\"Type\\":\\"Pass\\",\\"ResultPath\\":\\"$.$TaskExecution\\",\\"InputPath\\":\\"$$.Execution\\",\\"Parameters\\":{\\"Id.$\\":\\"$.Id\\",\\"Name.$\\":\\"$.Name\\",\\"RoleArn.$\\":\\"$.RoleArn\\",\\"StartTime.$\\":\\"$.StartTime\\"},\\"Next\\":\\"Prepare doc-gen ECS Command\\"},\\"Prepare doc-gen ECS Command\\":{\\"Type\\":\\"Pass\\",\\"ResultPath\\":\\"$.docGen\\",\\"Parameters\\":{\\"command.$\\":\\"States.Array(States.JsonToString($))\\"},\\"Next\\":\\"Generate docs\\"},\\"Generate docs\\":{\\"Next\\":\\"Check whether catalog needs udpating\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"jsii-docgen.NoSpaceLeftOnDevice\\"],\\"MaxAttempts\\":0},{\\"ErrorEquals\\":[\\"ECS.AmazonECSException\\",\\"ECS.InvalidParameterException\\",\\"jsii-docgen.NpmError.E429\\",\\"jsii-codgen.NpmError.EPROTO\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":30,\\"BackoffRate\\":1.1},{\\"ErrorEquals\\":[\\"jsii-docgen.NpmError.ETARGET\\"],\\"IntervalSeconds\\":300,\\"MaxAttempts\\":3,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"MaxAttempts\\":3}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"UnprocessablePackageError\\"],\\"Next\\":\\"Ignore\\"},{\\"ErrorEquals\\":[\\"States.Timeout\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"ECS.AmazonECSException\\",\\"ECS.InvalidParameterException\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Type\\":\\"Task\\",\\"TimeoutSeconds\\":3600,\\"HeartbeatSeconds\\":300,\\"InputPath\\":\\"$.docGen.command\\",\\"ResultPath\\":\\"$.docGenOutput\\",\\"Resource\\":\\"arn:",
               Object {
                 "Ref": "AWS::Partition",
               },
@@ -50545,7 +50177,7 @@ Direct link to function: /lambda/home#/functions/",
                   "GroupId",
                 ],
               },
-              "\\"]}},\\"Overrides\\":{\\"ContainerOverrides\\":[{\\"Name\\":\\"Resource\\",\\"Command.$\\":\\"$\\",\\"Environment\\":[{\\"Name\\":\\"SFN_TASK_TOKEN\\",\\"Value.$\\":\\"$$.Task.Token\\"}]}]},\\"LaunchType\\":\\"FARGATE\\",\\"PlatformVersion\\":\\"1.4.0\\"}},\\"Check whether catalog needs udpating\\":{\\"Next\\":\\"Is catalog update needed?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"Lambda.ServiceException\\",\\"Lambda.AWSLambdaException\\",\\"Lambda.SdkClientException\\"],\\"IntervalSeconds\\":2,\\"MaxAttempts\\":6,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\",\\"Lambda.Unknown\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":30,\\"BackoffRate\\":1.1}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\",\\"Lambda.Unknown\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.catalogNeedsUpdating\\",\\"Resource\\":\\"",
+              "\\"]}},\\"Overrides\\":{\\"ContainerOverrides\\":[{\\"Name\\":\\"Resource\\",\\"Command.$\\":\\"$\\",\\"Environment\\":[{\\"Name\\":\\"SFN_TASK_TOKEN\\",\\"Value.$\\":\\"$$.Task.Token\\"}]}]},\\"LaunchType\\":\\"FARGATE\\",\\"PlatformVersion\\":\\"1.4.0\\"}},\\"Check whether catalog needs udpating\\":{\\"Next\\":\\"Is catalog update needed?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"Lambda.ServiceException\\",\\"Lambda.AWSLambdaException\\",\\"Lambda.SdkClientException\\"],\\"IntervalSeconds\\":2,\\"MaxAttempts\\":6,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":30,\\"BackoffRate\\":1.1}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.catalogNeedsUpdating\\",\\"Resource\\":\\"",
               Object {
                 "Fn::GetAtt": Array [
                   "ConstructHubOrchestrationNeedsCatalogUpdate5D7370DC",
@@ -50596,7 +50228,7 @@ Direct link to function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3Bucket722FE70B",
+            "Ref": "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3Bucket2D6D8F86",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -50609,7 +50241,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3VersionKey8082F3BC",
+                          "Ref": "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3VersionKey0ECB40A6",
                         },
                       ],
                     },
@@ -50622,7 +50254,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3VersionKey8082F3BC",
+                          "Ref": "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3VersionKey0ECB40A6",
                         },
                       ],
                     },
@@ -51025,7 +50657,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3BucketE78A0203",
+            "Ref": "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3Bucket19B71C5A",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -51038,7 +50670,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3VersionKey598098A7",
+                          "Ref": "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3VersionKeyDF73A6F0",
                         },
                       ],
                     },
@@ -51051,7 +50683,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3VersionKey598098A7",
+                          "Ref": "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3VersionKeyDF73A6F0",
                         },
                       ],
                     },
@@ -51209,7 +50841,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3Bucket6F376B71",
+            "Ref": "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3Bucket1090210F",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -51222,7 +50854,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3VersionKey7F6E5804",
+                          "Ref": "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3VersionKeyD738CD6B",
                         },
                       ],
                     },
@@ -51235,7 +50867,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3VersionKey7F6E5804",
+                          "Ref": "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3VersionKeyD738CD6B",
                         },
                       ],
                     },
@@ -52019,7 +51651,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                   Object {
                     "Ref": "AWS::URLSuffix",
                   },
-                  "/aws-cdk/assets:89c6683e392b08bdb9bfd8e456f82a156b228534eed332191232b4aa0beec4f2",
+                  "/aws-cdk/assets:5fa39a328f34360df81ad2f478b29e7f72b6625d60d6ca775401e69a3b2c0faf",
                 ],
               ],
             },
@@ -52301,7 +51933,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.*",
+                      "/data/*/docs-typescript.md",
                     ],
                   ],
                 },
@@ -52331,7 +51963,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.*",
+                      "/data/*/docs-*-typescript.md",
                     ],
                   ],
                 },
@@ -52361,7 +51993,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.*.not-supported",
+                      "/data/*/docs-typescript.md.not-supported",
                     ],
                   ],
                 },
@@ -52391,7 +52023,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.*.not-supported",
+                      "/data/*/docs-*-typescript.md.not-supported",
                     ],
                   ],
                 },
@@ -52421,7 +52053,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.*.corruptassembly",
+                      "/data/*/docs-typescript.md.corruptassembly",
                     ],
                   ],
                 },
@@ -52451,7 +52083,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.*.corruptassembly",
+                      "/data/*/docs-*-typescript.md.corruptassembly",
                     ],
                   ],
                 },
@@ -52470,7 +52102,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-typescript.*.corruptassembly",
+                    "/data/*/docs-typescript.md.corruptassembly",
                   ],
                 ],
               },
@@ -52488,223 +52120,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-typescript.*.corruptassembly",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.*.not-supported",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.*.not-supported",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.*.corruptassembly",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.*.corruptassembly",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": "s3:DeleteObject*",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "ConstructHubPackageDataDC5EF35E",
-                        "Arn",
-                      ],
-                    },
-                    "/data/*/docs-python.*.corruptassembly",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": "s3:DeleteObject*",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "ConstructHubPackageDataDC5EF35E",
-                        "Arn",
-                      ],
-                    },
-                    "/data/*/docs-*-python.*.corruptassembly",
+                    "/data/*/docs-*-typescript.md.corruptassembly",
                   ],
                 ],
               },
@@ -52733,7 +52149,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.*",
+                      "/data/*/docs-python.md",
                     ],
                   ],
                 },
@@ -52763,7 +52179,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.*",
+                      "/data/*/docs-*-python.md",
                     ],
                   ],
                 },
@@ -52793,7 +52209,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.*.not-supported",
+                      "/data/*/docs-python.md.not-supported",
                     ],
                   ],
                 },
@@ -52823,7 +52239,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.*.not-supported",
+                      "/data/*/docs-*-python.md.not-supported",
                     ],
                   ],
                 },
@@ -52853,7 +52269,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.*.corruptassembly",
+                      "/data/*/docs-python.md.corruptassembly",
                     ],
                   ],
                 },
@@ -52883,7 +52299,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.*.corruptassembly",
+                      "/data/*/docs-*-python.md.corruptassembly",
                     ],
                   ],
                 },
@@ -52902,7 +52318,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-java.*.corruptassembly",
+                    "/data/*/docs-python.md.corruptassembly",
                   ],
                 ],
               },
@@ -52920,7 +52336,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-java.*.corruptassembly",
+                    "/data/*/docs-*-python.md.corruptassembly",
                   ],
                 ],
               },
@@ -52949,7 +52365,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.*",
+                      "/data/*/docs-java.md",
                     ],
                   ],
                 },
@@ -52979,7 +52395,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.*",
+                      "/data/*/docs-*-java.md",
                     ],
                   ],
                 },
@@ -53009,7 +52425,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.*.not-supported",
+                      "/data/*/docs-java.md.not-supported",
                     ],
                   ],
                 },
@@ -53039,7 +52455,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.*.not-supported",
+                      "/data/*/docs-*-java.md.not-supported",
                     ],
                   ],
                 },
@@ -53069,7 +52485,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.*.corruptassembly",
+                      "/data/*/docs-java.md.corruptassembly",
                     ],
                   ],
                 },
@@ -53099,7 +52515,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.*.corruptassembly",
+                      "/data/*/docs-*-java.md.corruptassembly",
                     ],
                   ],
                 },
@@ -53118,7 +52534,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-csharp.*.corruptassembly",
+                    "/data/*/docs-java.md.corruptassembly",
                   ],
                 ],
               },
@@ -53136,7 +52552,223 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-csharp.*.corruptassembly",
+                    "/data/*/docs-*-java.md.corruptassembly",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.md",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.md",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.md.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.md.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.md.corruptassembly",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.md.corruptassembly",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": "s3:DeleteObject*",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "ConstructHubPackageDataDC5EF35E",
+                        "Arn",
+                      ],
+                    },
+                    "/data/*/docs-csharp.md.corruptassembly",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:DeleteObject*",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "ConstructHubPackageDataDC5EF35E",
+                        "Arn",
+                      ],
+                    },
+                    "/data/*/docs-*-csharp.md.corruptassembly",
                   ],
                 ],
               },
@@ -53464,7 +53096,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3Bucket024B3DC6",
+            "Ref": "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3Bucket901B95EB",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -53477,7 +53109,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3VersionKeyEEA56859",
+                          "Ref": "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3VersionKeyC6FBD6BD",
                         },
                       ],
                     },
@@ -53490,7 +53122,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3VersionKeyEEA56859",
+                          "Ref": "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3VersionKeyC6FBD6BD",
                         },
                       ],
                     },
@@ -53547,7 +53179,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3Bucket37F2908E",
+            "Ref": "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3Bucket86DBA113",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -53560,7 +53192,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3VersionKey2C992F11",
+                          "Ref": "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3VersionKeyF547CFB5",
                         },
                       ],
                     },
@@ -53573,7 +53205,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3VersionKey2C992F11",
+                          "Ref": "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3VersionKeyF547CFB5",
                         },
                       ],
                     },
@@ -54136,7 +53768,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3Bucket8AF0E263",
+            "Ref": "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3BucketFFA964C8",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -54149,7 +53781,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3VersionKey5280D545",
+                          "Ref": "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3VersionKeyA62CD84A",
                         },
                       ],
                     },
@@ -54162,7 +53794,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3VersionKey5280D545",
+                          "Ref": "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3VersionKeyA62CD84A",
                         },
                       ],
                     },
@@ -54572,7 +54204,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3Bucket789CA701",
+            "Ref": "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3BucketE35D2278",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -54585,7 +54217,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3VersionKey0222399F",
+                          "Ref": "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3VersionKey88FA0AFA",
                         },
                       ],
                     },
@@ -54598,7 +54230,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3VersionKey0222399F",
+                          "Ref": "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3VersionKey88FA0AFA",
                         },
                       ],
                     },
@@ -55638,7 +55270,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.*",
+                      "/data/*/docs-typescript.md",
                     ],
                   ],
                 },
@@ -55671,7 +55303,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.*",
+                      "/data/*/docs-*-typescript.md",
                     ],
                   ],
                 },
@@ -55704,7 +55336,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.*.not-supported",
+                      "/data/*/docs-typescript.md.not-supported",
                     ],
                   ],
                 },
@@ -55737,7 +55369,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.*.not-supported",
+                      "/data/*/docs-*-typescript.md.not-supported",
                     ],
                   ],
                 },
@@ -55770,7 +55402,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.*.corruptassembly",
+                      "/data/*/docs-typescript.md.corruptassembly",
                     ],
                   ],
                 },
@@ -55803,7 +55435,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.*.corruptassembly",
+                      "/data/*/docs-*-typescript.md.corruptassembly",
                     ],
                   ],
                 },
@@ -55825,7 +55457,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-typescript.*.corruptassembly",
+                    "/data/*/docs-typescript.md.corruptassembly",
                   ],
                 ],
               },
@@ -55846,247 +55478,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-typescript.*.corruptassembly",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "s3:Abort*",
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-              ],
-              "Effect": "Allow",
-              "Principal": Object {
-                "AWS": "*",
-              },
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:Abort*",
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-              ],
-              "Effect": "Allow",
-              "Principal": Object {
-                "AWS": "*",
-              },
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:Abort*",
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-              ],
-              "Effect": "Allow",
-              "Principal": Object {
-                "AWS": "*",
-              },
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.*.not-supported",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:Abort*",
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-              ],
-              "Effect": "Allow",
-              "Principal": Object {
-                "AWS": "*",
-              },
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.*.not-supported",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:Abort*",
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-              ],
-              "Effect": "Allow",
-              "Principal": Object {
-                "AWS": "*",
-              },
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.*.corruptassembly",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:Abort*",
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-              ],
-              "Effect": "Allow",
-              "Principal": Object {
-                "AWS": "*",
-              },
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.*.corruptassembly",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": "s3:DeleteObject*",
-              "Effect": "Allow",
-              "Principal": Object {
-                "AWS": "*",
-              },
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "ConstructHubPackageDataDC5EF35E",
-                        "Arn",
-                      ],
-                    },
-                    "/data/*/docs-python.*.corruptassembly",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": "s3:DeleteObject*",
-              "Effect": "Allow",
-              "Principal": Object {
-                "AWS": "*",
-              },
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "ConstructHubPackageDataDC5EF35E",
-                        "Arn",
-                      ],
-                    },
-                    "/data/*/docs-*-python.*.corruptassembly",
+                    "/data/*/docs-*-typescript.md.corruptassembly",
                   ],
                 ],
               },
@@ -56118,7 +55510,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.*",
+                      "/data/*/docs-python.md",
                     ],
                   ],
                 },
@@ -56151,7 +55543,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.*",
+                      "/data/*/docs-*-python.md",
                     ],
                   ],
                 },
@@ -56184,7 +55576,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.*.not-supported",
+                      "/data/*/docs-python.md.not-supported",
                     ],
                   ],
                 },
@@ -56217,7 +55609,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.*.not-supported",
+                      "/data/*/docs-*-python.md.not-supported",
                     ],
                   ],
                 },
@@ -56250,7 +55642,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.*.corruptassembly",
+                      "/data/*/docs-python.md.corruptassembly",
                     ],
                   ],
                 },
@@ -56283,7 +55675,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.*.corruptassembly",
+                      "/data/*/docs-*-python.md.corruptassembly",
                     ],
                   ],
                 },
@@ -56305,7 +55697,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-java.*.corruptassembly",
+                    "/data/*/docs-python.md.corruptassembly",
                   ],
                 ],
               },
@@ -56326,7 +55718,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-java.*.corruptassembly",
+                    "/data/*/docs-*-python.md.corruptassembly",
                   ],
                 ],
               },
@@ -56358,7 +55750,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.*",
+                      "/data/*/docs-java.md",
                     ],
                   ],
                 },
@@ -56391,7 +55783,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.*",
+                      "/data/*/docs-*-java.md",
                     ],
                   ],
                 },
@@ -56424,7 +55816,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.*.not-supported",
+                      "/data/*/docs-java.md.not-supported",
                     ],
                   ],
                 },
@@ -56457,7 +55849,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.*.not-supported",
+                      "/data/*/docs-*-java.md.not-supported",
                     ],
                   ],
                 },
@@ -56490,7 +55882,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.*.corruptassembly",
+                      "/data/*/docs-java.md.corruptassembly",
                     ],
                   ],
                 },
@@ -56523,7 +55915,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.*.corruptassembly",
+                      "/data/*/docs-*-java.md.corruptassembly",
                     ],
                   ],
                 },
@@ -56545,7 +55937,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-csharp.*.corruptassembly",
+                    "/data/*/docs-java.md.corruptassembly",
                   ],
                 ],
               },
@@ -56566,7 +55958,247 @@ Direct link to Lambda function: /lambda/home#/functions/",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-csharp.*.corruptassembly",
+                    "/data/*/docs-*-java.md.corruptassembly",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "s3:Abort*",
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.md",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:Abort*",
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.md",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:Abort*",
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.md.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:Abort*",
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.md.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:Abort*",
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.md.corruptassembly",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:Abort*",
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.md.corruptassembly",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": "s3:DeleteObject*",
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "ConstructHubPackageDataDC5EF35E",
+                        "Arn",
+                      ],
+                    },
+                    "/data/*/docs-csharp.md.corruptassembly",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:DeleteObject*",
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "ConstructHubPackageDataDC5EF35E",
+                        "Arn",
+                      ],
+                    },
+                    "/data/*/docs-*-csharp.md.corruptassembly",
                   ],
                 ],
               },
@@ -56699,7 +56331,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3Bucket86412295",
+            "Ref": "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3BucketF9AF3C9C",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -56712,7 +56344,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3VersionKeyE42DDF01",
+                          "Ref": "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3VersionKey09B12EB1",
                         },
                       ],
                     },
@@ -56725,7 +56357,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3VersionKeyE42DDF01",
+                          "Ref": "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3VersionKey09B12EB1",
                         },
                       ],
                     },
@@ -57141,10 +56773,7 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3BucketED9FB7B0",
-          },
-          Object {
-            "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
+            "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1",
           },
         ],
         "SourceObjectKeys": Array [
@@ -57159,7 +56788,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3VersionKeyCFEDA3D4",
+                          "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3VersionKeyBA1CB663",
                         },
                       ],
                     },
@@ -57172,40 +56801,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3VersionKeyCFEDA3D4",
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            ],
-          },
-          Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                Object {
-                  "Fn::Select": Array [
-                    0,
-                    Object {
-                      "Fn::Split": Array [
-                        "||",
-                        Object {
-                          "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49",
-                        },
-                      ],
-                    },
-                  ],
-                },
-                Object {
-                  "Fn::Select": Array [
-                    1,
-                    Object {
-                      "Fn::Split": Array [
-                        "||",
-                        Object {
-                          "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49",
+                          "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3VersionKeyBA1CB663",
                         },
                       ],
                     },
@@ -57240,7 +56836,7 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2",
+            "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22",
           },
         ],
         "SourceObjectKeys": Array [
@@ -57255,7 +56851,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3VersionKeyEC7E3301",
+                          "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3VersionKeyCE5C5D3B",
                         },
                       ],
                     },
@@ -57268,7 +56864,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3VersionKeyEC7E3301",
+                          "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3VersionKeyCE5C5D3B",
                         },
                       ],
                     },
@@ -58357,7 +57953,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2",
+                        "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22",
                       },
                     ],
                   ],
@@ -58372,7 +57968,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2",
+                        "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22",
                       },
                       "/*",
                     ],
@@ -58439,7 +58035,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3BucketED9FB7B0",
+                        "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1",
                       },
                     ],
                   ],
@@ -58454,48 +58050,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3BucketED9FB7B0",
-                      },
-                      "/*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:GetObject*",
-                "s3:GetBucket*",
-                "s3:List*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":s3:::",
-                      Object {
-                        "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
-                      },
-                    ],
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":s3:::",
-                      Object {
-                        "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
+                        "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1",
                       },
                       "/*",
                     ],
@@ -58723,7 +58278,7 @@ function handler(event) {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3BucketCBEF8050",
+            "Ref": "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3Bucket1B95B117",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -58736,7 +58291,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3VersionKey57968381",
+                          "Ref": "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3VersionKey75D92238",
                         },
                       ],
                     },
@@ -58749,7 +58304,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3VersionKey57968381",
+                          "Ref": "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3VersionKey75D92238",
                         },
                       ],
                     },

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -141,28 +141,40 @@ Object {
     },
   },
   "Parameters": Object {
-    "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeArtifactHash322D47B8": Object {
-      "Description": "Artifact hash for asset \\"0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9ae\\"",
+    "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6ArtifactHashF2EEEBFF": Object {
+      "Description": "Artifact hash for asset \\"04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6\\"",
       "Type": "String",
     },
-    "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3Bucket635A0AFA": Object {
-      "Description": "S3 bucket for asset \\"0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9ae\\"",
+    "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3Bucket86412295": Object {
+      "Description": "S3 bucket for asset \\"04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6\\"",
       "Type": "String",
     },
-    "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3VersionKeyBB104177": Object {
-      "Description": "S3 key for asset version \\"0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9ae\\"",
+    "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3VersionKeyE42DDF01": Object {
+      "Description": "S3 key for asset version \\"04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6\\"",
       "Type": "String",
     },
-    "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadArtifactHash3158CABD": Object {
-      "Description": "Artifact hash for asset \\"0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362ead\\"",
+    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440ArtifactHash87A9FF22": Object {
+      "Description": "Artifact hash for asset \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
       "Type": "String",
     },
-    "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3Bucket288D5551": Object {
-      "Description": "S3 bucket for asset \\"0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362ead\\"",
+    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054": Object {
+      "Description": "S3 bucket for asset \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
       "Type": "String",
     },
-    "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3VersionKey4638DF79": Object {
-      "Description": "S3 key for asset version \\"0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362ead\\"",
+    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49": Object {
+      "Description": "S3 key for asset version \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
+      "Type": "String",
+    },
+    "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aArtifactHash82449A4A": Object {
+      "Description": "Artifact hash for asset \\"0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4a\\"",
+      "Type": "String",
+    },
+    "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3Bucket789CA701": Object {
+      "Description": "S3 bucket for asset \\"0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4a\\"",
+      "Type": "String",
+    },
+    "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3VersionKey0222399F": Object {
+      "Description": "S3 key for asset version \\"0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4a\\"",
       "Type": "String",
     },
     "AssetParameters0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9ArtifactHashB9E3BF29": Object {
@@ -177,42 +189,6 @@ Object {
       "Description": "S3 key for asset version \\"0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9\\"",
       "Type": "String",
     },
-    "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67ArtifactHashCF96E147": Object {
-      "Description": "Artifact hash for asset \\"1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67\\"",
-      "Type": "String",
-    },
-    "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3BucketFFA964C8": Object {
-      "Description": "S3 bucket for asset \\"1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67\\"",
-      "Type": "String",
-    },
-    "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3VersionKeyA62CD84A": Object {
-      "Description": "S3 key for asset version \\"1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67\\"",
-      "Type": "String",
-    },
-    "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3ArtifactHashA3981DF8": Object {
-      "Description": "Artifact hash for asset \\"1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3\\"",
-      "Type": "String",
-    },
-    "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1": Object {
-      "Description": "S3 bucket for asset \\"1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3\\"",
-      "Type": "String",
-    },
-    "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3VersionKeyBA1CB663": Object {
-      "Description": "S3 key for asset version \\"1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3\\"",
-      "Type": "String",
-    },
-    "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeArtifactHashD1A9CF6A": Object {
-      "Description": "Artifact hash for asset \\"1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33ae\\"",
-      "Type": "String",
-    },
-    "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3Bucket901B95EB": Object {
-      "Description": "S3 bucket for asset \\"1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33ae\\"",
-      "Type": "String",
-    },
-    "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3VersionKeyC6FBD6BD": Object {
-      "Description": "S3 key for asset version \\"1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33ae\\"",
-      "Type": "String",
-    },
     "AssetParameters1f7e277bd526ebce1983fa1e7a84a5281ec533d9187caaebb773681bbf7bf4c1ArtifactHash0128B949": Object {
       "Description": "Artifact hash for asset \\"1f7e277bd526ebce1983fa1e7a84a5281ec533d9187caaebb773681bbf7bf4c1\\"",
       "Type": "String",
@@ -225,112 +201,88 @@ Object {
       "Description": "S3 key for asset version \\"1f7e277bd526ebce1983fa1e7a84a5281ec533d9187caaebb773681bbf7bf4c1\\"",
       "Type": "String",
     },
-    "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cArtifactHash8D005B5F": Object {
-      "Description": "Artifact hash for asset \\"205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612c\\"",
+    "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5ArtifactHash0AFE0939": Object {
+      "Description": "Artifact hash for asset \\"37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5\\"",
       "Type": "String",
     },
-    "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3Bucket95F679AA": Object {
-      "Description": "S3 bucket for asset \\"205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612c\\"",
+    "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3Bucket722FE70B": Object {
+      "Description": "S3 bucket for asset \\"37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5\\"",
       "Type": "String",
     },
-    "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3VersionKeyE7A4EEDD": Object {
-      "Description": "S3 key for asset version \\"205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612c\\"",
+    "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3VersionKey8082F3BC": Object {
+      "Description": "S3 key for asset version \\"37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5\\"",
       "Type": "String",
     },
-    "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534ArtifactHash89381734": Object {
-      "Description": "Artifact hash for asset \\"25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534\\"",
+    "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5ArtifactHash499F6DFF": Object {
+      "Description": "Artifact hash for asset \\"3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5\\"",
       "Type": "String",
     },
-    "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3Bucket8AFE0D2F": Object {
-      "Description": "S3 bucket for asset \\"25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534\\"",
+    "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3Bucket37F2908E": Object {
+      "Description": "S3 bucket for asset \\"3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5\\"",
       "Type": "String",
     },
-    "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3VersionKey39383E8E": Object {
-      "Description": "S3 key for asset version \\"25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534\\"",
+    "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3VersionKey2C992F11": Object {
+      "Description": "S3 key for asset version \\"3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5\\"",
       "Type": "String",
     },
-    "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bArtifactHash270470CC": Object {
-      "Description": "Artifact hash for asset \\"3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934b\\"",
+    "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dArtifactHash3B82A2B3": Object {
+      "Description": "Artifact hash for asset \\"3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880d\\"",
       "Type": "String",
     },
-    "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3Bucket2D6D8F86": Object {
-      "Description": "S3 bucket for asset \\"3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934b\\"",
+    "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3BucketCBEF8050": Object {
+      "Description": "S3 bucket for asset \\"3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880d\\"",
       "Type": "String",
     },
-    "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3VersionKey0ECB40A6": Object {
-      "Description": "S3 key for asset version \\"3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934b\\"",
+    "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3VersionKey57968381": Object {
+      "Description": "S3 key for asset version \\"3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880d\\"",
       "Type": "String",
     },
-    "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0ArtifactHash6F14CF3C": Object {
-      "Description": "Artifact hash for asset \\"55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0\\"",
+    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afArtifactHash7F8A76FC": Object {
+      "Description": "Artifact hash for asset \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
       "Type": "String",
     },
-    "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3BucketE35D2278": Object {
-      "Description": "S3 bucket for asset \\"55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0\\"",
+    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3Bucket5515214C": Object {
+      "Description": "S3 bucket for asset \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
       "Type": "String",
     },
-    "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3VersionKey88FA0AFA": Object {
-      "Description": "S3 key for asset version \\"55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0\\"",
+    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED": Object {
+      "Description": "S3 key for asset version \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
       "Type": "String",
     },
-    "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420ArtifactHashC847AA8D": Object {
-      "Description": "Artifact hash for asset \\"6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420\\"",
+    "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bArtifactHash5ABBFB9B": Object {
+      "Description": "Artifact hash for asset \\"42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2b\\"",
       "Type": "String",
     },
-    "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3Bucket649728C0": Object {
-      "Description": "S3 bucket for asset \\"6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420\\"",
+    "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3Bucket8AF0E263": Object {
+      "Description": "S3 bucket for asset \\"42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2b\\"",
       "Type": "String",
     },
-    "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3VersionKey592D485B": Object {
-      "Description": "S3 key for asset version \\"6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420\\"",
+    "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3VersionKey5280D545": Object {
+      "Description": "S3 key for asset version \\"42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2b\\"",
       "Type": "String",
     },
-    "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cArtifactHashD2B94368": Object {
-      "Description": "Artifact hash for asset \\"73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06c\\"",
+    "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeArtifactHash3FAC57D3": Object {
+      "Description": "Artifact hash for asset \\"4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeee\\"",
       "Type": "String",
     },
-    "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3Bucket19B71C5A": Object {
-      "Description": "S3 bucket for asset \\"73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06c\\"",
+    "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3Bucket6F376B71": Object {
+      "Description": "S3 bucket for asset \\"4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeee\\"",
       "Type": "String",
     },
-    "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3VersionKeyDF73A6F0": Object {
-      "Description": "S3 key for asset version \\"73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06c\\"",
+    "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3VersionKey7F6E5804": Object {
+      "Description": "S3 key for asset version \\"4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeee\\"",
       "Type": "String",
     },
-    "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fArtifactHash2005F882": Object {
-      "Description": "Artifact hash for asset \\"778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6f\\"",
+    "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680ArtifactHash316B2926": Object {
+      "Description": "Artifact hash for asset \\"864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680\\"",
       "Type": "String",
     },
-    "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22": Object {
-      "Description": "S3 bucket for asset \\"778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6f\\"",
+    "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3BucketF13820EA": Object {
+      "Description": "S3 bucket for asset \\"864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680\\"",
       "Type": "String",
     },
-    "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3VersionKeyCE5C5D3B": Object {
-      "Description": "S3 key for asset version \\"778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6f\\"",
-      "Type": "String",
-    },
-    "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0ArtifactHashF4B56B1E": Object {
-      "Description": "Artifact hash for asset \\"782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0\\"",
-      "Type": "String",
-    },
-    "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3Bucket1090210F": Object {
-      "Description": "S3 bucket for asset \\"782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0\\"",
-      "Type": "String",
-    },
-    "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3VersionKeyD738CD6B": Object {
-      "Description": "S3 key for asset version \\"782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0\\"",
-      "Type": "String",
-    },
-    "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965ArtifactHashD4D3C5A6": Object {
-      "Description": "Artifact hash for asset \\"7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965\\"",
-      "Type": "String",
-    },
-    "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3Bucket0A90D6D3": Object {
-      "Description": "S3 bucket for asset \\"7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965\\"",
-      "Type": "String",
-    },
-    "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3VersionKeyA116EF05": Object {
-      "Description": "S3 key for asset version \\"7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965\\"",
+    "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3VersionKey52B24F16": Object {
+      "Description": "S3 key for asset version \\"864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680\\"",
       "Type": "String",
     },
     "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900ArtifactHash121EF458": Object {
@@ -345,6 +297,18 @@ Object {
       "Description": "S3 key for asset version \\"8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900\\"",
       "Type": "String",
     },
+    "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9ArtifactHash694505BF": Object {
+      "Description": "Artifact hash for asset \\"8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9\\"",
+      "Type": "String",
+    },
+    "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3BucketED9FB7B0": Object {
+      "Description": "S3 bucket for asset \\"8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9\\"",
+      "Type": "String",
+    },
+    "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3VersionKeyCFEDA3D4": Object {
+      "Description": "S3 key for asset version \\"8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9\\"",
+      "Type": "String",
+    },
     "AssetParameters8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064ArtifactHashEA963870": Object {
       "Description": "Artifact hash for asset \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
@@ -357,16 +321,16 @@ Object {
       "Description": "S3 key for asset version \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
     },
-    "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8ArtifactHash8DC0C383": Object {
-      "Description": "Artifact hash for asset \\"9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8\\"",
+    "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4ArtifactHash660A50B8": Object {
+      "Description": "Artifact hash for asset \\"98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4\\"",
       "Type": "String",
     },
-    "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3Bucket1B95B117": Object {
-      "Description": "S3 bucket for asset \\"9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8\\"",
+    "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3BucketE78A0203": Object {
+      "Description": "S3 bucket for asset \\"98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4\\"",
       "Type": "String",
     },
-    "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3VersionKey75D92238": Object {
-      "Description": "S3 key for asset version \\"9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8\\"",
+    "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3VersionKey598098A7": Object {
+      "Description": "S3 key for asset version \\"98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4\\"",
       "Type": "String",
     },
     "AssetParametersa3058ccb468d757ebb89df5363a1c20f5307c6911136f29d00e1a68c9b2aa7e8ArtifactHash238275D6": Object {
@@ -381,16 +345,16 @@ Object {
       "Description": "S3 key for asset version \\"a3058ccb468d757ebb89df5363a1c20f5307c6911136f29d00e1a68c9b2aa7e8\\"",
       "Type": "String",
     },
-    "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdArtifactHash22ECD1BE": Object {
-      "Description": "Artifact hash for asset \\"adb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbd\\"",
+    "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaArtifactHash8CCAA809": Object {
+      "Description": "Artifact hash for asset \\"af643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfba\\"",
       "Type": "String",
     },
-    "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3BucketF9AF3C9C": Object {
-      "Description": "S3 bucket for asset \\"adb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbd\\"",
+    "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2": Object {
+      "Description": "S3 bucket for asset \\"af643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfba\\"",
       "Type": "String",
     },
-    "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3VersionKey09B12EB1": Object {
-      "Description": "S3 key for asset version \\"adb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbd\\"",
+    "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3VersionKeyEC7E3301": Object {
+      "Description": "S3 key for asset version \\"af643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfba\\"",
       "Type": "String",
     },
     "AssetParametersb120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827ArtifactHash1355580A": Object {
@@ -405,16 +369,40 @@ Object {
       "Description": "S3 key for asset version \\"b120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827\\"",
       "Type": "String",
     },
-    "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8ArtifactHashBB72DCC8": Object {
-      "Description": "Artifact hash for asset \\"c8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8\\"",
+    "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04ArtifactHash394183E9": Object {
+      "Description": "Artifact hash for asset \\"b55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04\\"",
       "Type": "String",
     },
-    "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3Bucket86DBA113": Object {
-      "Description": "S3 bucket for asset \\"c8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8\\"",
+    "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3BucketE7A02ACD": Object {
+      "Description": "S3 bucket for asset \\"b55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04\\"",
       "Type": "String",
     },
-    "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3VersionKeyF547CFB5": Object {
-      "Description": "S3 key for asset version \\"c8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8\\"",
+    "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3VersionKeyCC994D9E": Object {
+      "Description": "S3 key for asset version \\"b55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04\\"",
+      "Type": "String",
+    },
+    "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcArtifactHash4E26EEC4": Object {
+      "Description": "Artifact hash for asset \\"c62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafc\\"",
+      "Type": "String",
+    },
+    "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3Bucket5255533F": Object {
+      "Description": "S3 bucket for asset \\"c62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafc\\"",
+      "Type": "String",
+    },
+    "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3VersionKey7909F675": Object {
+      "Description": "S3 key for asset version \\"c62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafc\\"",
+      "Type": "String",
+    },
+    "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aArtifactHash0386B8EC": Object {
+      "Description": "Artifact hash for asset \\"da314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17a\\"",
+      "Type": "String",
+    },
+    "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3BucketAE80D773": Object {
+      "Description": "S3 bucket for asset \\"da314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17a\\"",
+      "Type": "String",
+    },
+    "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3VersionKey662F0E6F": Object {
+      "Description": "S3 key for asset version \\"da314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17a\\"",
       "Type": "String",
     },
     "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68ArtifactHashD9A515C3": Object {
@@ -427,6 +415,30 @@ Object {
     },
     "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3VersionKeyE415415F": Object {
       "Description": "S3 key for asset version \\"e9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68\\"",
+      "Type": "String",
+    },
+    "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3ArtifactHash11DB5971": Object {
+      "Description": "Artifact hash for asset \\"f48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3\\"",
+      "Type": "String",
+    },
+    "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3BucketAC5DE359": Object {
+      "Description": "S3 bucket for asset \\"f48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3\\"",
+      "Type": "String",
+    },
+    "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3VersionKey503D22DC": Object {
+      "Description": "S3 key for asset version \\"f48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3\\"",
+      "Type": "String",
+    },
+    "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5ArtifactHash185A4671": Object {
+      "Description": "Artifact hash for asset \\"fbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5\\"",
+      "Type": "String",
+    },
+    "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3Bucket024B3DC6": Object {
+      "Description": "S3 bucket for asset \\"fbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5\\"",
+      "Type": "String",
+    },
+    "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3VersionKeyEEA56859": Object {
+      "Description": "S3 key for asset version \\"fbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5\\"",
       "Type": "String",
     },
   },
@@ -1675,7 +1687,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3Bucket288D5551",
+            "Ref": "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3BucketAE80D773",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -1688,7 +1700,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3VersionKey4638DF79",
+                          "Ref": "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3VersionKey662F0E6F",
                         },
                       ],
                     },
@@ -1701,7 +1713,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3VersionKey4638DF79",
+                          "Ref": "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3VersionKey662F0E6F",
                         },
                       ],
                     },
@@ -1884,7 +1896,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3Bucket95F679AA",
+            "Ref": "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3BucketAC5DE359",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -1897,7 +1909,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3VersionKeyE7A4EEDD",
+                          "Ref": "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3VersionKey503D22DC",
                         },
                       ],
                     },
@@ -1910,7 +1922,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3VersionKeyE7A4EEDD",
+                          "Ref": "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3VersionKey503D22DC",
                         },
                       ],
                     },
@@ -2150,7 +2162,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3Bucket8AFE0D2F",
+            "Ref": "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3BucketF13820EA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -2163,7 +2175,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3VersionKey39383E8E",
+                          "Ref": "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3VersionKey52B24F16",
                         },
                       ],
                     },
@@ -2176,7 +2188,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3VersionKey39383E8E",
+                          "Ref": "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3VersionKey52B24F16",
                         },
                       ],
                     },
@@ -2663,7 +2675,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3Bucket0A90D6D3",
+            "Ref": "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3Bucket5255533F",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -2676,7 +2688,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3VersionKeyA116EF05",
+                          "Ref": "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3VersionKey7909F675",
                         },
                       ],
                     },
@@ -2689,7 +2701,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3VersionKeyA116EF05",
+                          "Ref": "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3VersionKey7909F675",
                         },
                       ],
                     },
@@ -2873,7 +2885,7 @@ Direct link to the function: /lambda/home#/functions/",
               Object {
                 "Ref": "ConstructHubPackageDataDC5EF35E",
               },
-              "\\",\\"Prefix\\":\\"data/\\"}},\\"Is there more?\\":{\\"Type\\":\\"Choice\\",\\"Choices\\":[{\\"Variable\\":\\"$.response.NextContinuationToken\\",\\"IsPresent\\":true,\\"Next\\":\\"Continue as new\\"}],\\"Default\\":\\"Process Result\\"},\\"S3.ListObjectsV2(NextPage)\\":{\\"Next\\":\\"Is there more?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"S3.SdkClientException\\"]}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.response\\",\\"Resource\\":\\"arn:",
+              "\\",\\"Prefix\\":\\"data/\\"}},\\"Is there more?\\":{\\"Type\\":\\"Choice\\",\\"Choices\\":[{\\"Variable\\":\\"$.response.NextContinuationToken\\",\\"IsPresent\\":true,\\"Next\\":\\"Give room for on-demand work\\"}],\\"Default\\":\\"Process Result\\"},\\"S3.ListObjectsV2(NextPage)\\":{\\"Next\\":\\"Is there more?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"S3.SdkClientException\\"]}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.response\\",\\"Resource\\":\\"arn:",
               Object {
                 "Ref": "AWS::Partition",
               },
@@ -2908,7 +2920,7 @@ Direct link to the function: /lambda/home#/functions/",
               Object {
                 "Ref": "AWS::AccountId",
               },
-              ":stateMachine:Test.ConstructHub.Ingestion.ReprocessWorkflow\\"}}},\\"TimeoutSeconds\\":3600}",
+              ":stateMachine:Test.ConstructHub.Ingestion.ReprocessWorkflow\\"}},\\"Give room for on-demand work\\":{\\"Type\\":\\"Wait\\",\\"Seconds\\":300,\\"Next\\":\\"Continue as new\\"}},\\"TimeoutSeconds\\":3600}",
             ],
           ],
         },
@@ -3338,7 +3350,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3Bucket649728C0",
+            "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3Bucket5515214C",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -3351,7 +3363,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3VersionKey592D485B",
+                          "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED",
                         },
                       ],
                     },
@@ -3364,7 +3376,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3VersionKey592D485B",
+                          "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED",
                         },
                       ],
                     },
@@ -4393,7 +4405,7 @@ Direct link to function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3Bucket635A0AFA",
+            "Ref": "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3BucketE7A02ACD",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -4406,7 +4418,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3VersionKeyBB104177",
+                          "Ref": "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3VersionKeyCC994D9E",
                         },
                       ],
                     },
@@ -4419,7 +4431,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3VersionKeyBB104177",
+                          "Ref": "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3VersionKeyCC994D9E",
                         },
                       ],
                     },
@@ -4551,7 +4563,7 @@ Direct link to function: /lambda/home#/functions/",
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"StartAt\\":\\"Track Execution Infos\\",\\"States\\":{\\"Track Execution Infos\\":{\\"Type\\":\\"Pass\\",\\"ResultPath\\":\\"$.$TaskExecution\\",\\"InputPath\\":\\"$$.Execution\\",\\"Parameters\\":{\\"Id.$\\":\\"$.Id\\",\\"Name.$\\":\\"$.Name\\",\\"RoleArn.$\\":\\"$.RoleArn\\",\\"StartTime.$\\":\\"$.StartTime\\"},\\"Next\\":\\"Prepare doc-gen ECS Command\\"},\\"Prepare doc-gen ECS Command\\":{\\"Type\\":\\"Pass\\",\\"ResultPath\\":\\"$.docGen\\",\\"Parameters\\":{\\"command.$\\":\\"States.Array(States.JsonToString($))\\"},\\"Next\\":\\"Generate docs\\"},\\"Generate docs\\":{\\"Next\\":\\"Check whether catalog needs udpating\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"jsii-docgen.NoSpaceLeftOnDevice\\"],\\"MaxAttempts\\":0},{\\"ErrorEquals\\":[\\"ECS.AmazonECSException\\",\\"ECS.InvalidParameterException\\",\\"jsii-docgen.NpmError.E429\\",\\"jsii-codgen.NpmError.EPROTO\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":30,\\"BackoffRate\\":1.1},{\\"ErrorEquals\\":[\\"jsii-docgen.NpmError.ETARGET\\"],\\"IntervalSeconds\\":300,\\"MaxAttempts\\":3,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"MaxAttempts\\":3}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"UnprocessablePackageError\\"],\\"Next\\":\\"Ignore\\"},{\\"ErrorEquals\\":[\\"States.Timeout\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"ECS.AmazonECSException\\",\\"ECS.InvalidParameterException\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Type\\":\\"Task\\",\\"TimeoutSeconds\\":3600,\\"HeartbeatSeconds\\":300,\\"InputPath\\":\\"$.docGen.command\\",\\"ResultPath\\":\\"$.docGenOutput\\",\\"Resource\\":\\"arn:",
+              "{\\"StartAt\\":\\"Track Execution Infos\\",\\"States\\":{\\"Track Execution Infos\\":{\\"Type\\":\\"Pass\\",\\"ResultPath\\":\\"$.$TaskExecution\\",\\"InputPath\\":\\"$$.Execution\\",\\"Parameters\\":{\\"Id.$\\":\\"$.Id\\",\\"Name.$\\":\\"$.Name\\",\\"RoleArn.$\\":\\"$.RoleArn\\",\\"StartTime.$\\":\\"$.StartTime\\"},\\"Next\\":\\"Prepare doc-gen ECS Command\\"},\\"Prepare doc-gen ECS Command\\":{\\"Type\\":\\"Pass\\",\\"ResultPath\\":\\"$.docGen\\",\\"Parameters\\":{\\"command.$\\":\\"States.Array(States.JsonToString($))\\"},\\"Next\\":\\"Generate docs\\"},\\"Generate docs\\":{\\"Next\\":\\"Check whether catalog needs udpating\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"jsii-docgen.NoSpaceLeftOnDevice\\"],\\"MaxAttempts\\":0},{\\"ErrorEquals\\":[\\"ECS.AmazonECSException\\",\\"ECS.InvalidParameterException\\",\\"jsii-docgen.NpmError.E429\\",\\"jsii-codgen.NpmError.EPROTO\\"],\\"IntervalSeconds\\":120,\\"MaxAttempts\\":200,\\"BackoffRate\\":1},{\\"ErrorEquals\\":[\\"jsii-docgen.NpmError.ETARGET\\"],\\"IntervalSeconds\\":300,\\"MaxAttempts\\":3,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"MaxAttempts\\":3}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"UnprocessablePackageError\\"],\\"Next\\":\\"Ignore\\"},{\\"ErrorEquals\\":[\\"States.Timeout\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"ECS.AmazonECSException\\",\\"ECS.InvalidParameterException\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Type\\":\\"Task\\",\\"TimeoutSeconds\\":7200,\\"HeartbeatSeconds\\":300,\\"InputPath\\":\\"$.docGen.command\\",\\"ResultPath\\":\\"$.docGenOutput\\",\\"Resource\\":\\"arn:",
               Object {
                 "Ref": "AWS::Partition",
               },
@@ -4577,7 +4589,7 @@ Direct link to function: /lambda/home#/functions/",
                   "GroupId",
                 ],
               },
-              "\\"]}},\\"Overrides\\":{\\"ContainerOverrides\\":[{\\"Name\\":\\"Resource\\",\\"Command.$\\":\\"$\\",\\"Environment\\":[{\\"Name\\":\\"SFN_TASK_TOKEN\\",\\"Value.$\\":\\"$$.Task.Token\\"}]}]},\\"LaunchType\\":\\"FARGATE\\",\\"PlatformVersion\\":\\"1.4.0\\"}},\\"Check whether catalog needs udpating\\":{\\"Next\\":\\"Is catalog update needed?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"Lambda.ServiceException\\",\\"Lambda.AWSLambdaException\\",\\"Lambda.SdkClientException\\"],\\"IntervalSeconds\\":2,\\"MaxAttempts\\":6,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":30,\\"BackoffRate\\":1.1}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.catalogNeedsUpdating\\",\\"Resource\\":\\"",
+              "\\"]}},\\"Overrides\\":{\\"ContainerOverrides\\":[{\\"Name\\":\\"Resource\\",\\"Command.$\\":\\"$\\",\\"Environment\\":[{\\"Name\\":\\"SFN_TASK_TOKEN\\",\\"Value.$\\":\\"$$.Task.Token\\"}]}]},\\"LaunchType\\":\\"FARGATE\\",\\"PlatformVersion\\":\\"1.4.0\\"}},\\"Check whether catalog needs udpating\\":{\\"Next\\":\\"Is catalog update needed?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"Lambda.ServiceException\\",\\"Lambda.AWSLambdaException\\",\\"Lambda.SdkClientException\\"],\\"IntervalSeconds\\":2,\\"MaxAttempts\\":6,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\",\\"Lambda.Unknown\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":30,\\"BackoffRate\\":1.1}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\",\\"Lambda.Unknown\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.catalogNeedsUpdating\\",\\"Resource\\":\\"",
               Object {
                 "Fn::GetAtt": Array [
                   "ConstructHubOrchestrationNeedsCatalogUpdate5D7370DC",
@@ -4628,7 +4640,7 @@ Direct link to function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3Bucket2D6D8F86",
+            "Ref": "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3Bucket722FE70B",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -4641,7 +4653,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3VersionKey0ECB40A6",
+                          "Ref": "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3VersionKey8082F3BC",
                         },
                       ],
                     },
@@ -4654,7 +4666,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3VersionKey0ECB40A6",
+                          "Ref": "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3VersionKey8082F3BC",
                         },
                       ],
                     },
@@ -5456,7 +5468,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3Bucket19B71C5A",
+            "Ref": "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3BucketE78A0203",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -5469,7 +5481,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3VersionKeyDF73A6F0",
+                          "Ref": "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3VersionKey598098A7",
                         },
                       ],
                     },
@@ -5482,7 +5494,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3VersionKeyDF73A6F0",
+                          "Ref": "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3VersionKey598098A7",
                         },
                       ],
                     },
@@ -5640,7 +5652,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3Bucket1090210F",
+            "Ref": "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3Bucket6F376B71",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -5653,7 +5665,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3VersionKeyD738CD6B",
+                          "Ref": "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3VersionKey7F6E5804",
                         },
                       ],
                     },
@@ -5666,7 +5678,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3VersionKeyD738CD6B",
+                          "Ref": "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3VersionKey7F6E5804",
                         },
                       ],
                     },
@@ -6444,7 +6456,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                   Object {
                     "Ref": "AWS::URLSuffix",
                   },
-                  "/aws-cdk/assets:5fa39a328f34360df81ad2f478b29e7f72b6625d60d6ca775401e69a3b2c0faf",
+                  "/aws-cdk/assets:89c6683e392b08bdb9bfd8e456f82a156b228534eed332191232b4aa0beec4f2",
                 ],
               ],
             },
@@ -6726,7 +6738,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.md",
+                      "/data/*/docs-typescript.*",
                     ],
                   ],
                 },
@@ -6756,7 +6768,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.md",
+                      "/data/*/docs-*-typescript.*",
                     ],
                   ],
                 },
@@ -6786,7 +6798,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.md.not-supported",
+                      "/data/*/docs-typescript.*.not-supported",
                     ],
                   ],
                 },
@@ -6816,7 +6828,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.md.not-supported",
+                      "/data/*/docs-*-typescript.*.not-supported",
                     ],
                   ],
                 },
@@ -6846,7 +6858,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.md.corruptassembly",
+                      "/data/*/docs-typescript.*.corruptassembly",
                     ],
                   ],
                 },
@@ -6876,7 +6888,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.md.corruptassembly",
+                      "/data/*/docs-*-typescript.*.corruptassembly",
                     ],
                   ],
                 },
@@ -6895,7 +6907,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-typescript.md.corruptassembly",
+                    "/data/*/docs-typescript.*.corruptassembly",
                   ],
                 ],
               },
@@ -6913,223 +6925,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-typescript.md.corruptassembly",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.md",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.md",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.md.not-supported",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.md.not-supported",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.md.corruptassembly",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.md.corruptassembly",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": "s3:DeleteObject*",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "ConstructHubPackageDataDC5EF35E",
-                        "Arn",
-                      ],
-                    },
-                    "/data/*/docs-python.md.corruptassembly",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": "s3:DeleteObject*",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "ConstructHubPackageDataDC5EF35E",
-                        "Arn",
-                      ],
-                    },
-                    "/data/*/docs-*-python.md.corruptassembly",
+                    "/data/*/docs-*-typescript.*.corruptassembly",
                   ],
                 ],
               },
@@ -7158,7 +6954,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.md",
+                      "/data/*/docs-python.*",
                     ],
                   ],
                 },
@@ -7188,7 +6984,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.md",
+                      "/data/*/docs-*-python.*",
                     ],
                   ],
                 },
@@ -7218,7 +7014,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.md.not-supported",
+                      "/data/*/docs-python.*.not-supported",
                     ],
                   ],
                 },
@@ -7248,7 +7044,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.md.not-supported",
+                      "/data/*/docs-*-python.*.not-supported",
                     ],
                   ],
                 },
@@ -7278,7 +7074,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.md.corruptassembly",
+                      "/data/*/docs-python.*.corruptassembly",
                     ],
                   ],
                 },
@@ -7308,7 +7104,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.md.corruptassembly",
+                      "/data/*/docs-*-python.*.corruptassembly",
                     ],
                   ],
                 },
@@ -7327,7 +7123,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-java.md.corruptassembly",
+                    "/data/*/docs-python.*.corruptassembly",
                   ],
                 ],
               },
@@ -7345,7 +7141,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-java.md.corruptassembly",
+                    "/data/*/docs-*-python.*.corruptassembly",
                   ],
                 ],
               },
@@ -7374,7 +7170,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.md",
+                      "/data/*/docs-java.*",
                     ],
                   ],
                 },
@@ -7404,7 +7200,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.md",
+                      "/data/*/docs-*-java.*",
                     ],
                   ],
                 },
@@ -7434,7 +7230,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.md.not-supported",
+                      "/data/*/docs-java.*.not-supported",
                     ],
                   ],
                 },
@@ -7464,7 +7260,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.md.not-supported",
+                      "/data/*/docs-*-java.*.not-supported",
                     ],
                   ],
                 },
@@ -7494,7 +7290,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.md.corruptassembly",
+                      "/data/*/docs-java.*.corruptassembly",
                     ],
                   ],
                 },
@@ -7524,7 +7320,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.md.corruptassembly",
+                      "/data/*/docs-*-java.*.corruptassembly",
                     ],
                   ],
                 },
@@ -7543,7 +7339,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-csharp.md.corruptassembly",
+                    "/data/*/docs-java.*.corruptassembly",
                   ],
                 ],
               },
@@ -7561,7 +7357,223 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-csharp.md.corruptassembly",
+                    "/data/*/docs-*-java.*.corruptassembly",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.*.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.*.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.*.corruptassembly",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.*.corruptassembly",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": "s3:DeleteObject*",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "ConstructHubPackageDataDC5EF35E",
+                        "Arn",
+                      ],
+                    },
+                    "/data/*/docs-csharp.*.corruptassembly",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:DeleteObject*",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "ConstructHubPackageDataDC5EF35E",
+                        "Arn",
+                      ],
+                    },
+                    "/data/*/docs-*-csharp.*.corruptassembly",
                   ],
                 ],
               },
@@ -7827,7 +7839,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3Bucket901B95EB",
+            "Ref": "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3Bucket024B3DC6",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -7840,7 +7852,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3VersionKeyC6FBD6BD",
+                          "Ref": "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3VersionKeyEEA56859",
                         },
                       ],
                     },
@@ -7853,7 +7865,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3VersionKeyC6FBD6BD",
+                          "Ref": "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3VersionKeyEEA56859",
                         },
                       ],
                     },
@@ -7910,7 +7922,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3Bucket86DBA113",
+            "Ref": "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3Bucket37F2908E",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -7923,7 +7935,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3VersionKeyF547CFB5",
+                          "Ref": "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3VersionKey2C992F11",
                         },
                       ],
                     },
@@ -7936,7 +7948,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3VersionKeyF547CFB5",
+                          "Ref": "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3VersionKey2C992F11",
                         },
                       ],
                     },
@@ -8499,7 +8511,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3BucketFFA964C8",
+            "Ref": "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3Bucket8AF0E263",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -8512,7 +8524,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3VersionKeyA62CD84A",
+                          "Ref": "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3VersionKey5280D545",
                         },
                       ],
                     },
@@ -8525,7 +8537,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3VersionKeyA62CD84A",
+                          "Ref": "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3VersionKey5280D545",
                         },
                       ],
                     },
@@ -8935,7 +8947,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3BucketE35D2278",
+            "Ref": "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3Bucket789CA701",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -8948,7 +8960,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3VersionKey88FA0AFA",
+                          "Ref": "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3VersionKey0222399F",
                         },
                       ],
                     },
@@ -8961,7 +8973,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3VersionKey88FA0AFA",
+                          "Ref": "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3VersionKey0222399F",
                         },
                       ],
                     },
@@ -9167,7 +9179,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3BucketF9AF3C9C",
+            "Ref": "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3Bucket86412295",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -9180,7 +9192,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3VersionKey09B12EB1",
+                          "Ref": "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3VersionKeyE42DDF01",
                         },
                       ],
                     },
@@ -9193,7 +9205,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3VersionKey09B12EB1",
+                          "Ref": "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3VersionKeyE42DDF01",
                         },
                       ],
                     },
@@ -9609,7 +9621,10 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1",
+            "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3BucketED9FB7B0",
+          },
+          Object {
+            "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
           },
         ],
         "SourceObjectKeys": Array [
@@ -9624,7 +9639,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3VersionKeyBA1CB663",
+                          "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3VersionKeyCFEDA3D4",
                         },
                       ],
                     },
@@ -9637,7 +9652,40 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3VersionKeyBA1CB663",
+                          "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3VersionKeyCFEDA3D4",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            ],
+          },
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                Object {
+                  "Fn::Select": Array [
+                    0,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                Object {
+                  "Fn::Select": Array [
+                    1,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49",
                         },
                       ],
                     },
@@ -9672,7 +9720,7 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22",
+            "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2",
           },
         ],
         "SourceObjectKeys": Array [
@@ -9687,7 +9735,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3VersionKeyCE5C5D3B",
+                          "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3VersionKeyEC7E3301",
                         },
                       ],
                     },
@@ -9700,7 +9748,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3VersionKeyCE5C5D3B",
+                          "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3VersionKeyEC7E3301",
                         },
                       ],
                     },
@@ -10381,7 +10429,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22",
+                        "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2",
                       },
                     ],
                   ],
@@ -10396,7 +10444,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22",
+                        "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2",
                       },
                       "/*",
                     ],
@@ -10463,7 +10511,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1",
+                        "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3BucketED9FB7B0",
                       },
                     ],
                   ],
@@ -10478,7 +10526,48 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1",
+                        "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3BucketED9FB7B0",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
+                      },
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
                       },
                       "/*",
                     ],
@@ -10706,7 +10795,7 @@ function handler(event) {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3Bucket1B95B117",
+            "Ref": "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3BucketCBEF8050",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -10719,7 +10808,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3VersionKey75D92238",
+                          "Ref": "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3VersionKey57968381",
                         },
                       ],
                     },
@@ -10732,7 +10821,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3VersionKey75D92238",
+                          "Ref": "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3VersionKey57968381",
                         },
                       ],
                     },
@@ -11238,28 +11327,40 @@ Object {
     },
   },
   "Parameters": Object {
-    "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeArtifactHash322D47B8": Object {
-      "Description": "Artifact hash for asset \\"0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9ae\\"",
+    "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6ArtifactHashF2EEEBFF": Object {
+      "Description": "Artifact hash for asset \\"04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6\\"",
       "Type": "String",
     },
-    "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3Bucket635A0AFA": Object {
-      "Description": "S3 bucket for asset \\"0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9ae\\"",
+    "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3Bucket86412295": Object {
+      "Description": "S3 bucket for asset \\"04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6\\"",
       "Type": "String",
     },
-    "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3VersionKeyBB104177": Object {
-      "Description": "S3 key for asset version \\"0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9ae\\"",
+    "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3VersionKeyE42DDF01": Object {
+      "Description": "S3 key for asset version \\"04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6\\"",
       "Type": "String",
     },
-    "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadArtifactHash3158CABD": Object {
-      "Description": "Artifact hash for asset \\"0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362ead\\"",
+    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440ArtifactHash87A9FF22": Object {
+      "Description": "Artifact hash for asset \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
       "Type": "String",
     },
-    "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3Bucket288D5551": Object {
-      "Description": "S3 bucket for asset \\"0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362ead\\"",
+    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054": Object {
+      "Description": "S3 bucket for asset \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
       "Type": "String",
     },
-    "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3VersionKey4638DF79": Object {
-      "Description": "S3 key for asset version \\"0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362ead\\"",
+    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49": Object {
+      "Description": "S3 key for asset version \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
+      "Type": "String",
+    },
+    "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aArtifactHash82449A4A": Object {
+      "Description": "Artifact hash for asset \\"0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4a\\"",
+      "Type": "String",
+    },
+    "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3Bucket789CA701": Object {
+      "Description": "S3 bucket for asset \\"0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4a\\"",
+      "Type": "String",
+    },
+    "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3VersionKey0222399F": Object {
+      "Description": "S3 key for asset version \\"0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4a\\"",
       "Type": "String",
     },
     "AssetParameters0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9ArtifactHashB9E3BF29": Object {
@@ -11274,42 +11375,6 @@ Object {
       "Description": "S3 key for asset version \\"0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9\\"",
       "Type": "String",
     },
-    "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67ArtifactHashCF96E147": Object {
-      "Description": "Artifact hash for asset \\"1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67\\"",
-      "Type": "String",
-    },
-    "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3BucketFFA964C8": Object {
-      "Description": "S3 bucket for asset \\"1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67\\"",
-      "Type": "String",
-    },
-    "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3VersionKeyA62CD84A": Object {
-      "Description": "S3 key for asset version \\"1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67\\"",
-      "Type": "String",
-    },
-    "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3ArtifactHashA3981DF8": Object {
-      "Description": "Artifact hash for asset \\"1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3\\"",
-      "Type": "String",
-    },
-    "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1": Object {
-      "Description": "S3 bucket for asset \\"1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3\\"",
-      "Type": "String",
-    },
-    "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3VersionKeyBA1CB663": Object {
-      "Description": "S3 key for asset version \\"1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3\\"",
-      "Type": "String",
-    },
-    "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeArtifactHashD1A9CF6A": Object {
-      "Description": "Artifact hash for asset \\"1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33ae\\"",
-      "Type": "String",
-    },
-    "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3Bucket901B95EB": Object {
-      "Description": "S3 bucket for asset \\"1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33ae\\"",
-      "Type": "String",
-    },
-    "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3VersionKeyC6FBD6BD": Object {
-      "Description": "S3 key for asset version \\"1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33ae\\"",
-      "Type": "String",
-    },
     "AssetParameters1f7e277bd526ebce1983fa1e7a84a5281ec533d9187caaebb773681bbf7bf4c1ArtifactHash0128B949": Object {
       "Description": "Artifact hash for asset \\"1f7e277bd526ebce1983fa1e7a84a5281ec533d9187caaebb773681bbf7bf4c1\\"",
       "Type": "String",
@@ -11322,40 +11387,52 @@ Object {
       "Description": "S3 key for asset version \\"1f7e277bd526ebce1983fa1e7a84a5281ec533d9187caaebb773681bbf7bf4c1\\"",
       "Type": "String",
     },
-    "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cArtifactHash8D005B5F": Object {
-      "Description": "Artifact hash for asset \\"205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612c\\"",
+    "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5ArtifactHash0AFE0939": Object {
+      "Description": "Artifact hash for asset \\"37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5\\"",
       "Type": "String",
     },
-    "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3Bucket95F679AA": Object {
-      "Description": "S3 bucket for asset \\"205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612c\\"",
+    "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3Bucket722FE70B": Object {
+      "Description": "S3 bucket for asset \\"37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5\\"",
       "Type": "String",
     },
-    "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3VersionKeyE7A4EEDD": Object {
-      "Description": "S3 key for asset version \\"205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612c\\"",
+    "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3VersionKey8082F3BC": Object {
+      "Description": "S3 key for asset version \\"37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5\\"",
       "Type": "String",
     },
-    "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534ArtifactHash89381734": Object {
-      "Description": "Artifact hash for asset \\"25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534\\"",
+    "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5ArtifactHash499F6DFF": Object {
+      "Description": "Artifact hash for asset \\"3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5\\"",
       "Type": "String",
     },
-    "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3Bucket8AFE0D2F": Object {
-      "Description": "S3 bucket for asset \\"25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534\\"",
+    "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3Bucket37F2908E": Object {
+      "Description": "S3 bucket for asset \\"3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5\\"",
       "Type": "String",
     },
-    "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3VersionKey39383E8E": Object {
-      "Description": "S3 key for asset version \\"25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534\\"",
+    "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3VersionKey2C992F11": Object {
+      "Description": "S3 key for asset version \\"3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5\\"",
       "Type": "String",
     },
-    "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bArtifactHash270470CC": Object {
-      "Description": "Artifact hash for asset \\"3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934b\\"",
+    "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dArtifactHash3B82A2B3": Object {
+      "Description": "Artifact hash for asset \\"3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880d\\"",
       "Type": "String",
     },
-    "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3Bucket2D6D8F86": Object {
-      "Description": "S3 bucket for asset \\"3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934b\\"",
+    "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3BucketCBEF8050": Object {
+      "Description": "S3 bucket for asset \\"3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880d\\"",
       "Type": "String",
     },
-    "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3VersionKey0ECB40A6": Object {
-      "Description": "S3 key for asset version \\"3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934b\\"",
+    "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3VersionKey57968381": Object {
+      "Description": "S3 key for asset version \\"3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880d\\"",
+      "Type": "String",
+    },
+    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afArtifactHash7F8A76FC": Object {
+      "Description": "Artifact hash for asset \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
+      "Type": "String",
+    },
+    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3Bucket5515214C": Object {
+      "Description": "S3 bucket for asset \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
+      "Type": "String",
+    },
+    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED": Object {
+      "Description": "S3 key for asset version \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
       "Type": "String",
     },
     "AssetParameters4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbcArtifactHashF236251A": Object {
@@ -11370,76 +11447,40 @@ Object {
       "Description": "S3 key for asset version \\"4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbc\\"",
       "Type": "String",
     },
-    "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0ArtifactHash6F14CF3C": Object {
-      "Description": "Artifact hash for asset \\"55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0\\"",
+    "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bArtifactHash5ABBFB9B": Object {
+      "Description": "Artifact hash for asset \\"42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2b\\"",
       "Type": "String",
     },
-    "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3BucketE35D2278": Object {
-      "Description": "S3 bucket for asset \\"55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0\\"",
+    "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3Bucket8AF0E263": Object {
+      "Description": "S3 bucket for asset \\"42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2b\\"",
       "Type": "String",
     },
-    "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3VersionKey88FA0AFA": Object {
-      "Description": "S3 key for asset version \\"55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0\\"",
+    "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3VersionKey5280D545": Object {
+      "Description": "S3 key for asset version \\"42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2b\\"",
       "Type": "String",
     },
-    "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420ArtifactHashC847AA8D": Object {
-      "Description": "Artifact hash for asset \\"6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420\\"",
+    "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeArtifactHash3FAC57D3": Object {
+      "Description": "Artifact hash for asset \\"4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeee\\"",
       "Type": "String",
     },
-    "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3Bucket649728C0": Object {
-      "Description": "S3 bucket for asset \\"6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420\\"",
+    "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3Bucket6F376B71": Object {
+      "Description": "S3 bucket for asset \\"4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeee\\"",
       "Type": "String",
     },
-    "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3VersionKey592D485B": Object {
-      "Description": "S3 key for asset version \\"6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420\\"",
+    "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3VersionKey7F6E5804": Object {
+      "Description": "S3 key for asset version \\"4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeee\\"",
       "Type": "String",
     },
-    "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cArtifactHashD2B94368": Object {
-      "Description": "Artifact hash for asset \\"73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06c\\"",
+    "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680ArtifactHash316B2926": Object {
+      "Description": "Artifact hash for asset \\"864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680\\"",
       "Type": "String",
     },
-    "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3Bucket19B71C5A": Object {
-      "Description": "S3 bucket for asset \\"73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06c\\"",
+    "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3BucketF13820EA": Object {
+      "Description": "S3 bucket for asset \\"864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680\\"",
       "Type": "String",
     },
-    "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3VersionKeyDF73A6F0": Object {
-      "Description": "S3 key for asset version \\"73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06c\\"",
-      "Type": "String",
-    },
-    "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fArtifactHash2005F882": Object {
-      "Description": "Artifact hash for asset \\"778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6f\\"",
-      "Type": "String",
-    },
-    "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22": Object {
-      "Description": "S3 bucket for asset \\"778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6f\\"",
-      "Type": "String",
-    },
-    "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3VersionKeyCE5C5D3B": Object {
-      "Description": "S3 key for asset version \\"778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6f\\"",
-      "Type": "String",
-    },
-    "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0ArtifactHashF4B56B1E": Object {
-      "Description": "Artifact hash for asset \\"782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0\\"",
-      "Type": "String",
-    },
-    "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3Bucket1090210F": Object {
-      "Description": "S3 bucket for asset \\"782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0\\"",
-      "Type": "String",
-    },
-    "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3VersionKeyD738CD6B": Object {
-      "Description": "S3 key for asset version \\"782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0\\"",
-      "Type": "String",
-    },
-    "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965ArtifactHashD4D3C5A6": Object {
-      "Description": "Artifact hash for asset \\"7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965\\"",
-      "Type": "String",
-    },
-    "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3Bucket0A90D6D3": Object {
-      "Description": "S3 bucket for asset \\"7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965\\"",
-      "Type": "String",
-    },
-    "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3VersionKeyA116EF05": Object {
-      "Description": "S3 key for asset version \\"7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965\\"",
+    "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3VersionKey52B24F16": Object {
+      "Description": "S3 key for asset version \\"864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680\\"",
       "Type": "String",
     },
     "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900ArtifactHash121EF458": Object {
@@ -11454,6 +11495,18 @@ Object {
       "Description": "S3 key for asset version \\"8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900\\"",
       "Type": "String",
     },
+    "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9ArtifactHash694505BF": Object {
+      "Description": "Artifact hash for asset \\"8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9\\"",
+      "Type": "String",
+    },
+    "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3BucketED9FB7B0": Object {
+      "Description": "S3 bucket for asset \\"8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9\\"",
+      "Type": "String",
+    },
+    "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3VersionKeyCFEDA3D4": Object {
+      "Description": "S3 key for asset version \\"8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9\\"",
+      "Type": "String",
+    },
     "AssetParameters8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064ArtifactHashEA963870": Object {
       "Description": "Artifact hash for asset \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
@@ -11466,16 +11519,16 @@ Object {
       "Description": "S3 key for asset version \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
     },
-    "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8ArtifactHash8DC0C383": Object {
-      "Description": "Artifact hash for asset \\"9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8\\"",
+    "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4ArtifactHash660A50B8": Object {
+      "Description": "Artifact hash for asset \\"98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4\\"",
       "Type": "String",
     },
-    "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3Bucket1B95B117": Object {
-      "Description": "S3 bucket for asset \\"9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8\\"",
+    "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3BucketE78A0203": Object {
+      "Description": "S3 bucket for asset \\"98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4\\"",
       "Type": "String",
     },
-    "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3VersionKey75D92238": Object {
-      "Description": "S3 key for asset version \\"9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8\\"",
+    "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3VersionKey598098A7": Object {
+      "Description": "S3 key for asset version \\"98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4\\"",
       "Type": "String",
     },
     "AssetParametersa3058ccb468d757ebb89df5363a1c20f5307c6911136f29d00e1a68c9b2aa7e8ArtifactHash238275D6": Object {
@@ -11490,16 +11543,16 @@ Object {
       "Description": "S3 key for asset version \\"a3058ccb468d757ebb89df5363a1c20f5307c6911136f29d00e1a68c9b2aa7e8\\"",
       "Type": "String",
     },
-    "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdArtifactHash22ECD1BE": Object {
-      "Description": "Artifact hash for asset \\"adb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbd\\"",
+    "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaArtifactHash8CCAA809": Object {
+      "Description": "Artifact hash for asset \\"af643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfba\\"",
       "Type": "String",
     },
-    "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3BucketF9AF3C9C": Object {
-      "Description": "S3 bucket for asset \\"adb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbd\\"",
+    "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2": Object {
+      "Description": "S3 bucket for asset \\"af643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfba\\"",
       "Type": "String",
     },
-    "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3VersionKey09B12EB1": Object {
-      "Description": "S3 key for asset version \\"adb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbd\\"",
+    "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3VersionKeyEC7E3301": Object {
+      "Description": "S3 key for asset version \\"af643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfba\\"",
       "Type": "String",
     },
     "AssetParametersb120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827ArtifactHash1355580A": Object {
@@ -11514,16 +11567,40 @@ Object {
       "Description": "S3 key for asset version \\"b120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827\\"",
       "Type": "String",
     },
-    "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8ArtifactHashBB72DCC8": Object {
-      "Description": "Artifact hash for asset \\"c8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8\\"",
+    "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04ArtifactHash394183E9": Object {
+      "Description": "Artifact hash for asset \\"b55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04\\"",
       "Type": "String",
     },
-    "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3Bucket86DBA113": Object {
-      "Description": "S3 bucket for asset \\"c8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8\\"",
+    "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3BucketE7A02ACD": Object {
+      "Description": "S3 bucket for asset \\"b55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04\\"",
       "Type": "String",
     },
-    "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3VersionKeyF547CFB5": Object {
-      "Description": "S3 key for asset version \\"c8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8\\"",
+    "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3VersionKeyCC994D9E": Object {
+      "Description": "S3 key for asset version \\"b55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04\\"",
+      "Type": "String",
+    },
+    "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcArtifactHash4E26EEC4": Object {
+      "Description": "Artifact hash for asset \\"c62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafc\\"",
+      "Type": "String",
+    },
+    "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3Bucket5255533F": Object {
+      "Description": "S3 bucket for asset \\"c62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafc\\"",
+      "Type": "String",
+    },
+    "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3VersionKey7909F675": Object {
+      "Description": "S3 key for asset version \\"c62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafc\\"",
+      "Type": "String",
+    },
+    "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aArtifactHash0386B8EC": Object {
+      "Description": "Artifact hash for asset \\"da314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17a\\"",
+      "Type": "String",
+    },
+    "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3BucketAE80D773": Object {
+      "Description": "S3 bucket for asset \\"da314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17a\\"",
+      "Type": "String",
+    },
+    "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3VersionKey662F0E6F": Object {
+      "Description": "S3 key for asset version \\"da314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17a\\"",
       "Type": "String",
     },
     "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68ArtifactHashD9A515C3": Object {
@@ -11536,6 +11613,30 @@ Object {
     },
     "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3VersionKeyE415415F": Object {
       "Description": "S3 key for asset version \\"e9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68\\"",
+      "Type": "String",
+    },
+    "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3ArtifactHash11DB5971": Object {
+      "Description": "Artifact hash for asset \\"f48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3\\"",
+      "Type": "String",
+    },
+    "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3BucketAC5DE359": Object {
+      "Description": "S3 bucket for asset \\"f48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3\\"",
+      "Type": "String",
+    },
+    "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3VersionKey503D22DC": Object {
+      "Description": "S3 key for asset version \\"f48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3\\"",
+      "Type": "String",
+    },
+    "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5ArtifactHash185A4671": Object {
+      "Description": "Artifact hash for asset \\"fbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5\\"",
+      "Type": "String",
+    },
+    "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3Bucket024B3DC6": Object {
+      "Description": "S3 bucket for asset \\"fbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5\\"",
+      "Type": "String",
+    },
+    "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3VersionKeyEEA56859": Object {
+      "Description": "S3 key for asset version \\"fbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5\\"",
       "Type": "String",
     },
   },
@@ -13073,7 +13174,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3Bucket288D5551",
+            "Ref": "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3BucketAE80D773",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -13086,7 +13187,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3VersionKey4638DF79",
+                          "Ref": "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3VersionKey662F0E6F",
                         },
                       ],
                     },
@@ -13099,7 +13200,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3VersionKey4638DF79",
+                          "Ref": "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3VersionKey662F0E6F",
                         },
                       ],
                     },
@@ -13282,7 +13383,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3Bucket95F679AA",
+            "Ref": "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3BucketAC5DE359",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -13295,7 +13396,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3VersionKeyE7A4EEDD",
+                          "Ref": "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3VersionKey503D22DC",
                         },
                       ],
                     },
@@ -13308,7 +13409,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3VersionKeyE7A4EEDD",
+                          "Ref": "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3VersionKey503D22DC",
                         },
                       ],
                     },
@@ -13548,7 +13649,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3Bucket8AFE0D2F",
+            "Ref": "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3BucketF13820EA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -13561,7 +13662,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3VersionKey39383E8E",
+                          "Ref": "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3VersionKey52B24F16",
                         },
                       ],
                     },
@@ -13574,7 +13675,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3VersionKey39383E8E",
+                          "Ref": "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3VersionKey52B24F16",
                         },
                       ],
                     },
@@ -14079,7 +14180,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3Bucket0A90D6D3",
+            "Ref": "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3Bucket5255533F",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -14092,7 +14193,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3VersionKeyA116EF05",
+                          "Ref": "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3VersionKey7909F675",
                         },
                       ],
                     },
@@ -14105,7 +14206,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3VersionKeyA116EF05",
+                          "Ref": "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3VersionKey7909F675",
                         },
                       ],
                     },
@@ -14289,7 +14390,7 @@ Direct link to the function: /lambda/home#/functions/",
               Object {
                 "Ref": "ConstructHubPackageDataDC5EF35E",
               },
-              "\\",\\"Prefix\\":\\"data/\\"}},\\"Is there more?\\":{\\"Type\\":\\"Choice\\",\\"Choices\\":[{\\"Variable\\":\\"$.response.NextContinuationToken\\",\\"IsPresent\\":true,\\"Next\\":\\"Continue as new\\"}],\\"Default\\":\\"Process Result\\"},\\"S3.ListObjectsV2(NextPage)\\":{\\"Next\\":\\"Is there more?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"S3.SdkClientException\\"]}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.response\\",\\"Resource\\":\\"arn:",
+              "\\",\\"Prefix\\":\\"data/\\"}},\\"Is there more?\\":{\\"Type\\":\\"Choice\\",\\"Choices\\":[{\\"Variable\\":\\"$.response.NextContinuationToken\\",\\"IsPresent\\":true,\\"Next\\":\\"Give room for on-demand work\\"}],\\"Default\\":\\"Process Result\\"},\\"S3.ListObjectsV2(NextPage)\\":{\\"Next\\":\\"Is there more?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"S3.SdkClientException\\"]}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.response\\",\\"Resource\\":\\"arn:",
               Object {
                 "Ref": "AWS::Partition",
               },
@@ -14324,7 +14425,7 @@ Direct link to the function: /lambda/home#/functions/",
               Object {
                 "Ref": "AWS::AccountId",
               },
-              ":stateMachine:Test.ConstructHub.Ingestion.ReprocessWorkflow\\"}}},\\"TimeoutSeconds\\":3600}",
+              ":stateMachine:Test.ConstructHub.Ingestion.ReprocessWorkflow\\"}},\\"Give room for on-demand work\\":{\\"Type\\":\\"Wait\\",\\"Seconds\\":300,\\"Next\\":\\"Continue as new\\"}},\\"TimeoutSeconds\\":3600}",
             ],
           ],
         },
@@ -14834,7 +14935,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3Bucket649728C0",
+            "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3Bucket5515214C",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -14847,7 +14948,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3VersionKey592D485B",
+                          "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED",
                         },
                       ],
                     },
@@ -14860,7 +14961,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3VersionKey592D485B",
+                          "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED",
                         },
                       ],
                     },
@@ -15889,7 +15990,7 @@ Direct link to function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3Bucket635A0AFA",
+            "Ref": "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3BucketE7A02ACD",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -15902,7 +16003,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3VersionKeyBB104177",
+                          "Ref": "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3VersionKeyCC994D9E",
                         },
                       ],
                     },
@@ -15915,7 +16016,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3VersionKeyBB104177",
+                          "Ref": "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3VersionKeyCC994D9E",
                         },
                       ],
                     },
@@ -16047,7 +16148,7 @@ Direct link to function: /lambda/home#/functions/",
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"StartAt\\":\\"Track Execution Infos\\",\\"States\\":{\\"Track Execution Infos\\":{\\"Type\\":\\"Pass\\",\\"ResultPath\\":\\"$.$TaskExecution\\",\\"InputPath\\":\\"$$.Execution\\",\\"Parameters\\":{\\"Id.$\\":\\"$.Id\\",\\"Name.$\\":\\"$.Name\\",\\"RoleArn.$\\":\\"$.RoleArn\\",\\"StartTime.$\\":\\"$.StartTime\\"},\\"Next\\":\\"Prepare doc-gen ECS Command\\"},\\"Prepare doc-gen ECS Command\\":{\\"Type\\":\\"Pass\\",\\"ResultPath\\":\\"$.docGen\\",\\"Parameters\\":{\\"command.$\\":\\"States.Array(States.JsonToString($))\\"},\\"Next\\":\\"Generate docs\\"},\\"Generate docs\\":{\\"Next\\":\\"Check whether catalog needs udpating\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"jsii-docgen.NoSpaceLeftOnDevice\\"],\\"MaxAttempts\\":0},{\\"ErrorEquals\\":[\\"ECS.AmazonECSException\\",\\"ECS.InvalidParameterException\\",\\"jsii-docgen.NpmError.E429\\",\\"jsii-codgen.NpmError.EPROTO\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":30,\\"BackoffRate\\":1.1},{\\"ErrorEquals\\":[\\"jsii-docgen.NpmError.ETARGET\\"],\\"IntervalSeconds\\":300,\\"MaxAttempts\\":3,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"MaxAttempts\\":3}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"UnprocessablePackageError\\"],\\"Next\\":\\"Ignore\\"},{\\"ErrorEquals\\":[\\"States.Timeout\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"ECS.AmazonECSException\\",\\"ECS.InvalidParameterException\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Type\\":\\"Task\\",\\"TimeoutSeconds\\":3600,\\"HeartbeatSeconds\\":300,\\"InputPath\\":\\"$.docGen.command\\",\\"ResultPath\\":\\"$.docGenOutput\\",\\"Resource\\":\\"arn:",
+              "{\\"StartAt\\":\\"Track Execution Infos\\",\\"States\\":{\\"Track Execution Infos\\":{\\"Type\\":\\"Pass\\",\\"ResultPath\\":\\"$.$TaskExecution\\",\\"InputPath\\":\\"$$.Execution\\",\\"Parameters\\":{\\"Id.$\\":\\"$.Id\\",\\"Name.$\\":\\"$.Name\\",\\"RoleArn.$\\":\\"$.RoleArn\\",\\"StartTime.$\\":\\"$.StartTime\\"},\\"Next\\":\\"Prepare doc-gen ECS Command\\"},\\"Prepare doc-gen ECS Command\\":{\\"Type\\":\\"Pass\\",\\"ResultPath\\":\\"$.docGen\\",\\"Parameters\\":{\\"command.$\\":\\"States.Array(States.JsonToString($))\\"},\\"Next\\":\\"Generate docs\\"},\\"Generate docs\\":{\\"Next\\":\\"Check whether catalog needs udpating\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"jsii-docgen.NoSpaceLeftOnDevice\\"],\\"MaxAttempts\\":0},{\\"ErrorEquals\\":[\\"ECS.AmazonECSException\\",\\"ECS.InvalidParameterException\\",\\"jsii-docgen.NpmError.E429\\",\\"jsii-codgen.NpmError.EPROTO\\"],\\"IntervalSeconds\\":120,\\"MaxAttempts\\":200,\\"BackoffRate\\":1},{\\"ErrorEquals\\":[\\"jsii-docgen.NpmError.ETARGET\\"],\\"IntervalSeconds\\":300,\\"MaxAttempts\\":3,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"MaxAttempts\\":3}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"UnprocessablePackageError\\"],\\"Next\\":\\"Ignore\\"},{\\"ErrorEquals\\":[\\"States.Timeout\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"ECS.AmazonECSException\\",\\"ECS.InvalidParameterException\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Type\\":\\"Task\\",\\"TimeoutSeconds\\":7200,\\"HeartbeatSeconds\\":300,\\"InputPath\\":\\"$.docGen.command\\",\\"ResultPath\\":\\"$.docGenOutput\\",\\"Resource\\":\\"arn:",
               Object {
                 "Ref": "AWS::Partition",
               },
@@ -16073,7 +16174,7 @@ Direct link to function: /lambda/home#/functions/",
                   "GroupId",
                 ],
               },
-              "\\"]}},\\"Overrides\\":{\\"ContainerOverrides\\":[{\\"Name\\":\\"Resource\\",\\"Command.$\\":\\"$\\",\\"Environment\\":[{\\"Name\\":\\"SFN_TASK_TOKEN\\",\\"Value.$\\":\\"$$.Task.Token\\"}]}]},\\"LaunchType\\":\\"FARGATE\\",\\"PlatformVersion\\":\\"1.4.0\\"}},\\"Check whether catalog needs udpating\\":{\\"Next\\":\\"Is catalog update needed?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"Lambda.ServiceException\\",\\"Lambda.AWSLambdaException\\",\\"Lambda.SdkClientException\\"],\\"IntervalSeconds\\":2,\\"MaxAttempts\\":6,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":30,\\"BackoffRate\\":1.1}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.catalogNeedsUpdating\\",\\"Resource\\":\\"",
+              "\\"]}},\\"Overrides\\":{\\"ContainerOverrides\\":[{\\"Name\\":\\"Resource\\",\\"Command.$\\":\\"$\\",\\"Environment\\":[{\\"Name\\":\\"SFN_TASK_TOKEN\\",\\"Value.$\\":\\"$$.Task.Token\\"}]}]},\\"LaunchType\\":\\"FARGATE\\",\\"PlatformVersion\\":\\"1.4.0\\"}},\\"Check whether catalog needs udpating\\":{\\"Next\\":\\"Is catalog update needed?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"Lambda.ServiceException\\",\\"Lambda.AWSLambdaException\\",\\"Lambda.SdkClientException\\"],\\"IntervalSeconds\\":2,\\"MaxAttempts\\":6,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\",\\"Lambda.Unknown\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":30,\\"BackoffRate\\":1.1}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\",\\"Lambda.Unknown\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.catalogNeedsUpdating\\",\\"Resource\\":\\"",
               Object {
                 "Fn::GetAtt": Array [
                   "ConstructHubOrchestrationNeedsCatalogUpdate5D7370DC",
@@ -16124,7 +16225,7 @@ Direct link to function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3Bucket2D6D8F86",
+            "Ref": "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3Bucket722FE70B",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -16137,7 +16238,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3VersionKey0ECB40A6",
+                          "Ref": "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3VersionKey8082F3BC",
                         },
                       ],
                     },
@@ -16150,7 +16251,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3VersionKey0ECB40A6",
+                          "Ref": "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3VersionKey8082F3BC",
                         },
                       ],
                     },
@@ -16952,7 +17053,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3Bucket19B71C5A",
+            "Ref": "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3BucketE78A0203",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -16965,7 +17066,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3VersionKeyDF73A6F0",
+                          "Ref": "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3VersionKey598098A7",
                         },
                       ],
                     },
@@ -16978,7 +17079,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3VersionKeyDF73A6F0",
+                          "Ref": "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3VersionKey598098A7",
                         },
                       ],
                     },
@@ -17136,7 +17237,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3Bucket1090210F",
+            "Ref": "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3Bucket6F376B71",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -17149,7 +17250,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3VersionKeyD738CD6B",
+                          "Ref": "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3VersionKey7F6E5804",
                         },
                       ],
                     },
@@ -17162,7 +17263,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3VersionKeyD738CD6B",
+                          "Ref": "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3VersionKey7F6E5804",
                         },
                       ],
                     },
@@ -17967,7 +18068,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                   Object {
                     "Ref": "AWS::URLSuffix",
                   },
-                  "/aws-cdk/assets:5fa39a328f34360df81ad2f478b29e7f72b6625d60d6ca775401e69a3b2c0faf",
+                  "/aws-cdk/assets:89c6683e392b08bdb9bfd8e456f82a156b228534eed332191232b4aa0beec4f2",
                 ],
               ],
             },
@@ -18295,7 +18396,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.md",
+                      "/data/*/docs-typescript.*",
                     ],
                   ],
                 },
@@ -18325,7 +18426,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.md",
+                      "/data/*/docs-*-typescript.*",
                     ],
                   ],
                 },
@@ -18355,7 +18456,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.md.not-supported",
+                      "/data/*/docs-typescript.*.not-supported",
                     ],
                   ],
                 },
@@ -18385,7 +18486,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.md.not-supported",
+                      "/data/*/docs-*-typescript.*.not-supported",
                     ],
                   ],
                 },
@@ -18415,7 +18516,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.md.corruptassembly",
+                      "/data/*/docs-typescript.*.corruptassembly",
                     ],
                   ],
                 },
@@ -18445,7 +18546,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.md.corruptassembly",
+                      "/data/*/docs-*-typescript.*.corruptassembly",
                     ],
                   ],
                 },
@@ -18464,7 +18565,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-typescript.md.corruptassembly",
+                    "/data/*/docs-typescript.*.corruptassembly",
                   ],
                 ],
               },
@@ -18482,223 +18583,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-typescript.md.corruptassembly",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.md",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.md",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.md.not-supported",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.md.not-supported",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.md.corruptassembly",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.md.corruptassembly",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": "s3:DeleteObject*",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "ConstructHubPackageDataDC5EF35E",
-                        "Arn",
-                      ],
-                    },
-                    "/data/*/docs-python.md.corruptassembly",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": "s3:DeleteObject*",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "ConstructHubPackageDataDC5EF35E",
-                        "Arn",
-                      ],
-                    },
-                    "/data/*/docs-*-python.md.corruptassembly",
+                    "/data/*/docs-*-typescript.*.corruptassembly",
                   ],
                 ],
               },
@@ -18727,7 +18612,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.md",
+                      "/data/*/docs-python.*",
                     ],
                   ],
                 },
@@ -18757,7 +18642,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.md",
+                      "/data/*/docs-*-python.*",
                     ],
                   ],
                 },
@@ -18787,7 +18672,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.md.not-supported",
+                      "/data/*/docs-python.*.not-supported",
                     ],
                   ],
                 },
@@ -18817,7 +18702,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.md.not-supported",
+                      "/data/*/docs-*-python.*.not-supported",
                     ],
                   ],
                 },
@@ -18847,7 +18732,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.md.corruptassembly",
+                      "/data/*/docs-python.*.corruptassembly",
                     ],
                   ],
                 },
@@ -18877,7 +18762,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.md.corruptassembly",
+                      "/data/*/docs-*-python.*.corruptassembly",
                     ],
                   ],
                 },
@@ -18896,7 +18781,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-java.md.corruptassembly",
+                    "/data/*/docs-python.*.corruptassembly",
                   ],
                 ],
               },
@@ -18914,7 +18799,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-java.md.corruptassembly",
+                    "/data/*/docs-*-python.*.corruptassembly",
                   ],
                 ],
               },
@@ -18943,7 +18828,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.md",
+                      "/data/*/docs-java.*",
                     ],
                   ],
                 },
@@ -18973,7 +18858,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.md",
+                      "/data/*/docs-*-java.*",
                     ],
                   ],
                 },
@@ -19003,7 +18888,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.md.not-supported",
+                      "/data/*/docs-java.*.not-supported",
                     ],
                   ],
                 },
@@ -19033,7 +18918,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.md.not-supported",
+                      "/data/*/docs-*-java.*.not-supported",
                     ],
                   ],
                 },
@@ -19063,7 +18948,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.md.corruptassembly",
+                      "/data/*/docs-java.*.corruptassembly",
                     ],
                   ],
                 },
@@ -19093,7 +18978,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.md.corruptassembly",
+                      "/data/*/docs-*-java.*.corruptassembly",
                     ],
                   ],
                 },
@@ -19112,7 +18997,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-csharp.md.corruptassembly",
+                    "/data/*/docs-java.*.corruptassembly",
                   ],
                 ],
               },
@@ -19130,7 +19015,223 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-csharp.md.corruptassembly",
+                    "/data/*/docs-*-java.*.corruptassembly",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.*.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.*.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.*.corruptassembly",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.*.corruptassembly",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": "s3:DeleteObject*",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "ConstructHubPackageDataDC5EF35E",
+                        "Arn",
+                      ],
+                    },
+                    "/data/*/docs-csharp.*.corruptassembly",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:DeleteObject*",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "ConstructHubPackageDataDC5EF35E",
+                        "Arn",
+                      ],
+                    },
+                    "/data/*/docs-*-csharp.*.corruptassembly",
                   ],
                 ],
               },
@@ -19396,7 +19497,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3Bucket901B95EB",
+            "Ref": "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3Bucket024B3DC6",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -19409,7 +19510,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3VersionKeyC6FBD6BD",
+                          "Ref": "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3VersionKeyEEA56859",
                         },
                       ],
                     },
@@ -19422,7 +19523,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3VersionKeyC6FBD6BD",
+                          "Ref": "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3VersionKeyEEA56859",
                         },
                       ],
                     },
@@ -19479,7 +19580,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3Bucket86DBA113",
+            "Ref": "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3Bucket37F2908E",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -19492,7 +19593,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3VersionKeyF547CFB5",
+                          "Ref": "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3VersionKey2C992F11",
                         },
                       ],
                     },
@@ -19505,7 +19606,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3VersionKeyF547CFB5",
+                          "Ref": "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3VersionKey2C992F11",
                         },
                       ],
                     },
@@ -20068,7 +20169,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3BucketFFA964C8",
+            "Ref": "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3Bucket8AF0E263",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -20081,7 +20182,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3VersionKeyA62CD84A",
+                          "Ref": "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3VersionKey5280D545",
                         },
                       ],
                     },
@@ -20094,7 +20195,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3VersionKeyA62CD84A",
+                          "Ref": "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3VersionKey5280D545",
                         },
                       ],
                     },
@@ -20504,7 +20605,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3BucketE35D2278",
+            "Ref": "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3Bucket789CA701",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -20517,7 +20618,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3VersionKey88FA0AFA",
+                          "Ref": "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3VersionKey0222399F",
                         },
                       ],
                     },
@@ -20530,7 +20631,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3VersionKey88FA0AFA",
+                          "Ref": "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3VersionKey0222399F",
                         },
                       ],
                     },
@@ -20736,7 +20837,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3BucketF9AF3C9C",
+            "Ref": "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3Bucket86412295",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -20749,7 +20850,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3VersionKey09B12EB1",
+                          "Ref": "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3VersionKeyE42DDF01",
                         },
                       ],
                     },
@@ -20762,7 +20863,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3VersionKey09B12EB1",
+                          "Ref": "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3VersionKeyE42DDF01",
                         },
                       ],
                     },
@@ -21178,7 +21279,10 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1",
+            "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3BucketED9FB7B0",
+          },
+          Object {
+            "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
           },
         ],
         "SourceObjectKeys": Array [
@@ -21193,7 +21297,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3VersionKeyBA1CB663",
+                          "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3VersionKeyCFEDA3D4",
                         },
                       ],
                     },
@@ -21206,7 +21310,40 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3VersionKeyBA1CB663",
+                          "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3VersionKeyCFEDA3D4",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            ],
+          },
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                Object {
+                  "Fn::Select": Array [
+                    0,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                Object {
+                  "Fn::Select": Array [
+                    1,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49",
                         },
                       ],
                     },
@@ -21241,7 +21378,7 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22",
+            "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2",
           },
         ],
         "SourceObjectKeys": Array [
@@ -21256,7 +21393,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3VersionKeyCE5C5D3B",
+                          "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3VersionKeyEC7E3301",
                         },
                       ],
                     },
@@ -21269,7 +21406,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3VersionKeyCE5C5D3B",
+                          "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3VersionKeyEC7E3301",
                         },
                       ],
                     },
@@ -21950,7 +22087,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22",
+                        "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2",
                       },
                     ],
                   ],
@@ -21965,7 +22102,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22",
+                        "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2",
                       },
                       "/*",
                     ],
@@ -22032,7 +22169,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1",
+                        "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3BucketED9FB7B0",
                       },
                     ],
                   ],
@@ -22047,7 +22184,48 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1",
+                        "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3BucketED9FB7B0",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
+                      },
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
                       },
                       "/*",
                     ],
@@ -22275,7 +22453,7 @@ function handler(event) {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3Bucket1B95B117",
+            "Ref": "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3BucketCBEF8050",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -22288,7 +22466,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3VersionKey75D92238",
+                          "Ref": "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3VersionKey57968381",
                         },
                       ],
                     },
@@ -22301,7 +22479,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3VersionKey75D92238",
+                          "Ref": "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3VersionKey57968381",
                         },
                       ],
                     },
@@ -22807,28 +22985,40 @@ Object {
     },
   },
   "Parameters": Object {
-    "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeArtifactHash322D47B8": Object {
-      "Description": "Artifact hash for asset \\"0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9ae\\"",
+    "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6ArtifactHashF2EEEBFF": Object {
+      "Description": "Artifact hash for asset \\"04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6\\"",
       "Type": "String",
     },
-    "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3Bucket635A0AFA": Object {
-      "Description": "S3 bucket for asset \\"0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9ae\\"",
+    "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3Bucket86412295": Object {
+      "Description": "S3 bucket for asset \\"04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6\\"",
       "Type": "String",
     },
-    "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3VersionKeyBB104177": Object {
-      "Description": "S3 key for asset version \\"0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9ae\\"",
+    "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3VersionKeyE42DDF01": Object {
+      "Description": "S3 key for asset version \\"04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6\\"",
       "Type": "String",
     },
-    "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadArtifactHash3158CABD": Object {
-      "Description": "Artifact hash for asset \\"0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362ead\\"",
+    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440ArtifactHash87A9FF22": Object {
+      "Description": "Artifact hash for asset \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
       "Type": "String",
     },
-    "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3Bucket288D5551": Object {
-      "Description": "S3 bucket for asset \\"0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362ead\\"",
+    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054": Object {
+      "Description": "S3 bucket for asset \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
       "Type": "String",
     },
-    "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3VersionKey4638DF79": Object {
-      "Description": "S3 key for asset version \\"0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362ead\\"",
+    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49": Object {
+      "Description": "S3 key for asset version \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
+      "Type": "String",
+    },
+    "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aArtifactHash82449A4A": Object {
+      "Description": "Artifact hash for asset \\"0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4a\\"",
+      "Type": "String",
+    },
+    "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3Bucket789CA701": Object {
+      "Description": "S3 bucket for asset \\"0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4a\\"",
+      "Type": "String",
+    },
+    "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3VersionKey0222399F": Object {
+      "Description": "S3 key for asset version \\"0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4a\\"",
       "Type": "String",
     },
     "AssetParameters0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9ArtifactHashB9E3BF29": Object {
@@ -22843,42 +23033,6 @@ Object {
       "Description": "S3 key for asset version \\"0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9\\"",
       "Type": "String",
     },
-    "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67ArtifactHashCF96E147": Object {
-      "Description": "Artifact hash for asset \\"1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67\\"",
-      "Type": "String",
-    },
-    "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3BucketFFA964C8": Object {
-      "Description": "S3 bucket for asset \\"1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67\\"",
-      "Type": "String",
-    },
-    "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3VersionKeyA62CD84A": Object {
-      "Description": "S3 key for asset version \\"1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67\\"",
-      "Type": "String",
-    },
-    "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3ArtifactHashA3981DF8": Object {
-      "Description": "Artifact hash for asset \\"1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3\\"",
-      "Type": "String",
-    },
-    "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1": Object {
-      "Description": "S3 bucket for asset \\"1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3\\"",
-      "Type": "String",
-    },
-    "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3VersionKeyBA1CB663": Object {
-      "Description": "S3 key for asset version \\"1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3\\"",
-      "Type": "String",
-    },
-    "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeArtifactHashD1A9CF6A": Object {
-      "Description": "Artifact hash for asset \\"1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33ae\\"",
-      "Type": "String",
-    },
-    "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3Bucket901B95EB": Object {
-      "Description": "S3 bucket for asset \\"1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33ae\\"",
-      "Type": "String",
-    },
-    "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3VersionKeyC6FBD6BD": Object {
-      "Description": "S3 key for asset version \\"1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33ae\\"",
-      "Type": "String",
-    },
     "AssetParameters1f7e277bd526ebce1983fa1e7a84a5281ec533d9187caaebb773681bbf7bf4c1ArtifactHash0128B949": Object {
       "Description": "Artifact hash for asset \\"1f7e277bd526ebce1983fa1e7a84a5281ec533d9187caaebb773681bbf7bf4c1\\"",
       "Type": "String",
@@ -22891,112 +23045,88 @@ Object {
       "Description": "S3 key for asset version \\"1f7e277bd526ebce1983fa1e7a84a5281ec533d9187caaebb773681bbf7bf4c1\\"",
       "Type": "String",
     },
-    "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cArtifactHash8D005B5F": Object {
-      "Description": "Artifact hash for asset \\"205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612c\\"",
+    "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5ArtifactHash0AFE0939": Object {
+      "Description": "Artifact hash for asset \\"37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5\\"",
       "Type": "String",
     },
-    "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3Bucket95F679AA": Object {
-      "Description": "S3 bucket for asset \\"205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612c\\"",
+    "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3Bucket722FE70B": Object {
+      "Description": "S3 bucket for asset \\"37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5\\"",
       "Type": "String",
     },
-    "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3VersionKeyE7A4EEDD": Object {
-      "Description": "S3 key for asset version \\"205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612c\\"",
+    "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3VersionKey8082F3BC": Object {
+      "Description": "S3 key for asset version \\"37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5\\"",
       "Type": "String",
     },
-    "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534ArtifactHash89381734": Object {
-      "Description": "Artifact hash for asset \\"25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534\\"",
+    "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5ArtifactHash499F6DFF": Object {
+      "Description": "Artifact hash for asset \\"3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5\\"",
       "Type": "String",
     },
-    "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3Bucket8AFE0D2F": Object {
-      "Description": "S3 bucket for asset \\"25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534\\"",
+    "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3Bucket37F2908E": Object {
+      "Description": "S3 bucket for asset \\"3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5\\"",
       "Type": "String",
     },
-    "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3VersionKey39383E8E": Object {
-      "Description": "S3 key for asset version \\"25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534\\"",
+    "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3VersionKey2C992F11": Object {
+      "Description": "S3 key for asset version \\"3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5\\"",
       "Type": "String",
     },
-    "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bArtifactHash270470CC": Object {
-      "Description": "Artifact hash for asset \\"3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934b\\"",
+    "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dArtifactHash3B82A2B3": Object {
+      "Description": "Artifact hash for asset \\"3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880d\\"",
       "Type": "String",
     },
-    "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3Bucket2D6D8F86": Object {
-      "Description": "S3 bucket for asset \\"3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934b\\"",
+    "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3BucketCBEF8050": Object {
+      "Description": "S3 bucket for asset \\"3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880d\\"",
       "Type": "String",
     },
-    "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3VersionKey0ECB40A6": Object {
-      "Description": "S3 key for asset version \\"3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934b\\"",
+    "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3VersionKey57968381": Object {
+      "Description": "S3 key for asset version \\"3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880d\\"",
       "Type": "String",
     },
-    "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0ArtifactHash6F14CF3C": Object {
-      "Description": "Artifact hash for asset \\"55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0\\"",
+    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afArtifactHash7F8A76FC": Object {
+      "Description": "Artifact hash for asset \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
       "Type": "String",
     },
-    "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3BucketE35D2278": Object {
-      "Description": "S3 bucket for asset \\"55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0\\"",
+    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3Bucket5515214C": Object {
+      "Description": "S3 bucket for asset \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
       "Type": "String",
     },
-    "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3VersionKey88FA0AFA": Object {
-      "Description": "S3 key for asset version \\"55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0\\"",
+    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED": Object {
+      "Description": "S3 key for asset version \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
       "Type": "String",
     },
-    "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420ArtifactHashC847AA8D": Object {
-      "Description": "Artifact hash for asset \\"6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420\\"",
+    "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bArtifactHash5ABBFB9B": Object {
+      "Description": "Artifact hash for asset \\"42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2b\\"",
       "Type": "String",
     },
-    "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3Bucket649728C0": Object {
-      "Description": "S3 bucket for asset \\"6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420\\"",
+    "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3Bucket8AF0E263": Object {
+      "Description": "S3 bucket for asset \\"42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2b\\"",
       "Type": "String",
     },
-    "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3VersionKey592D485B": Object {
-      "Description": "S3 key for asset version \\"6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420\\"",
+    "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3VersionKey5280D545": Object {
+      "Description": "S3 key for asset version \\"42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2b\\"",
       "Type": "String",
     },
-    "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cArtifactHashD2B94368": Object {
-      "Description": "Artifact hash for asset \\"73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06c\\"",
+    "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeArtifactHash3FAC57D3": Object {
+      "Description": "Artifact hash for asset \\"4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeee\\"",
       "Type": "String",
     },
-    "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3Bucket19B71C5A": Object {
-      "Description": "S3 bucket for asset \\"73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06c\\"",
+    "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3Bucket6F376B71": Object {
+      "Description": "S3 bucket for asset \\"4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeee\\"",
       "Type": "String",
     },
-    "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3VersionKeyDF73A6F0": Object {
-      "Description": "S3 key for asset version \\"73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06c\\"",
+    "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3VersionKey7F6E5804": Object {
+      "Description": "S3 key for asset version \\"4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeee\\"",
       "Type": "String",
     },
-    "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fArtifactHash2005F882": Object {
-      "Description": "Artifact hash for asset \\"778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6f\\"",
+    "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680ArtifactHash316B2926": Object {
+      "Description": "Artifact hash for asset \\"864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680\\"",
       "Type": "String",
     },
-    "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22": Object {
-      "Description": "S3 bucket for asset \\"778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6f\\"",
+    "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3BucketF13820EA": Object {
+      "Description": "S3 bucket for asset \\"864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680\\"",
       "Type": "String",
     },
-    "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3VersionKeyCE5C5D3B": Object {
-      "Description": "S3 key for asset version \\"778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6f\\"",
-      "Type": "String",
-    },
-    "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0ArtifactHashF4B56B1E": Object {
-      "Description": "Artifact hash for asset \\"782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0\\"",
-      "Type": "String",
-    },
-    "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3Bucket1090210F": Object {
-      "Description": "S3 bucket for asset \\"782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0\\"",
-      "Type": "String",
-    },
-    "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3VersionKeyD738CD6B": Object {
-      "Description": "S3 key for asset version \\"782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0\\"",
-      "Type": "String",
-    },
-    "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965ArtifactHashD4D3C5A6": Object {
-      "Description": "Artifact hash for asset \\"7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965\\"",
-      "Type": "String",
-    },
-    "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3Bucket0A90D6D3": Object {
-      "Description": "S3 bucket for asset \\"7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965\\"",
-      "Type": "String",
-    },
-    "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3VersionKeyA116EF05": Object {
-      "Description": "S3 key for asset version \\"7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965\\"",
+    "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3VersionKey52B24F16": Object {
+      "Description": "S3 key for asset version \\"864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680\\"",
       "Type": "String",
     },
     "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900ArtifactHash121EF458": Object {
@@ -23011,6 +23141,18 @@ Object {
       "Description": "S3 key for asset version \\"8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900\\"",
       "Type": "String",
     },
+    "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9ArtifactHash694505BF": Object {
+      "Description": "Artifact hash for asset \\"8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9\\"",
+      "Type": "String",
+    },
+    "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3BucketED9FB7B0": Object {
+      "Description": "S3 bucket for asset \\"8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9\\"",
+      "Type": "String",
+    },
+    "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3VersionKeyCFEDA3D4": Object {
+      "Description": "S3 key for asset version \\"8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9\\"",
+      "Type": "String",
+    },
     "AssetParameters8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064ArtifactHashEA963870": Object {
       "Description": "Artifact hash for asset \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
@@ -23023,16 +23165,16 @@ Object {
       "Description": "S3 key for asset version \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
     },
-    "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8ArtifactHash8DC0C383": Object {
-      "Description": "Artifact hash for asset \\"9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8\\"",
+    "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4ArtifactHash660A50B8": Object {
+      "Description": "Artifact hash for asset \\"98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4\\"",
       "Type": "String",
     },
-    "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3Bucket1B95B117": Object {
-      "Description": "S3 bucket for asset \\"9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8\\"",
+    "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3BucketE78A0203": Object {
+      "Description": "S3 bucket for asset \\"98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4\\"",
       "Type": "String",
     },
-    "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3VersionKey75D92238": Object {
-      "Description": "S3 key for asset version \\"9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8\\"",
+    "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3VersionKey598098A7": Object {
+      "Description": "S3 key for asset version \\"98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4\\"",
       "Type": "String",
     },
     "AssetParametersa3058ccb468d757ebb89df5363a1c20f5307c6911136f29d00e1a68c9b2aa7e8ArtifactHash238275D6": Object {
@@ -23047,16 +23189,16 @@ Object {
       "Description": "S3 key for asset version \\"a3058ccb468d757ebb89df5363a1c20f5307c6911136f29d00e1a68c9b2aa7e8\\"",
       "Type": "String",
     },
-    "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdArtifactHash22ECD1BE": Object {
-      "Description": "Artifact hash for asset \\"adb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbd\\"",
+    "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaArtifactHash8CCAA809": Object {
+      "Description": "Artifact hash for asset \\"af643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfba\\"",
       "Type": "String",
     },
-    "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3BucketF9AF3C9C": Object {
-      "Description": "S3 bucket for asset \\"adb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbd\\"",
+    "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2": Object {
+      "Description": "S3 bucket for asset \\"af643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfba\\"",
       "Type": "String",
     },
-    "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3VersionKey09B12EB1": Object {
-      "Description": "S3 key for asset version \\"adb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbd\\"",
+    "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3VersionKeyEC7E3301": Object {
+      "Description": "S3 key for asset version \\"af643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfba\\"",
       "Type": "String",
     },
     "AssetParametersb120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827ArtifactHash1355580A": Object {
@@ -23071,16 +23213,40 @@ Object {
       "Description": "S3 key for asset version \\"b120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827\\"",
       "Type": "String",
     },
-    "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8ArtifactHashBB72DCC8": Object {
-      "Description": "Artifact hash for asset \\"c8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8\\"",
+    "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04ArtifactHash394183E9": Object {
+      "Description": "Artifact hash for asset \\"b55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04\\"",
       "Type": "String",
     },
-    "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3Bucket86DBA113": Object {
-      "Description": "S3 bucket for asset \\"c8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8\\"",
+    "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3BucketE7A02ACD": Object {
+      "Description": "S3 bucket for asset \\"b55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04\\"",
       "Type": "String",
     },
-    "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3VersionKeyF547CFB5": Object {
-      "Description": "S3 key for asset version \\"c8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8\\"",
+    "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3VersionKeyCC994D9E": Object {
+      "Description": "S3 key for asset version \\"b55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04\\"",
+      "Type": "String",
+    },
+    "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcArtifactHash4E26EEC4": Object {
+      "Description": "Artifact hash for asset \\"c62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafc\\"",
+      "Type": "String",
+    },
+    "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3Bucket5255533F": Object {
+      "Description": "S3 bucket for asset \\"c62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafc\\"",
+      "Type": "String",
+    },
+    "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3VersionKey7909F675": Object {
+      "Description": "S3 key for asset version \\"c62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafc\\"",
+      "Type": "String",
+    },
+    "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aArtifactHash0386B8EC": Object {
+      "Description": "Artifact hash for asset \\"da314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17a\\"",
+      "Type": "String",
+    },
+    "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3BucketAE80D773": Object {
+      "Description": "S3 bucket for asset \\"da314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17a\\"",
+      "Type": "String",
+    },
+    "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3VersionKey662F0E6F": Object {
+      "Description": "S3 key for asset version \\"da314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17a\\"",
       "Type": "String",
     },
     "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68ArtifactHashD9A515C3": Object {
@@ -23093,6 +23259,30 @@ Object {
     },
     "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3VersionKeyE415415F": Object {
       "Description": "S3 key for asset version \\"e9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68\\"",
+      "Type": "String",
+    },
+    "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3ArtifactHash11DB5971": Object {
+      "Description": "Artifact hash for asset \\"f48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3\\"",
+      "Type": "String",
+    },
+    "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3BucketAC5DE359": Object {
+      "Description": "S3 bucket for asset \\"f48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3\\"",
+      "Type": "String",
+    },
+    "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3VersionKey503D22DC": Object {
+      "Description": "S3 key for asset version \\"f48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3\\"",
+      "Type": "String",
+    },
+    "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5ArtifactHash185A4671": Object {
+      "Description": "Artifact hash for asset \\"fbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5\\"",
+      "Type": "String",
+    },
+    "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3Bucket024B3DC6": Object {
+      "Description": "S3 bucket for asset \\"fbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5\\"",
+      "Type": "String",
+    },
+    "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3VersionKeyEEA56859": Object {
+      "Description": "S3 key for asset version \\"fbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5\\"",
       "Type": "String",
     },
   },
@@ -24341,7 +24531,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3Bucket288D5551",
+            "Ref": "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3BucketAE80D773",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -24354,7 +24544,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3VersionKey4638DF79",
+                          "Ref": "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3VersionKey662F0E6F",
                         },
                       ],
                     },
@@ -24367,7 +24557,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3VersionKey4638DF79",
+                          "Ref": "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3VersionKey662F0E6F",
                         },
                       ],
                     },
@@ -24550,7 +24740,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3Bucket95F679AA",
+            "Ref": "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3BucketAC5DE359",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -24563,7 +24753,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3VersionKeyE7A4EEDD",
+                          "Ref": "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3VersionKey503D22DC",
                         },
                       ],
                     },
@@ -24576,7 +24766,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3VersionKeyE7A4EEDD",
+                          "Ref": "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3VersionKey503D22DC",
                         },
                       ],
                     },
@@ -24816,7 +25006,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3Bucket8AFE0D2F",
+            "Ref": "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3BucketF13820EA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -24829,7 +25019,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3VersionKey39383E8E",
+                          "Ref": "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3VersionKey52B24F16",
                         },
                       ],
                     },
@@ -24842,7 +25032,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3VersionKey39383E8E",
+                          "Ref": "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3VersionKey52B24F16",
                         },
                       ],
                     },
@@ -25329,7 +25519,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3Bucket0A90D6D3",
+            "Ref": "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3Bucket5255533F",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -25342,7 +25532,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3VersionKeyA116EF05",
+                          "Ref": "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3VersionKey7909F675",
                         },
                       ],
                     },
@@ -25355,7 +25545,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3VersionKeyA116EF05",
+                          "Ref": "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3VersionKey7909F675",
                         },
                       ],
                     },
@@ -25539,7 +25729,7 @@ Direct link to the function: /lambda/home#/functions/",
               Object {
                 "Ref": "ConstructHubPackageDataDC5EF35E",
               },
-              "\\",\\"Prefix\\":\\"data/\\"}},\\"Is there more?\\":{\\"Type\\":\\"Choice\\",\\"Choices\\":[{\\"Variable\\":\\"$.response.NextContinuationToken\\",\\"IsPresent\\":true,\\"Next\\":\\"Continue as new\\"}],\\"Default\\":\\"Process Result\\"},\\"S3.ListObjectsV2(NextPage)\\":{\\"Next\\":\\"Is there more?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"S3.SdkClientException\\"]}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.response\\",\\"Resource\\":\\"arn:",
+              "\\",\\"Prefix\\":\\"data/\\"}},\\"Is there more?\\":{\\"Type\\":\\"Choice\\",\\"Choices\\":[{\\"Variable\\":\\"$.response.NextContinuationToken\\",\\"IsPresent\\":true,\\"Next\\":\\"Give room for on-demand work\\"}],\\"Default\\":\\"Process Result\\"},\\"S3.ListObjectsV2(NextPage)\\":{\\"Next\\":\\"Is there more?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"S3.SdkClientException\\"]}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.response\\",\\"Resource\\":\\"arn:",
               Object {
                 "Ref": "AWS::Partition",
               },
@@ -25574,7 +25764,7 @@ Direct link to the function: /lambda/home#/functions/",
               Object {
                 "Ref": "AWS::AccountId",
               },
-              ":stateMachine:Test.ConstructHub.Ingestion.ReprocessWorkflow\\"}}},\\"TimeoutSeconds\\":3600}",
+              ":stateMachine:Test.ConstructHub.Ingestion.ReprocessWorkflow\\"}},\\"Give room for on-demand work\\":{\\"Type\\":\\"Wait\\",\\"Seconds\\":300,\\"Next\\":\\"Continue as new\\"}},\\"TimeoutSeconds\\":3600}",
             ],
           ],
         },
@@ -26004,7 +26194,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3Bucket649728C0",
+            "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3Bucket5515214C",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -26017,7 +26207,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3VersionKey592D485B",
+                          "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED",
                         },
                       ],
                     },
@@ -26030,7 +26220,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3VersionKey592D485B",
+                          "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED",
                         },
                       ],
                     },
@@ -27059,7 +27249,7 @@ Direct link to function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3Bucket635A0AFA",
+            "Ref": "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3BucketE7A02ACD",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -27072,7 +27262,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3VersionKeyBB104177",
+                          "Ref": "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3VersionKeyCC994D9E",
                         },
                       ],
                     },
@@ -27085,7 +27275,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3VersionKeyBB104177",
+                          "Ref": "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3VersionKeyCC994D9E",
                         },
                       ],
                     },
@@ -27217,7 +27407,7 @@ Direct link to function: /lambda/home#/functions/",
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"StartAt\\":\\"Track Execution Infos\\",\\"States\\":{\\"Track Execution Infos\\":{\\"Type\\":\\"Pass\\",\\"ResultPath\\":\\"$.$TaskExecution\\",\\"InputPath\\":\\"$$.Execution\\",\\"Parameters\\":{\\"Id.$\\":\\"$.Id\\",\\"Name.$\\":\\"$.Name\\",\\"RoleArn.$\\":\\"$.RoleArn\\",\\"StartTime.$\\":\\"$.StartTime\\"},\\"Next\\":\\"Prepare doc-gen ECS Command\\"},\\"Prepare doc-gen ECS Command\\":{\\"Type\\":\\"Pass\\",\\"ResultPath\\":\\"$.docGen\\",\\"Parameters\\":{\\"command.$\\":\\"States.Array(States.JsonToString($))\\"},\\"Next\\":\\"Generate docs\\"},\\"Generate docs\\":{\\"Next\\":\\"Check whether catalog needs udpating\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"jsii-docgen.NoSpaceLeftOnDevice\\"],\\"MaxAttempts\\":0},{\\"ErrorEquals\\":[\\"ECS.AmazonECSException\\",\\"ECS.InvalidParameterException\\",\\"jsii-docgen.NpmError.E429\\",\\"jsii-codgen.NpmError.EPROTO\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":30,\\"BackoffRate\\":1.1},{\\"ErrorEquals\\":[\\"jsii-docgen.NpmError.ETARGET\\"],\\"IntervalSeconds\\":300,\\"MaxAttempts\\":3,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"MaxAttempts\\":3}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"UnprocessablePackageError\\"],\\"Next\\":\\"Ignore\\"},{\\"ErrorEquals\\":[\\"States.Timeout\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"ECS.AmazonECSException\\",\\"ECS.InvalidParameterException\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Type\\":\\"Task\\",\\"TimeoutSeconds\\":3600,\\"HeartbeatSeconds\\":300,\\"InputPath\\":\\"$.docGen.command\\",\\"ResultPath\\":\\"$.docGenOutput\\",\\"Resource\\":\\"arn:",
+              "{\\"StartAt\\":\\"Track Execution Infos\\",\\"States\\":{\\"Track Execution Infos\\":{\\"Type\\":\\"Pass\\",\\"ResultPath\\":\\"$.$TaskExecution\\",\\"InputPath\\":\\"$$.Execution\\",\\"Parameters\\":{\\"Id.$\\":\\"$.Id\\",\\"Name.$\\":\\"$.Name\\",\\"RoleArn.$\\":\\"$.RoleArn\\",\\"StartTime.$\\":\\"$.StartTime\\"},\\"Next\\":\\"Prepare doc-gen ECS Command\\"},\\"Prepare doc-gen ECS Command\\":{\\"Type\\":\\"Pass\\",\\"ResultPath\\":\\"$.docGen\\",\\"Parameters\\":{\\"command.$\\":\\"States.Array(States.JsonToString($))\\"},\\"Next\\":\\"Generate docs\\"},\\"Generate docs\\":{\\"Next\\":\\"Check whether catalog needs udpating\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"jsii-docgen.NoSpaceLeftOnDevice\\"],\\"MaxAttempts\\":0},{\\"ErrorEquals\\":[\\"ECS.AmazonECSException\\",\\"ECS.InvalidParameterException\\",\\"jsii-docgen.NpmError.E429\\",\\"jsii-codgen.NpmError.EPROTO\\"],\\"IntervalSeconds\\":120,\\"MaxAttempts\\":200,\\"BackoffRate\\":1},{\\"ErrorEquals\\":[\\"jsii-docgen.NpmError.ETARGET\\"],\\"IntervalSeconds\\":300,\\"MaxAttempts\\":3,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"MaxAttempts\\":3}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"UnprocessablePackageError\\"],\\"Next\\":\\"Ignore\\"},{\\"ErrorEquals\\":[\\"States.Timeout\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"ECS.AmazonECSException\\",\\"ECS.InvalidParameterException\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Type\\":\\"Task\\",\\"TimeoutSeconds\\":7200,\\"HeartbeatSeconds\\":300,\\"InputPath\\":\\"$.docGen.command\\",\\"ResultPath\\":\\"$.docGenOutput\\",\\"Resource\\":\\"arn:",
               Object {
                 "Ref": "AWS::Partition",
               },
@@ -27243,7 +27433,7 @@ Direct link to function: /lambda/home#/functions/",
                   "GroupId",
                 ],
               },
-              "\\"]}},\\"Overrides\\":{\\"ContainerOverrides\\":[{\\"Name\\":\\"Resource\\",\\"Command.$\\":\\"$\\",\\"Environment\\":[{\\"Name\\":\\"SFN_TASK_TOKEN\\",\\"Value.$\\":\\"$$.Task.Token\\"}]}]},\\"LaunchType\\":\\"FARGATE\\",\\"PlatformVersion\\":\\"1.4.0\\"}},\\"Check whether catalog needs udpating\\":{\\"Next\\":\\"Is catalog update needed?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"Lambda.ServiceException\\",\\"Lambda.AWSLambdaException\\",\\"Lambda.SdkClientException\\"],\\"IntervalSeconds\\":2,\\"MaxAttempts\\":6,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":30,\\"BackoffRate\\":1.1}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.catalogNeedsUpdating\\",\\"Resource\\":\\"",
+              "\\"]}},\\"Overrides\\":{\\"ContainerOverrides\\":[{\\"Name\\":\\"Resource\\",\\"Command.$\\":\\"$\\",\\"Environment\\":[{\\"Name\\":\\"SFN_TASK_TOKEN\\",\\"Value.$\\":\\"$$.Task.Token\\"}]}]},\\"LaunchType\\":\\"FARGATE\\",\\"PlatformVersion\\":\\"1.4.0\\"}},\\"Check whether catalog needs udpating\\":{\\"Next\\":\\"Is catalog update needed?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"Lambda.ServiceException\\",\\"Lambda.AWSLambdaException\\",\\"Lambda.SdkClientException\\"],\\"IntervalSeconds\\":2,\\"MaxAttempts\\":6,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\",\\"Lambda.Unknown\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":30,\\"BackoffRate\\":1.1}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\",\\"Lambda.Unknown\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.catalogNeedsUpdating\\",\\"Resource\\":\\"",
               Object {
                 "Fn::GetAtt": Array [
                   "ConstructHubOrchestrationNeedsCatalogUpdate5D7370DC",
@@ -27294,7 +27484,7 @@ Direct link to function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3Bucket2D6D8F86",
+            "Ref": "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3Bucket722FE70B",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -27307,7 +27497,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3VersionKey0ECB40A6",
+                          "Ref": "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3VersionKey8082F3BC",
                         },
                       ],
                     },
@@ -27320,7 +27510,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3VersionKey0ECB40A6",
+                          "Ref": "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3VersionKey8082F3BC",
                         },
                       ],
                     },
@@ -28122,7 +28312,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3Bucket19B71C5A",
+            "Ref": "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3BucketE78A0203",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -28135,7 +28325,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3VersionKeyDF73A6F0",
+                          "Ref": "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3VersionKey598098A7",
                         },
                       ],
                     },
@@ -28148,7 +28338,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3VersionKeyDF73A6F0",
+                          "Ref": "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3VersionKey598098A7",
                         },
                       ],
                     },
@@ -28306,7 +28496,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3Bucket1090210F",
+            "Ref": "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3Bucket6F376B71",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -28319,7 +28509,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3VersionKeyD738CD6B",
+                          "Ref": "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3VersionKey7F6E5804",
                         },
                       ],
                     },
@@ -28332,7 +28522,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3VersionKeyD738CD6B",
+                          "Ref": "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3VersionKey7F6E5804",
                         },
                       ],
                     },
@@ -29110,7 +29300,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                   Object {
                     "Ref": "AWS::URLSuffix",
                   },
-                  "/aws-cdk/assets:5fa39a328f34360df81ad2f478b29e7f72b6625d60d6ca775401e69a3b2c0faf",
+                  "/aws-cdk/assets:89c6683e392b08bdb9bfd8e456f82a156b228534eed332191232b4aa0beec4f2",
                 ],
               ],
             },
@@ -29392,7 +29582,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.md",
+                      "/data/*/docs-typescript.*",
                     ],
                   ],
                 },
@@ -29422,7 +29612,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.md",
+                      "/data/*/docs-*-typescript.*",
                     ],
                   ],
                 },
@@ -29452,7 +29642,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.md.not-supported",
+                      "/data/*/docs-typescript.*.not-supported",
                     ],
                   ],
                 },
@@ -29482,7 +29672,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.md.not-supported",
+                      "/data/*/docs-*-typescript.*.not-supported",
                     ],
                   ],
                 },
@@ -29512,7 +29702,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.md.corruptassembly",
+                      "/data/*/docs-typescript.*.corruptassembly",
                     ],
                   ],
                 },
@@ -29542,7 +29732,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.md.corruptassembly",
+                      "/data/*/docs-*-typescript.*.corruptassembly",
                     ],
                   ],
                 },
@@ -29561,7 +29751,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-typescript.md.corruptassembly",
+                    "/data/*/docs-typescript.*.corruptassembly",
                   ],
                 ],
               },
@@ -29579,223 +29769,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-typescript.md.corruptassembly",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.md",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.md",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.md.not-supported",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.md.not-supported",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.md.corruptassembly",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.md.corruptassembly",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": "s3:DeleteObject*",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "ConstructHubPackageDataDC5EF35E",
-                        "Arn",
-                      ],
-                    },
-                    "/data/*/docs-python.md.corruptassembly",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": "s3:DeleteObject*",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "ConstructHubPackageDataDC5EF35E",
-                        "Arn",
-                      ],
-                    },
-                    "/data/*/docs-*-python.md.corruptassembly",
+                    "/data/*/docs-*-typescript.*.corruptassembly",
                   ],
                 ],
               },
@@ -29824,7 +29798,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.md",
+                      "/data/*/docs-python.*",
                     ],
                   ],
                 },
@@ -29854,7 +29828,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.md",
+                      "/data/*/docs-*-python.*",
                     ],
                   ],
                 },
@@ -29884,7 +29858,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.md.not-supported",
+                      "/data/*/docs-python.*.not-supported",
                     ],
                   ],
                 },
@@ -29914,7 +29888,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.md.not-supported",
+                      "/data/*/docs-*-python.*.not-supported",
                     ],
                   ],
                 },
@@ -29944,7 +29918,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.md.corruptassembly",
+                      "/data/*/docs-python.*.corruptassembly",
                     ],
                   ],
                 },
@@ -29974,7 +29948,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.md.corruptassembly",
+                      "/data/*/docs-*-python.*.corruptassembly",
                     ],
                   ],
                 },
@@ -29993,7 +29967,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-java.md.corruptassembly",
+                    "/data/*/docs-python.*.corruptassembly",
                   ],
                 ],
               },
@@ -30011,7 +29985,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-java.md.corruptassembly",
+                    "/data/*/docs-*-python.*.corruptassembly",
                   ],
                 ],
               },
@@ -30040,7 +30014,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.md",
+                      "/data/*/docs-java.*",
                     ],
                   ],
                 },
@@ -30070,7 +30044,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.md",
+                      "/data/*/docs-*-java.*",
                     ],
                   ],
                 },
@@ -30100,7 +30074,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.md.not-supported",
+                      "/data/*/docs-java.*.not-supported",
                     ],
                   ],
                 },
@@ -30130,7 +30104,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.md.not-supported",
+                      "/data/*/docs-*-java.*.not-supported",
                     ],
                   ],
                 },
@@ -30160,7 +30134,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.md.corruptassembly",
+                      "/data/*/docs-java.*.corruptassembly",
                     ],
                   ],
                 },
@@ -30190,7 +30164,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.md.corruptassembly",
+                      "/data/*/docs-*-java.*.corruptassembly",
                     ],
                   ],
                 },
@@ -30209,7 +30183,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-csharp.md.corruptassembly",
+                    "/data/*/docs-java.*.corruptassembly",
                   ],
                 ],
               },
@@ -30227,7 +30201,223 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-csharp.md.corruptassembly",
+                    "/data/*/docs-*-java.*.corruptassembly",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.*.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.*.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.*.corruptassembly",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.*.corruptassembly",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": "s3:DeleteObject*",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "ConstructHubPackageDataDC5EF35E",
+                        "Arn",
+                      ],
+                    },
+                    "/data/*/docs-csharp.*.corruptassembly",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:DeleteObject*",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "ConstructHubPackageDataDC5EF35E",
+                        "Arn",
+                      ],
+                    },
+                    "/data/*/docs-*-csharp.*.corruptassembly",
                   ],
                 ],
               },
@@ -30493,7 +30683,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3Bucket901B95EB",
+            "Ref": "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3Bucket024B3DC6",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -30506,7 +30696,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3VersionKeyC6FBD6BD",
+                          "Ref": "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3VersionKeyEEA56859",
                         },
                       ],
                     },
@@ -30519,7 +30709,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3VersionKeyC6FBD6BD",
+                          "Ref": "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3VersionKeyEEA56859",
                         },
                       ],
                     },
@@ -30576,7 +30766,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3Bucket86DBA113",
+            "Ref": "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3Bucket37F2908E",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -30589,7 +30779,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3VersionKeyF547CFB5",
+                          "Ref": "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3VersionKey2C992F11",
                         },
                       ],
                     },
@@ -30602,7 +30792,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3VersionKeyF547CFB5",
+                          "Ref": "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3VersionKey2C992F11",
                         },
                       ],
                     },
@@ -31165,7 +31355,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3BucketFFA964C8",
+            "Ref": "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3Bucket8AF0E263",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -31178,7 +31368,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3VersionKeyA62CD84A",
+                          "Ref": "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3VersionKey5280D545",
                         },
                       ],
                     },
@@ -31191,7 +31381,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3VersionKeyA62CD84A",
+                          "Ref": "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3VersionKey5280D545",
                         },
                       ],
                     },
@@ -31601,7 +31791,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3BucketE35D2278",
+            "Ref": "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3Bucket789CA701",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -31614,7 +31804,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3VersionKey88FA0AFA",
+                          "Ref": "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3VersionKey0222399F",
                         },
                       ],
                     },
@@ -31627,7 +31817,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3VersionKey88FA0AFA",
+                          "Ref": "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3VersionKey0222399F",
                         },
                       ],
                     },
@@ -31833,7 +32023,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3BucketF9AF3C9C",
+            "Ref": "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3Bucket86412295",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -31846,7 +32036,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3VersionKey09B12EB1",
+                          "Ref": "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3VersionKeyE42DDF01",
                         },
                       ],
                     },
@@ -31859,7 +32049,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3VersionKey09B12EB1",
+                          "Ref": "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3VersionKeyE42DDF01",
                         },
                       ],
                     },
@@ -32275,7 +32465,10 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1",
+            "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3BucketED9FB7B0",
+          },
+          Object {
+            "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
           },
         ],
         "SourceObjectKeys": Array [
@@ -32290,7 +32483,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3VersionKeyBA1CB663",
+                          "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3VersionKeyCFEDA3D4",
                         },
                       ],
                     },
@@ -32303,7 +32496,40 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3VersionKeyBA1CB663",
+                          "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3VersionKeyCFEDA3D4",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            ],
+          },
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                Object {
+                  "Fn::Select": Array [
+                    0,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                Object {
+                  "Fn::Select": Array [
+                    1,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49",
                         },
                       ],
                     },
@@ -32338,7 +32564,7 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22",
+            "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2",
           },
         ],
         "SourceObjectKeys": Array [
@@ -32353,7 +32579,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3VersionKeyCE5C5D3B",
+                          "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3VersionKeyEC7E3301",
                         },
                       ],
                     },
@@ -32366,7 +32592,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3VersionKeyCE5C5D3B",
+                          "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3VersionKeyEC7E3301",
                         },
                       ],
                     },
@@ -33047,7 +33273,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22",
+                        "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2",
                       },
                     ],
                   ],
@@ -33062,7 +33288,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22",
+                        "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2",
                       },
                       "/*",
                     ],
@@ -33129,7 +33355,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1",
+                        "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3BucketED9FB7B0",
                       },
                     ],
                   ],
@@ -33144,7 +33370,48 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1",
+                        "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3BucketED9FB7B0",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
+                      },
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
                       },
                       "/*",
                     ],
@@ -33372,7 +33639,7 @@ function handler(event) {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3Bucket1B95B117",
+            "Ref": "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3BucketCBEF8050",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -33385,7 +33652,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3VersionKey75D92238",
+                          "Ref": "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3VersionKey57968381",
                         },
                       ],
                     },
@@ -33398,7 +33665,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3VersionKey75D92238",
+                          "Ref": "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3VersionKey57968381",
                         },
                       ],
                     },
@@ -33914,28 +34181,52 @@ Object {
     },
   },
   "Parameters": Object {
-    "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeArtifactHash322D47B8": Object {
-      "Description": "Artifact hash for asset \\"0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9ae\\"",
+    "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6ArtifactHashF2EEEBFF": Object {
+      "Description": "Artifact hash for asset \\"04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6\\"",
       "Type": "String",
     },
-    "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3Bucket635A0AFA": Object {
-      "Description": "S3 bucket for asset \\"0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9ae\\"",
+    "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3Bucket86412295": Object {
+      "Description": "S3 bucket for asset \\"04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6\\"",
       "Type": "String",
     },
-    "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3VersionKeyBB104177": Object {
-      "Description": "S3 key for asset version \\"0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9ae\\"",
+    "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3VersionKeyE42DDF01": Object {
+      "Description": "S3 key for asset version \\"04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6\\"",
       "Type": "String",
     },
-    "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadArtifactHash3158CABD": Object {
-      "Description": "Artifact hash for asset \\"0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362ead\\"",
+    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440ArtifactHash87A9FF22": Object {
+      "Description": "Artifact hash for asset \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
       "Type": "String",
     },
-    "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3Bucket288D5551": Object {
-      "Description": "S3 bucket for asset \\"0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362ead\\"",
+    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054": Object {
+      "Description": "S3 bucket for asset \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
       "Type": "String",
     },
-    "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3VersionKey4638DF79": Object {
-      "Description": "S3 key for asset version \\"0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362ead\\"",
+    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49": Object {
+      "Description": "S3 key for asset version \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
+      "Type": "String",
+    },
+    "AssetParameters069043dc5c067ee8fba8c04a297886c3ecb0c208f06ea32fc40bb0761e8c9a99ArtifactHash3971F0E0": Object {
+      "Description": "Artifact hash for asset \\"069043dc5c067ee8fba8c04a297886c3ecb0c208f06ea32fc40bb0761e8c9a99\\"",
+      "Type": "String",
+    },
+    "AssetParameters069043dc5c067ee8fba8c04a297886c3ecb0c208f06ea32fc40bb0761e8c9a99S3Bucket7FED7AFC": Object {
+      "Description": "S3 bucket for asset \\"069043dc5c067ee8fba8c04a297886c3ecb0c208f06ea32fc40bb0761e8c9a99\\"",
+      "Type": "String",
+    },
+    "AssetParameters069043dc5c067ee8fba8c04a297886c3ecb0c208f06ea32fc40bb0761e8c9a99S3VersionKey4EDE2DC8": Object {
+      "Description": "S3 key for asset version \\"069043dc5c067ee8fba8c04a297886c3ecb0c208f06ea32fc40bb0761e8c9a99\\"",
+      "Type": "String",
+    },
+    "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aArtifactHash82449A4A": Object {
+      "Description": "Artifact hash for asset \\"0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4a\\"",
+      "Type": "String",
+    },
+    "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3Bucket789CA701": Object {
+      "Description": "S3 bucket for asset \\"0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4a\\"",
+      "Type": "String",
+    },
+    "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3VersionKey0222399F": Object {
+      "Description": "S3 key for asset version \\"0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4a\\"",
       "Type": "String",
     },
     "AssetParameters0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9ArtifactHashB9E3BF29": Object {
@@ -33950,42 +34241,6 @@ Object {
       "Description": "S3 key for asset version \\"0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9\\"",
       "Type": "String",
     },
-    "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67ArtifactHashCF96E147": Object {
-      "Description": "Artifact hash for asset \\"1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67\\"",
-      "Type": "String",
-    },
-    "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3BucketFFA964C8": Object {
-      "Description": "S3 bucket for asset \\"1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67\\"",
-      "Type": "String",
-    },
-    "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3VersionKeyA62CD84A": Object {
-      "Description": "S3 key for asset version \\"1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67\\"",
-      "Type": "String",
-    },
-    "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3ArtifactHashA3981DF8": Object {
-      "Description": "Artifact hash for asset \\"1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3\\"",
-      "Type": "String",
-    },
-    "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1": Object {
-      "Description": "S3 bucket for asset \\"1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3\\"",
-      "Type": "String",
-    },
-    "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3VersionKeyBA1CB663": Object {
-      "Description": "S3 key for asset version \\"1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3\\"",
-      "Type": "String",
-    },
-    "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeArtifactHashD1A9CF6A": Object {
-      "Description": "Artifact hash for asset \\"1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33ae\\"",
-      "Type": "String",
-    },
-    "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3Bucket901B95EB": Object {
-      "Description": "S3 bucket for asset \\"1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33ae\\"",
-      "Type": "String",
-    },
-    "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3VersionKeyC6FBD6BD": Object {
-      "Description": "S3 key for asset version \\"1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33ae\\"",
-      "Type": "String",
-    },
     "AssetParameters1f7e277bd526ebce1983fa1e7a84a5281ec533d9187caaebb773681bbf7bf4c1ArtifactHash0128B949": Object {
       "Description": "Artifact hash for asset \\"1f7e277bd526ebce1983fa1e7a84a5281ec533d9187caaebb773681bbf7bf4c1\\"",
       "Type": "String",
@@ -33998,112 +34253,76 @@ Object {
       "Description": "S3 key for asset version \\"1f7e277bd526ebce1983fa1e7a84a5281ec533d9187caaebb773681bbf7bf4c1\\"",
       "Type": "String",
     },
-    "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cArtifactHash8D005B5F": Object {
-      "Description": "Artifact hash for asset \\"205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612c\\"",
+    "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5ArtifactHash0AFE0939": Object {
+      "Description": "Artifact hash for asset \\"37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5\\"",
       "Type": "String",
     },
-    "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3Bucket95F679AA": Object {
-      "Description": "S3 bucket for asset \\"205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612c\\"",
+    "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3Bucket722FE70B": Object {
+      "Description": "S3 bucket for asset \\"37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5\\"",
       "Type": "String",
     },
-    "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3VersionKeyE7A4EEDD": Object {
-      "Description": "S3 key for asset version \\"205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612c\\"",
+    "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3VersionKey8082F3BC": Object {
+      "Description": "S3 key for asset version \\"37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5\\"",
       "Type": "String",
     },
-    "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534ArtifactHash89381734": Object {
-      "Description": "Artifact hash for asset \\"25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534\\"",
+    "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5ArtifactHash499F6DFF": Object {
+      "Description": "Artifact hash for asset \\"3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5\\"",
       "Type": "String",
     },
-    "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3Bucket8AFE0D2F": Object {
-      "Description": "S3 bucket for asset \\"25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534\\"",
+    "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3Bucket37F2908E": Object {
+      "Description": "S3 bucket for asset \\"3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5\\"",
       "Type": "String",
     },
-    "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3VersionKey39383E8E": Object {
-      "Description": "S3 key for asset version \\"25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534\\"",
+    "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3VersionKey2C992F11": Object {
+      "Description": "S3 key for asset version \\"3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5\\"",
       "Type": "String",
     },
-    "AssetParameters2df718f41e56d9d22eaf2a5519630f8240755ba8b4c447afedb38b7a5cd3975aArtifactHashDAF3B2D1": Object {
-      "Description": "Artifact hash for asset \\"2df718f41e56d9d22eaf2a5519630f8240755ba8b4c447afedb38b7a5cd3975a\\"",
+    "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dArtifactHash3B82A2B3": Object {
+      "Description": "Artifact hash for asset \\"3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880d\\"",
       "Type": "String",
     },
-    "AssetParameters2df718f41e56d9d22eaf2a5519630f8240755ba8b4c447afedb38b7a5cd3975aS3BucketDDE27CEF": Object {
-      "Description": "S3 bucket for asset \\"2df718f41e56d9d22eaf2a5519630f8240755ba8b4c447afedb38b7a5cd3975a\\"",
+    "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3BucketCBEF8050": Object {
+      "Description": "S3 bucket for asset \\"3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880d\\"",
       "Type": "String",
     },
-    "AssetParameters2df718f41e56d9d22eaf2a5519630f8240755ba8b4c447afedb38b7a5cd3975aS3VersionKey9136CD97": Object {
-      "Description": "S3 key for asset version \\"2df718f41e56d9d22eaf2a5519630f8240755ba8b4c447afedb38b7a5cd3975a\\"",
+    "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3VersionKey57968381": Object {
+      "Description": "S3 key for asset version \\"3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880d\\"",
       "Type": "String",
     },
-    "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bArtifactHash270470CC": Object {
-      "Description": "Artifact hash for asset \\"3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934b\\"",
+    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afArtifactHash7F8A76FC": Object {
+      "Description": "Artifact hash for asset \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
       "Type": "String",
     },
-    "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3Bucket2D6D8F86": Object {
-      "Description": "S3 bucket for asset \\"3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934b\\"",
+    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3Bucket5515214C": Object {
+      "Description": "S3 bucket for asset \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
       "Type": "String",
     },
-    "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3VersionKey0ECB40A6": Object {
-      "Description": "S3 key for asset version \\"3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934b\\"",
+    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED": Object {
+      "Description": "S3 key for asset version \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
       "Type": "String",
     },
-    "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0ArtifactHash6F14CF3C": Object {
-      "Description": "Artifact hash for asset \\"55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0\\"",
+    "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bArtifactHash5ABBFB9B": Object {
+      "Description": "Artifact hash for asset \\"42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2b\\"",
       "Type": "String",
     },
-    "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3BucketE35D2278": Object {
-      "Description": "S3 bucket for asset \\"55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0\\"",
+    "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3Bucket8AF0E263": Object {
+      "Description": "S3 bucket for asset \\"42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2b\\"",
       "Type": "String",
     },
-    "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3VersionKey88FA0AFA": Object {
-      "Description": "S3 key for asset version \\"55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0\\"",
+    "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3VersionKey5280D545": Object {
+      "Description": "S3 key for asset version \\"42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2b\\"",
       "Type": "String",
     },
-    "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420ArtifactHashC847AA8D": Object {
-      "Description": "Artifact hash for asset \\"6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420\\"",
+    "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeArtifactHash3FAC57D3": Object {
+      "Description": "Artifact hash for asset \\"4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeee\\"",
       "Type": "String",
     },
-    "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3Bucket649728C0": Object {
-      "Description": "S3 bucket for asset \\"6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420\\"",
+    "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3Bucket6F376B71": Object {
+      "Description": "S3 bucket for asset \\"4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeee\\"",
       "Type": "String",
     },
-    "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3VersionKey592D485B": Object {
-      "Description": "S3 key for asset version \\"6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420\\"",
-      "Type": "String",
-    },
-    "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cArtifactHashD2B94368": Object {
-      "Description": "Artifact hash for asset \\"73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06c\\"",
-      "Type": "String",
-    },
-    "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3Bucket19B71C5A": Object {
-      "Description": "S3 bucket for asset \\"73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06c\\"",
-      "Type": "String",
-    },
-    "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3VersionKeyDF73A6F0": Object {
-      "Description": "S3 key for asset version \\"73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06c\\"",
-      "Type": "String",
-    },
-    "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fArtifactHash2005F882": Object {
-      "Description": "Artifact hash for asset \\"778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6f\\"",
-      "Type": "String",
-    },
-    "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22": Object {
-      "Description": "S3 bucket for asset \\"778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6f\\"",
-      "Type": "String",
-    },
-    "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3VersionKeyCE5C5D3B": Object {
-      "Description": "S3 key for asset version \\"778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6f\\"",
-      "Type": "String",
-    },
-    "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0ArtifactHashF4B56B1E": Object {
-      "Description": "Artifact hash for asset \\"782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0\\"",
-      "Type": "String",
-    },
-    "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3Bucket1090210F": Object {
-      "Description": "S3 bucket for asset \\"782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0\\"",
-      "Type": "String",
-    },
-    "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3VersionKeyD738CD6B": Object {
-      "Description": "S3 key for asset version \\"782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0\\"",
+    "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3VersionKey7F6E5804": Object {
+      "Description": "S3 key for asset version \\"4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeee\\"",
       "Type": "String",
     },
     "AssetParameters7af6295e521fd55af94332393ceffb3e866aac4dc4956321f7918f21e72199e4ArtifactHash5E28809B": Object {
@@ -34118,16 +34337,16 @@ Object {
       "Description": "S3 key for asset version \\"7af6295e521fd55af94332393ceffb3e866aac4dc4956321f7918f21e72199e4\\"",
       "Type": "String",
     },
-    "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965ArtifactHashD4D3C5A6": Object {
-      "Description": "Artifact hash for asset \\"7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965\\"",
+    "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680ArtifactHash316B2926": Object {
+      "Description": "Artifact hash for asset \\"864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680\\"",
       "Type": "String",
     },
-    "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3Bucket0A90D6D3": Object {
-      "Description": "S3 bucket for asset \\"7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965\\"",
+    "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3BucketF13820EA": Object {
+      "Description": "S3 bucket for asset \\"864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680\\"",
       "Type": "String",
     },
-    "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3VersionKeyA116EF05": Object {
-      "Description": "S3 key for asset version \\"7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965\\"",
+    "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3VersionKey52B24F16": Object {
+      "Description": "S3 key for asset version \\"864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680\\"",
       "Type": "String",
     },
     "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900ArtifactHash121EF458": Object {
@@ -34142,6 +34361,18 @@ Object {
       "Description": "S3 key for asset version \\"8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900\\"",
       "Type": "String",
     },
+    "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9ArtifactHash694505BF": Object {
+      "Description": "Artifact hash for asset \\"8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9\\"",
+      "Type": "String",
+    },
+    "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3BucketED9FB7B0": Object {
+      "Description": "S3 bucket for asset \\"8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9\\"",
+      "Type": "String",
+    },
+    "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3VersionKeyCFEDA3D4": Object {
+      "Description": "S3 key for asset version \\"8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9\\"",
+      "Type": "String",
+    },
     "AssetParameters8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064ArtifactHashEA963870": Object {
       "Description": "Artifact hash for asset \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
@@ -34154,16 +34385,16 @@ Object {
       "Description": "S3 key for asset version \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
     },
-    "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8ArtifactHash8DC0C383": Object {
-      "Description": "Artifact hash for asset \\"9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8\\"",
+    "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4ArtifactHash660A50B8": Object {
+      "Description": "Artifact hash for asset \\"98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4\\"",
       "Type": "String",
     },
-    "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3Bucket1B95B117": Object {
-      "Description": "S3 bucket for asset \\"9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8\\"",
+    "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3BucketE78A0203": Object {
+      "Description": "S3 bucket for asset \\"98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4\\"",
       "Type": "String",
     },
-    "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3VersionKey75D92238": Object {
-      "Description": "S3 key for asset version \\"9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8\\"",
+    "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3VersionKey598098A7": Object {
+      "Description": "S3 key for asset version \\"98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4\\"",
       "Type": "String",
     },
     "AssetParametersa3058ccb468d757ebb89df5363a1c20f5307c6911136f29d00e1a68c9b2aa7e8ArtifactHash238275D6": Object {
@@ -34178,16 +34409,16 @@ Object {
       "Description": "S3 key for asset version \\"a3058ccb468d757ebb89df5363a1c20f5307c6911136f29d00e1a68c9b2aa7e8\\"",
       "Type": "String",
     },
-    "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdArtifactHash22ECD1BE": Object {
-      "Description": "Artifact hash for asset \\"adb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbd\\"",
+    "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaArtifactHash8CCAA809": Object {
+      "Description": "Artifact hash for asset \\"af643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfba\\"",
       "Type": "String",
     },
-    "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3BucketF9AF3C9C": Object {
-      "Description": "S3 bucket for asset \\"adb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbd\\"",
+    "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2": Object {
+      "Description": "S3 bucket for asset \\"af643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfba\\"",
       "Type": "String",
     },
-    "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3VersionKey09B12EB1": Object {
-      "Description": "S3 key for asset version \\"adb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbd\\"",
+    "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3VersionKeyEC7E3301": Object {
+      "Description": "S3 key for asset version \\"af643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfba\\"",
       "Type": "String",
     },
     "AssetParametersb120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827ArtifactHash1355580A": Object {
@@ -34202,16 +34433,40 @@ Object {
       "Description": "S3 key for asset version \\"b120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827\\"",
       "Type": "String",
     },
-    "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8ArtifactHashBB72DCC8": Object {
-      "Description": "Artifact hash for asset \\"c8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8\\"",
+    "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04ArtifactHash394183E9": Object {
+      "Description": "Artifact hash for asset \\"b55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04\\"",
       "Type": "String",
     },
-    "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3Bucket86DBA113": Object {
-      "Description": "S3 bucket for asset \\"c8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8\\"",
+    "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3BucketE7A02ACD": Object {
+      "Description": "S3 bucket for asset \\"b55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04\\"",
       "Type": "String",
     },
-    "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3VersionKeyF547CFB5": Object {
-      "Description": "S3 key for asset version \\"c8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8\\"",
+    "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3VersionKeyCC994D9E": Object {
+      "Description": "S3 key for asset version \\"b55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04\\"",
+      "Type": "String",
+    },
+    "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcArtifactHash4E26EEC4": Object {
+      "Description": "Artifact hash for asset \\"c62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafc\\"",
+      "Type": "String",
+    },
+    "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3Bucket5255533F": Object {
+      "Description": "S3 bucket for asset \\"c62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafc\\"",
+      "Type": "String",
+    },
+    "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3VersionKey7909F675": Object {
+      "Description": "S3 key for asset version \\"c62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafc\\"",
+      "Type": "String",
+    },
+    "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aArtifactHash0386B8EC": Object {
+      "Description": "Artifact hash for asset \\"da314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17a\\"",
+      "Type": "String",
+    },
+    "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3BucketAE80D773": Object {
+      "Description": "S3 bucket for asset \\"da314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17a\\"",
+      "Type": "String",
+    },
+    "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3VersionKey662F0E6F": Object {
+      "Description": "S3 key for asset version \\"da314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17a\\"",
       "Type": "String",
     },
     "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68ArtifactHashD9A515C3": Object {
@@ -34224,6 +34479,30 @@ Object {
     },
     "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3VersionKeyE415415F": Object {
       "Description": "S3 key for asset version \\"e9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68\\"",
+      "Type": "String",
+    },
+    "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3ArtifactHash11DB5971": Object {
+      "Description": "Artifact hash for asset \\"f48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3\\"",
+      "Type": "String",
+    },
+    "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3BucketAC5DE359": Object {
+      "Description": "S3 bucket for asset \\"f48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3\\"",
+      "Type": "String",
+    },
+    "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3VersionKey503D22DC": Object {
+      "Description": "S3 key for asset version \\"f48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3\\"",
+      "Type": "String",
+    },
+    "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5ArtifactHash185A4671": Object {
+      "Description": "Artifact hash for asset \\"fbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5\\"",
+      "Type": "String",
+    },
+    "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3Bucket024B3DC6": Object {
+      "Description": "S3 bucket for asset \\"fbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5\\"",
+      "Type": "String",
+    },
+    "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3VersionKeyEEA56859": Object {
+      "Description": "S3 key for asset version \\"fbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5\\"",
       "Type": "String",
     },
   },
@@ -35621,7 +35900,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3Bucket288D5551",
+            "Ref": "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3BucketAE80D773",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -35634,7 +35913,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3VersionKey4638DF79",
+                          "Ref": "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3VersionKey662F0E6F",
                         },
                       ],
                     },
@@ -35647,7 +35926,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3VersionKey4638DF79",
+                          "Ref": "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3VersionKey662F0E6F",
                         },
                       ],
                     },
@@ -35830,7 +36109,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3Bucket95F679AA",
+            "Ref": "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3BucketAC5DE359",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -35843,7 +36122,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3VersionKeyE7A4EEDD",
+                          "Ref": "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3VersionKey503D22DC",
                         },
                       ],
                     },
@@ -35856,7 +36135,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3VersionKeyE7A4EEDD",
+                          "Ref": "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3VersionKey503D22DC",
                         },
                       ],
                     },
@@ -36096,7 +36375,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3Bucket8AFE0D2F",
+            "Ref": "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3BucketF13820EA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -36109,7 +36388,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3VersionKey39383E8E",
+                          "Ref": "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3VersionKey52B24F16",
                         },
                       ],
                     },
@@ -36122,7 +36401,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3VersionKey39383E8E",
+                          "Ref": "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3VersionKey52B24F16",
                         },
                       ],
                     },
@@ -36609,7 +36888,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3Bucket0A90D6D3",
+            "Ref": "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3Bucket5255533F",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -36622,7 +36901,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3VersionKeyA116EF05",
+                          "Ref": "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3VersionKey7909F675",
                         },
                       ],
                     },
@@ -36635,7 +36914,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3VersionKeyA116EF05",
+                          "Ref": "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3VersionKey7909F675",
                         },
                       ],
                     },
@@ -36819,7 +37098,7 @@ Direct link to the function: /lambda/home#/functions/",
               Object {
                 "Ref": "ConstructHubPackageDataDC5EF35E",
               },
-              "\\",\\"Prefix\\":\\"data/\\"}},\\"Is there more?\\":{\\"Type\\":\\"Choice\\",\\"Choices\\":[{\\"Variable\\":\\"$.response.NextContinuationToken\\",\\"IsPresent\\":true,\\"Next\\":\\"Continue as new\\"}],\\"Default\\":\\"Process Result\\"},\\"S3.ListObjectsV2(NextPage)\\":{\\"Next\\":\\"Is there more?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"S3.SdkClientException\\"]}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.response\\",\\"Resource\\":\\"arn:",
+              "\\",\\"Prefix\\":\\"data/\\"}},\\"Is there more?\\":{\\"Type\\":\\"Choice\\",\\"Choices\\":[{\\"Variable\\":\\"$.response.NextContinuationToken\\",\\"IsPresent\\":true,\\"Next\\":\\"Give room for on-demand work\\"}],\\"Default\\":\\"Process Result\\"},\\"S3.ListObjectsV2(NextPage)\\":{\\"Next\\":\\"Is there more?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"S3.SdkClientException\\"]}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.response\\",\\"Resource\\":\\"arn:",
               Object {
                 "Ref": "AWS::Partition",
               },
@@ -36854,7 +37133,7 @@ Direct link to the function: /lambda/home#/functions/",
               Object {
                 "Ref": "AWS::AccountId",
               },
-              ":stateMachine:Test.ConstructHub.Ingestion.ReprocessWorkflow\\"}}},\\"TimeoutSeconds\\":3600}",
+              ":stateMachine:Test.ConstructHub.Ingestion.ReprocessWorkflow\\"}},\\"Give room for on-demand work\\":{\\"Type\\":\\"Wait\\",\\"Seconds\\":300,\\"Next\\":\\"Continue as new\\"}},\\"TimeoutSeconds\\":3600}",
             ],
           ],
         },
@@ -37284,7 +37563,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3Bucket649728C0",
+            "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3Bucket5515214C",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -37297,7 +37576,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3VersionKey592D485B",
+                          "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED",
                         },
                       ],
                     },
@@ -37310,7 +37589,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3VersionKey592D485B",
+                          "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED",
                         },
                       ],
                     },
@@ -38361,7 +38640,7 @@ Direct link to function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3Bucket635A0AFA",
+            "Ref": "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3BucketE7A02ACD",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -38374,7 +38653,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3VersionKeyBB104177",
+                          "Ref": "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3VersionKeyCC994D9E",
                         },
                       ],
                     },
@@ -38387,7 +38666,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3VersionKeyBB104177",
+                          "Ref": "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3VersionKeyCC994D9E",
                         },
                       ],
                     },
@@ -38519,7 +38798,7 @@ Direct link to function: /lambda/home#/functions/",
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"StartAt\\":\\"Track Execution Infos\\",\\"States\\":{\\"Track Execution Infos\\":{\\"Type\\":\\"Pass\\",\\"ResultPath\\":\\"$.$TaskExecution\\",\\"InputPath\\":\\"$$.Execution\\",\\"Parameters\\":{\\"Id.$\\":\\"$.Id\\",\\"Name.$\\":\\"$.Name\\",\\"RoleArn.$\\":\\"$.RoleArn\\",\\"StartTime.$\\":\\"$.StartTime\\"},\\"Next\\":\\"Prepare doc-gen ECS Command\\"},\\"Prepare doc-gen ECS Command\\":{\\"Type\\":\\"Pass\\",\\"ResultPath\\":\\"$.docGen\\",\\"Parameters\\":{\\"command.$\\":\\"States.Array(States.JsonToString($))\\"},\\"Next\\":\\"Generate docs\\"},\\"Generate docs\\":{\\"Next\\":\\"Check whether catalog needs udpating\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"jsii-docgen.NoSpaceLeftOnDevice\\"],\\"MaxAttempts\\":0},{\\"ErrorEquals\\":[\\"ECS.AmazonECSException\\",\\"ECS.InvalidParameterException\\",\\"jsii-docgen.NpmError.E429\\",\\"jsii-codgen.NpmError.EPROTO\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":30,\\"BackoffRate\\":1.1},{\\"ErrorEquals\\":[\\"jsii-docgen.NpmError.ETARGET\\"],\\"IntervalSeconds\\":300,\\"MaxAttempts\\":3,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"MaxAttempts\\":3}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"UnprocessablePackageError\\"],\\"Next\\":\\"Ignore\\"},{\\"ErrorEquals\\":[\\"States.Timeout\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"ECS.AmazonECSException\\",\\"ECS.InvalidParameterException\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Type\\":\\"Task\\",\\"TimeoutSeconds\\":3600,\\"HeartbeatSeconds\\":300,\\"InputPath\\":\\"$.docGen.command\\",\\"ResultPath\\":\\"$.docGenOutput\\",\\"Resource\\":\\"arn:",
+              "{\\"StartAt\\":\\"Track Execution Infos\\",\\"States\\":{\\"Track Execution Infos\\":{\\"Type\\":\\"Pass\\",\\"ResultPath\\":\\"$.$TaskExecution\\",\\"InputPath\\":\\"$$.Execution\\",\\"Parameters\\":{\\"Id.$\\":\\"$.Id\\",\\"Name.$\\":\\"$.Name\\",\\"RoleArn.$\\":\\"$.RoleArn\\",\\"StartTime.$\\":\\"$.StartTime\\"},\\"Next\\":\\"Prepare doc-gen ECS Command\\"},\\"Prepare doc-gen ECS Command\\":{\\"Type\\":\\"Pass\\",\\"ResultPath\\":\\"$.docGen\\",\\"Parameters\\":{\\"command.$\\":\\"States.Array(States.JsonToString($))\\"},\\"Next\\":\\"Generate docs\\"},\\"Generate docs\\":{\\"Next\\":\\"Check whether catalog needs udpating\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"jsii-docgen.NoSpaceLeftOnDevice\\"],\\"MaxAttempts\\":0},{\\"ErrorEquals\\":[\\"ECS.AmazonECSException\\",\\"ECS.InvalidParameterException\\",\\"jsii-docgen.NpmError.E429\\",\\"jsii-codgen.NpmError.EPROTO\\"],\\"IntervalSeconds\\":120,\\"MaxAttempts\\":200,\\"BackoffRate\\":1},{\\"ErrorEquals\\":[\\"jsii-docgen.NpmError.ETARGET\\"],\\"IntervalSeconds\\":300,\\"MaxAttempts\\":3,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"MaxAttempts\\":3}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"UnprocessablePackageError\\"],\\"Next\\":\\"Ignore\\"},{\\"ErrorEquals\\":[\\"States.Timeout\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"ECS.AmazonECSException\\",\\"ECS.InvalidParameterException\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Type\\":\\"Task\\",\\"TimeoutSeconds\\":7200,\\"HeartbeatSeconds\\":300,\\"InputPath\\":\\"$.docGen.command\\",\\"ResultPath\\":\\"$.docGenOutput\\",\\"Resource\\":\\"arn:",
               Object {
                 "Ref": "AWS::Partition",
               },
@@ -38545,7 +38824,7 @@ Direct link to function: /lambda/home#/functions/",
                   "GroupId",
                 ],
               },
-              "\\"]}},\\"Overrides\\":{\\"ContainerOverrides\\":[{\\"Name\\":\\"Resource\\",\\"Command.$\\":\\"$\\",\\"Environment\\":[{\\"Name\\":\\"SFN_TASK_TOKEN\\",\\"Value.$\\":\\"$$.Task.Token\\"}]}]},\\"LaunchType\\":\\"FARGATE\\",\\"PlatformVersion\\":\\"1.4.0\\"}},\\"Check whether catalog needs udpating\\":{\\"Next\\":\\"Is catalog update needed?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"Lambda.ServiceException\\",\\"Lambda.AWSLambdaException\\",\\"Lambda.SdkClientException\\"],\\"IntervalSeconds\\":2,\\"MaxAttempts\\":6,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":30,\\"BackoffRate\\":1.1}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.catalogNeedsUpdating\\",\\"Resource\\":\\"",
+              "\\"]}},\\"Overrides\\":{\\"ContainerOverrides\\":[{\\"Name\\":\\"Resource\\",\\"Command.$\\":\\"$\\",\\"Environment\\":[{\\"Name\\":\\"SFN_TASK_TOKEN\\",\\"Value.$\\":\\"$$.Task.Token\\"}]}]},\\"LaunchType\\":\\"FARGATE\\",\\"PlatformVersion\\":\\"1.4.0\\"}},\\"Check whether catalog needs udpating\\":{\\"Next\\":\\"Is catalog update needed?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"Lambda.ServiceException\\",\\"Lambda.AWSLambdaException\\",\\"Lambda.SdkClientException\\"],\\"IntervalSeconds\\":2,\\"MaxAttempts\\":6,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\",\\"Lambda.Unknown\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":30,\\"BackoffRate\\":1.1}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\",\\"Lambda.Unknown\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.catalogNeedsUpdating\\",\\"Resource\\":\\"",
               Object {
                 "Fn::GetAtt": Array [
                   "ConstructHubOrchestrationNeedsCatalogUpdate5D7370DC",
@@ -38596,7 +38875,7 @@ Direct link to function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3Bucket2D6D8F86",
+            "Ref": "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3Bucket722FE70B",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -38609,7 +38888,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3VersionKey0ECB40A6",
+                          "Ref": "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3VersionKey8082F3BC",
                         },
                       ],
                     },
@@ -38622,7 +38901,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3VersionKey0ECB40A6",
+                          "Ref": "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3VersionKey8082F3BC",
                         },
                       ],
                     },
@@ -39424,7 +39703,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3Bucket19B71C5A",
+            "Ref": "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3BucketE78A0203",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -39437,7 +39716,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3VersionKeyDF73A6F0",
+                          "Ref": "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3VersionKey598098A7",
                         },
                       ],
                     },
@@ -39450,7 +39729,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3VersionKeyDF73A6F0",
+                          "Ref": "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3VersionKey598098A7",
                         },
                       ],
                     },
@@ -39608,7 +39887,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3Bucket1090210F",
+            "Ref": "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3Bucket6F376B71",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -39621,7 +39900,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3VersionKeyD738CD6B",
+                          "Ref": "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3VersionKey7F6E5804",
                         },
                       ],
                     },
@@ -39634,7 +39913,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3VersionKeyD738CD6B",
+                          "Ref": "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3VersionKey7F6E5804",
                         },
                       ],
                     },
@@ -40412,7 +40691,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                   Object {
                     "Ref": "AWS::URLSuffix",
                   },
-                  "/aws-cdk/assets:5fa39a328f34360df81ad2f478b29e7f72b6625d60d6ca775401e69a3b2c0faf",
+                  "/aws-cdk/assets:89c6683e392b08bdb9bfd8e456f82a156b228534eed332191232b4aa0beec4f2",
                 ],
               ],
             },
@@ -40694,7 +40973,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.md",
+                      "/data/*/docs-typescript.*",
                     ],
                   ],
                 },
@@ -40724,7 +41003,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.md",
+                      "/data/*/docs-*-typescript.*",
                     ],
                   ],
                 },
@@ -40754,7 +41033,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.md.not-supported",
+                      "/data/*/docs-typescript.*.not-supported",
                     ],
                   ],
                 },
@@ -40784,7 +41063,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.md.not-supported",
+                      "/data/*/docs-*-typescript.*.not-supported",
                     ],
                   ],
                 },
@@ -40814,7 +41093,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.md.corruptassembly",
+                      "/data/*/docs-typescript.*.corruptassembly",
                     ],
                   ],
                 },
@@ -40844,7 +41123,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.md.corruptassembly",
+                      "/data/*/docs-*-typescript.*.corruptassembly",
                     ],
                   ],
                 },
@@ -40863,7 +41142,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-typescript.md.corruptassembly",
+                    "/data/*/docs-typescript.*.corruptassembly",
                   ],
                 ],
               },
@@ -40881,223 +41160,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-typescript.md.corruptassembly",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.md",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.md",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.md.not-supported",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.md.not-supported",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.md.corruptassembly",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.md.corruptassembly",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": "s3:DeleteObject*",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "ConstructHubPackageDataDC5EF35E",
-                        "Arn",
-                      ],
-                    },
-                    "/data/*/docs-python.md.corruptassembly",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": "s3:DeleteObject*",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "ConstructHubPackageDataDC5EF35E",
-                        "Arn",
-                      ],
-                    },
-                    "/data/*/docs-*-python.md.corruptassembly",
+                    "/data/*/docs-*-typescript.*.corruptassembly",
                   ],
                 ],
               },
@@ -41126,7 +41189,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.md",
+                      "/data/*/docs-python.*",
                     ],
                   ],
                 },
@@ -41156,7 +41219,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.md",
+                      "/data/*/docs-*-python.*",
                     ],
                   ],
                 },
@@ -41186,7 +41249,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.md.not-supported",
+                      "/data/*/docs-python.*.not-supported",
                     ],
                   ],
                 },
@@ -41216,7 +41279,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.md.not-supported",
+                      "/data/*/docs-*-python.*.not-supported",
                     ],
                   ],
                 },
@@ -41246,7 +41309,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.md.corruptassembly",
+                      "/data/*/docs-python.*.corruptassembly",
                     ],
                   ],
                 },
@@ -41276,7 +41339,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.md.corruptassembly",
+                      "/data/*/docs-*-python.*.corruptassembly",
                     ],
                   ],
                 },
@@ -41295,7 +41358,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-java.md.corruptassembly",
+                    "/data/*/docs-python.*.corruptassembly",
                   ],
                 ],
               },
@@ -41313,7 +41376,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-java.md.corruptassembly",
+                    "/data/*/docs-*-python.*.corruptassembly",
                   ],
                 ],
               },
@@ -41342,7 +41405,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.md",
+                      "/data/*/docs-java.*",
                     ],
                   ],
                 },
@@ -41372,7 +41435,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.md",
+                      "/data/*/docs-*-java.*",
                     ],
                   ],
                 },
@@ -41402,7 +41465,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.md.not-supported",
+                      "/data/*/docs-java.*.not-supported",
                     ],
                   ],
                 },
@@ -41432,7 +41495,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.md.not-supported",
+                      "/data/*/docs-*-java.*.not-supported",
                     ],
                   ],
                 },
@@ -41462,7 +41525,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.md.corruptassembly",
+                      "/data/*/docs-java.*.corruptassembly",
                     ],
                   ],
                 },
@@ -41492,7 +41555,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.md.corruptassembly",
+                      "/data/*/docs-*-java.*.corruptassembly",
                     ],
                   ],
                 },
@@ -41511,7 +41574,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-csharp.md.corruptassembly",
+                    "/data/*/docs-java.*.corruptassembly",
                   ],
                 ],
               },
@@ -41529,7 +41592,223 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-csharp.md.corruptassembly",
+                    "/data/*/docs-*-java.*.corruptassembly",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.*.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.*.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.*.corruptassembly",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.*.corruptassembly",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": "s3:DeleteObject*",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "ConstructHubPackageDataDC5EF35E",
+                        "Arn",
+                      ],
+                    },
+                    "/data/*/docs-csharp.*.corruptassembly",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:DeleteObject*",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "ConstructHubPackageDataDC5EF35E",
+                        "Arn",
+                      ],
+                    },
+                    "/data/*/docs-*-csharp.*.corruptassembly",
                   ],
                 ],
               },
@@ -41795,7 +42074,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3Bucket901B95EB",
+            "Ref": "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3Bucket024B3DC6",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -41808,7 +42087,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3VersionKeyC6FBD6BD",
+                          "Ref": "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3VersionKeyEEA56859",
                         },
                       ],
                     },
@@ -41821,7 +42100,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3VersionKeyC6FBD6BD",
+                          "Ref": "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3VersionKeyEEA56859",
                         },
                       ],
                     },
@@ -41878,7 +42157,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3Bucket86DBA113",
+            "Ref": "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3Bucket37F2908E",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -41891,7 +42170,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3VersionKeyF547CFB5",
+                          "Ref": "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3VersionKey2C992F11",
                         },
                       ],
                     },
@@ -41904,7 +42183,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3VersionKeyF547CFB5",
+                          "Ref": "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3VersionKey2C992F11",
                         },
                       ],
                     },
@@ -42454,7 +42733,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3BucketFFA964C8",
+            "Ref": "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3Bucket8AF0E263",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -42467,7 +42746,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3VersionKeyA62CD84A",
+                          "Ref": "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3VersionKey5280D545",
                         },
                       ],
                     },
@@ -42480,7 +42759,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3VersionKeyA62CD84A",
+                          "Ref": "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3VersionKey5280D545",
                         },
                       ],
                     },
@@ -42890,7 +43169,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3BucketE35D2278",
+            "Ref": "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3Bucket789CA701",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -42903,7 +43182,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3VersionKey88FA0AFA",
+                          "Ref": "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3VersionKey0222399F",
                         },
                       ],
                     },
@@ -42916,7 +43195,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3VersionKey88FA0AFA",
+                          "Ref": "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3VersionKey0222399F",
                         },
                       ],
                     },
@@ -43122,7 +43401,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3BucketF9AF3C9C",
+            "Ref": "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3Bucket86412295",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -43135,7 +43414,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3VersionKey09B12EB1",
+                          "Ref": "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3VersionKeyE42DDF01",
                         },
                       ],
                     },
@@ -43148,7 +43427,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3VersionKey09B12EB1",
+                          "Ref": "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3VersionKeyE42DDF01",
                         },
                       ],
                     },
@@ -43616,7 +43895,10 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1",
+            "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3BucketED9FB7B0",
+          },
+          Object {
+            "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
           },
         ],
         "SourceObjectKeys": Array [
@@ -43631,7 +43913,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3VersionKeyBA1CB663",
+                          "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3VersionKeyCFEDA3D4",
                         },
                       ],
                     },
@@ -43644,7 +43926,40 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3VersionKeyBA1CB663",
+                          "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3VersionKeyCFEDA3D4",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            ],
+          },
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                Object {
+                  "Fn::Select": Array [
+                    0,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                Object {
+                  "Fn::Select": Array [
+                    1,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49",
                         },
                       ],
                     },
@@ -43679,7 +43994,7 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22",
+            "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2",
           },
         ],
         "SourceObjectKeys": Array [
@@ -43694,7 +44009,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3VersionKeyCE5C5D3B",
+                          "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3VersionKeyEC7E3301",
                         },
                       ],
                     },
@@ -43707,7 +44022,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3VersionKeyCE5C5D3B",
+                          "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3VersionKeyEC7E3301",
                         },
                       ],
                     },
@@ -43962,7 +44277,7 @@ function handler(event) {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters2df718f41e56d9d22eaf2a5519630f8240755ba8b4c447afedb38b7a5cd3975aS3BucketDDE27CEF",
+            "Ref": "AssetParameters069043dc5c067ee8fba8c04a297886c3ecb0c208f06ea32fc40bb0761e8c9a99S3Bucket7FED7AFC",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -43975,7 +44290,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters2df718f41e56d9d22eaf2a5519630f8240755ba8b4c447afedb38b7a5cd3975aS3VersionKey9136CD97",
+                          "Ref": "AssetParameters069043dc5c067ee8fba8c04a297886c3ecb0c208f06ea32fc40bb0761e8c9a99S3VersionKey4EDE2DC8",
                         },
                       ],
                     },
@@ -43988,7 +44303,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters2df718f41e56d9d22eaf2a5519630f8240755ba8b4c447afedb38b7a5cd3975aS3VersionKey9136CD97",
+                          "Ref": "AssetParameters069043dc5c067ee8fba8c04a297886c3ecb0c208f06ea32fc40bb0761e8c9a99S3VersionKey4EDE2DC8",
                         },
                       ],
                     },
@@ -44615,7 +44930,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22",
+                        "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2",
                       },
                     ],
                   ],
@@ -44630,7 +44945,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22",
+                        "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2",
                       },
                       "/*",
                     ],
@@ -44697,7 +45012,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1",
+                        "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3BucketED9FB7B0",
                       },
                     ],
                   ],
@@ -44712,7 +45027,48 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1",
+                        "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3BucketED9FB7B0",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
+                      },
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
                       },
                       "/*",
                     ],
@@ -44940,7 +45296,7 @@ function handler(event) {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3Bucket1B95B117",
+            "Ref": "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3BucketCBEF8050",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -44953,7 +45309,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3VersionKey75D92238",
+                          "Ref": "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3VersionKey57968381",
                         },
                       ],
                     },
@@ -44966,7 +45322,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3VersionKey75D92238",
+                          "Ref": "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3VersionKey57968381",
                         },
                       ],
                     },
@@ -45472,28 +45828,40 @@ Object {
     },
   },
   "Parameters": Object {
-    "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeArtifactHash322D47B8": Object {
-      "Description": "Artifact hash for asset \\"0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9ae\\"",
+    "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6ArtifactHashF2EEEBFF": Object {
+      "Description": "Artifact hash for asset \\"04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6\\"",
       "Type": "String",
     },
-    "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3Bucket635A0AFA": Object {
-      "Description": "S3 bucket for asset \\"0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9ae\\"",
+    "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3Bucket86412295": Object {
+      "Description": "S3 bucket for asset \\"04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6\\"",
       "Type": "String",
     },
-    "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3VersionKeyBB104177": Object {
-      "Description": "S3 key for asset version \\"0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9ae\\"",
+    "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3VersionKeyE42DDF01": Object {
+      "Description": "S3 key for asset version \\"04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6\\"",
       "Type": "String",
     },
-    "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadArtifactHash3158CABD": Object {
-      "Description": "Artifact hash for asset \\"0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362ead\\"",
+    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440ArtifactHash87A9FF22": Object {
+      "Description": "Artifact hash for asset \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
       "Type": "String",
     },
-    "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3Bucket288D5551": Object {
-      "Description": "S3 bucket for asset \\"0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362ead\\"",
+    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054": Object {
+      "Description": "S3 bucket for asset \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
       "Type": "String",
     },
-    "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3VersionKey4638DF79": Object {
-      "Description": "S3 key for asset version \\"0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362ead\\"",
+    "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49": Object {
+      "Description": "S3 key for asset version \\"061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440\\"",
+      "Type": "String",
+    },
+    "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aArtifactHash82449A4A": Object {
+      "Description": "Artifact hash for asset \\"0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4a\\"",
+      "Type": "String",
+    },
+    "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3Bucket789CA701": Object {
+      "Description": "S3 bucket for asset \\"0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4a\\"",
+      "Type": "String",
+    },
+    "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3VersionKey0222399F": Object {
+      "Description": "S3 key for asset version \\"0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4a\\"",
       "Type": "String",
     },
     "AssetParameters0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9ArtifactHashB9E3BF29": Object {
@@ -45508,42 +45876,6 @@ Object {
       "Description": "S3 key for asset version \\"0f7c0428d7c72a325aadf3427ca47c80d2aa2eb282b5a5328965ab9e40c1dfd9\\"",
       "Type": "String",
     },
-    "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67ArtifactHashCF96E147": Object {
-      "Description": "Artifact hash for asset \\"1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67\\"",
-      "Type": "String",
-    },
-    "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3BucketFFA964C8": Object {
-      "Description": "S3 bucket for asset \\"1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67\\"",
-      "Type": "String",
-    },
-    "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3VersionKeyA62CD84A": Object {
-      "Description": "S3 key for asset version \\"1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67\\"",
-      "Type": "String",
-    },
-    "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3ArtifactHashA3981DF8": Object {
-      "Description": "Artifact hash for asset \\"1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3\\"",
-      "Type": "String",
-    },
-    "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1": Object {
-      "Description": "S3 bucket for asset \\"1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3\\"",
-      "Type": "String",
-    },
-    "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3VersionKeyBA1CB663": Object {
-      "Description": "S3 key for asset version \\"1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3\\"",
-      "Type": "String",
-    },
-    "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeArtifactHashD1A9CF6A": Object {
-      "Description": "Artifact hash for asset \\"1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33ae\\"",
-      "Type": "String",
-    },
-    "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3Bucket901B95EB": Object {
-      "Description": "S3 bucket for asset \\"1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33ae\\"",
-      "Type": "String",
-    },
-    "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3VersionKeyC6FBD6BD": Object {
-      "Description": "S3 key for asset version \\"1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33ae\\"",
-      "Type": "String",
-    },
     "AssetParameters1f7e277bd526ebce1983fa1e7a84a5281ec533d9187caaebb773681bbf7bf4c1ArtifactHash0128B949": Object {
       "Description": "Artifact hash for asset \\"1f7e277bd526ebce1983fa1e7a84a5281ec533d9187caaebb773681bbf7bf4c1\\"",
       "Type": "String",
@@ -45556,40 +45888,52 @@ Object {
       "Description": "S3 key for asset version \\"1f7e277bd526ebce1983fa1e7a84a5281ec533d9187caaebb773681bbf7bf4c1\\"",
       "Type": "String",
     },
-    "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cArtifactHash8D005B5F": Object {
-      "Description": "Artifact hash for asset \\"205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612c\\"",
+    "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5ArtifactHash0AFE0939": Object {
+      "Description": "Artifact hash for asset \\"37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5\\"",
       "Type": "String",
     },
-    "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3Bucket95F679AA": Object {
-      "Description": "S3 bucket for asset \\"205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612c\\"",
+    "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3Bucket722FE70B": Object {
+      "Description": "S3 bucket for asset \\"37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5\\"",
       "Type": "String",
     },
-    "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3VersionKeyE7A4EEDD": Object {
-      "Description": "S3 key for asset version \\"205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612c\\"",
+    "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3VersionKey8082F3BC": Object {
+      "Description": "S3 key for asset version \\"37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5\\"",
       "Type": "String",
     },
-    "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534ArtifactHash89381734": Object {
-      "Description": "Artifact hash for asset \\"25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534\\"",
+    "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5ArtifactHash499F6DFF": Object {
+      "Description": "Artifact hash for asset \\"3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5\\"",
       "Type": "String",
     },
-    "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3Bucket8AFE0D2F": Object {
-      "Description": "S3 bucket for asset \\"25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534\\"",
+    "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3Bucket37F2908E": Object {
+      "Description": "S3 bucket for asset \\"3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5\\"",
       "Type": "String",
     },
-    "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3VersionKey39383E8E": Object {
-      "Description": "S3 key for asset version \\"25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534\\"",
+    "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3VersionKey2C992F11": Object {
+      "Description": "S3 key for asset version \\"3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5\\"",
       "Type": "String",
     },
-    "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bArtifactHash270470CC": Object {
-      "Description": "Artifact hash for asset \\"3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934b\\"",
+    "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dArtifactHash3B82A2B3": Object {
+      "Description": "Artifact hash for asset \\"3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880d\\"",
       "Type": "String",
     },
-    "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3Bucket2D6D8F86": Object {
-      "Description": "S3 bucket for asset \\"3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934b\\"",
+    "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3BucketCBEF8050": Object {
+      "Description": "S3 bucket for asset \\"3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880d\\"",
       "Type": "String",
     },
-    "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3VersionKey0ECB40A6": Object {
-      "Description": "S3 key for asset version \\"3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934b\\"",
+    "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3VersionKey57968381": Object {
+      "Description": "S3 key for asset version \\"3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880d\\"",
+      "Type": "String",
+    },
+    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afArtifactHash7F8A76FC": Object {
+      "Description": "Artifact hash for asset \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
+      "Type": "String",
+    },
+    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3Bucket5515214C": Object {
+      "Description": "S3 bucket for asset \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
+      "Type": "String",
+    },
+    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED": Object {
+      "Description": "S3 key for asset version \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
       "Type": "String",
     },
     "AssetParameters4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbcArtifactHashF236251A": Object {
@@ -45604,76 +45948,40 @@ Object {
       "Description": "S3 key for asset version \\"4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbc\\"",
       "Type": "String",
     },
-    "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0ArtifactHash6F14CF3C": Object {
-      "Description": "Artifact hash for asset \\"55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0\\"",
+    "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bArtifactHash5ABBFB9B": Object {
+      "Description": "Artifact hash for asset \\"42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2b\\"",
       "Type": "String",
     },
-    "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3BucketE35D2278": Object {
-      "Description": "S3 bucket for asset \\"55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0\\"",
+    "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3Bucket8AF0E263": Object {
+      "Description": "S3 bucket for asset \\"42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2b\\"",
       "Type": "String",
     },
-    "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3VersionKey88FA0AFA": Object {
-      "Description": "S3 key for asset version \\"55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0\\"",
+    "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3VersionKey5280D545": Object {
+      "Description": "S3 key for asset version \\"42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2b\\"",
       "Type": "String",
     },
-    "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420ArtifactHashC847AA8D": Object {
-      "Description": "Artifact hash for asset \\"6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420\\"",
+    "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeArtifactHash3FAC57D3": Object {
+      "Description": "Artifact hash for asset \\"4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeee\\"",
       "Type": "String",
     },
-    "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3Bucket649728C0": Object {
-      "Description": "S3 bucket for asset \\"6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420\\"",
+    "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3Bucket6F376B71": Object {
+      "Description": "S3 bucket for asset \\"4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeee\\"",
       "Type": "String",
     },
-    "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3VersionKey592D485B": Object {
-      "Description": "S3 key for asset version \\"6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420\\"",
+    "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3VersionKey7F6E5804": Object {
+      "Description": "S3 key for asset version \\"4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeee\\"",
       "Type": "String",
     },
-    "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cArtifactHashD2B94368": Object {
-      "Description": "Artifact hash for asset \\"73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06c\\"",
+    "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680ArtifactHash316B2926": Object {
+      "Description": "Artifact hash for asset \\"864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680\\"",
       "Type": "String",
     },
-    "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3Bucket19B71C5A": Object {
-      "Description": "S3 bucket for asset \\"73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06c\\"",
+    "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3BucketF13820EA": Object {
+      "Description": "S3 bucket for asset \\"864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680\\"",
       "Type": "String",
     },
-    "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3VersionKeyDF73A6F0": Object {
-      "Description": "S3 key for asset version \\"73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06c\\"",
-      "Type": "String",
-    },
-    "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fArtifactHash2005F882": Object {
-      "Description": "Artifact hash for asset \\"778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6f\\"",
-      "Type": "String",
-    },
-    "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22": Object {
-      "Description": "S3 bucket for asset \\"778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6f\\"",
-      "Type": "String",
-    },
-    "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3VersionKeyCE5C5D3B": Object {
-      "Description": "S3 key for asset version \\"778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6f\\"",
-      "Type": "String",
-    },
-    "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0ArtifactHashF4B56B1E": Object {
-      "Description": "Artifact hash for asset \\"782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0\\"",
-      "Type": "String",
-    },
-    "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3Bucket1090210F": Object {
-      "Description": "S3 bucket for asset \\"782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0\\"",
-      "Type": "String",
-    },
-    "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3VersionKeyD738CD6B": Object {
-      "Description": "S3 key for asset version \\"782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0\\"",
-      "Type": "String",
-    },
-    "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965ArtifactHashD4D3C5A6": Object {
-      "Description": "Artifact hash for asset \\"7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965\\"",
-      "Type": "String",
-    },
-    "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3Bucket0A90D6D3": Object {
-      "Description": "S3 bucket for asset \\"7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965\\"",
-      "Type": "String",
-    },
-    "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3VersionKeyA116EF05": Object {
-      "Description": "S3 key for asset version \\"7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965\\"",
+    "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3VersionKey52B24F16": Object {
+      "Description": "S3 key for asset version \\"864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680\\"",
       "Type": "String",
     },
     "AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900ArtifactHash121EF458": Object {
@@ -45688,6 +45996,18 @@ Object {
       "Description": "S3 key for asset version \\"8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900\\"",
       "Type": "String",
     },
+    "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9ArtifactHash694505BF": Object {
+      "Description": "Artifact hash for asset \\"8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9\\"",
+      "Type": "String",
+    },
+    "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3BucketED9FB7B0": Object {
+      "Description": "S3 bucket for asset \\"8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9\\"",
+      "Type": "String",
+    },
+    "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3VersionKeyCFEDA3D4": Object {
+      "Description": "S3 key for asset version \\"8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9\\"",
+      "Type": "String",
+    },
     "AssetParameters8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064ArtifactHashEA963870": Object {
       "Description": "Artifact hash for asset \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
@@ -45700,16 +46020,16 @@ Object {
       "Description": "S3 key for asset version \\"8fb25fdd4f1ddeae2b028b9896c12ee4ce71b7b9a580a348a5d48a1459a2e064\\"",
       "Type": "String",
     },
-    "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8ArtifactHash8DC0C383": Object {
-      "Description": "Artifact hash for asset \\"9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8\\"",
+    "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4ArtifactHash660A50B8": Object {
+      "Description": "Artifact hash for asset \\"98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4\\"",
       "Type": "String",
     },
-    "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3Bucket1B95B117": Object {
-      "Description": "S3 bucket for asset \\"9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8\\"",
+    "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3BucketE78A0203": Object {
+      "Description": "S3 bucket for asset \\"98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4\\"",
       "Type": "String",
     },
-    "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3VersionKey75D92238": Object {
-      "Description": "S3 key for asset version \\"9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8\\"",
+    "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3VersionKey598098A7": Object {
+      "Description": "S3 key for asset version \\"98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4\\"",
       "Type": "String",
     },
     "AssetParametersa3058ccb468d757ebb89df5363a1c20f5307c6911136f29d00e1a68c9b2aa7e8ArtifactHash238275D6": Object {
@@ -45724,16 +46044,16 @@ Object {
       "Description": "S3 key for asset version \\"a3058ccb468d757ebb89df5363a1c20f5307c6911136f29d00e1a68c9b2aa7e8\\"",
       "Type": "String",
     },
-    "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdArtifactHash22ECD1BE": Object {
-      "Description": "Artifact hash for asset \\"adb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbd\\"",
+    "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaArtifactHash8CCAA809": Object {
+      "Description": "Artifact hash for asset \\"af643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfba\\"",
       "Type": "String",
     },
-    "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3BucketF9AF3C9C": Object {
-      "Description": "S3 bucket for asset \\"adb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbd\\"",
+    "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2": Object {
+      "Description": "S3 bucket for asset \\"af643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfba\\"",
       "Type": "String",
     },
-    "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3VersionKey09B12EB1": Object {
-      "Description": "S3 key for asset version \\"adb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbd\\"",
+    "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3VersionKeyEC7E3301": Object {
+      "Description": "S3 key for asset version \\"af643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfba\\"",
       "Type": "String",
     },
     "AssetParametersb120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827ArtifactHash1355580A": Object {
@@ -45748,16 +46068,40 @@ Object {
       "Description": "S3 key for asset version \\"b120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827\\"",
       "Type": "String",
     },
-    "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8ArtifactHashBB72DCC8": Object {
-      "Description": "Artifact hash for asset \\"c8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8\\"",
+    "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04ArtifactHash394183E9": Object {
+      "Description": "Artifact hash for asset \\"b55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04\\"",
       "Type": "String",
     },
-    "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3Bucket86DBA113": Object {
-      "Description": "S3 bucket for asset \\"c8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8\\"",
+    "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3BucketE7A02ACD": Object {
+      "Description": "S3 bucket for asset \\"b55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04\\"",
       "Type": "String",
     },
-    "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3VersionKeyF547CFB5": Object {
-      "Description": "S3 key for asset version \\"c8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8\\"",
+    "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3VersionKeyCC994D9E": Object {
+      "Description": "S3 key for asset version \\"b55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04\\"",
+      "Type": "String",
+    },
+    "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcArtifactHash4E26EEC4": Object {
+      "Description": "Artifact hash for asset \\"c62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafc\\"",
+      "Type": "String",
+    },
+    "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3Bucket5255533F": Object {
+      "Description": "S3 bucket for asset \\"c62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafc\\"",
+      "Type": "String",
+    },
+    "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3VersionKey7909F675": Object {
+      "Description": "S3 key for asset version \\"c62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafc\\"",
+      "Type": "String",
+    },
+    "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aArtifactHash0386B8EC": Object {
+      "Description": "Artifact hash for asset \\"da314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17a\\"",
+      "Type": "String",
+    },
+    "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3BucketAE80D773": Object {
+      "Description": "S3 bucket for asset \\"da314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17a\\"",
+      "Type": "String",
+    },
+    "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3VersionKey662F0E6F": Object {
+      "Description": "S3 key for asset version \\"da314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17a\\"",
       "Type": "String",
     },
     "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68ArtifactHashD9A515C3": Object {
@@ -45770,6 +46114,30 @@ Object {
     },
     "AssetParameterse9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68S3VersionKeyE415415F": Object {
       "Description": "S3 key for asset version \\"e9882ab123687399f934da0d45effe675ecc8ce13b40cb946f3e1d6141fe8d68\\"",
+      "Type": "String",
+    },
+    "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3ArtifactHash11DB5971": Object {
+      "Description": "Artifact hash for asset \\"f48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3\\"",
+      "Type": "String",
+    },
+    "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3BucketAC5DE359": Object {
+      "Description": "S3 bucket for asset \\"f48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3\\"",
+      "Type": "String",
+    },
+    "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3VersionKey503D22DC": Object {
+      "Description": "S3 key for asset version \\"f48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3\\"",
+      "Type": "String",
+    },
+    "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5ArtifactHash185A4671": Object {
+      "Description": "Artifact hash for asset \\"fbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5\\"",
+      "Type": "String",
+    },
+    "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3Bucket024B3DC6": Object {
+      "Description": "S3 bucket for asset \\"fbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5\\"",
+      "Type": "String",
+    },
+    "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3VersionKeyEEA56859": Object {
+      "Description": "S3 key for asset version \\"fbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5\\"",
       "Type": "String",
     },
   },
@@ -47127,7 +47495,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3Bucket288D5551",
+            "Ref": "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3BucketAE80D773",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -47140,7 +47508,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3VersionKey4638DF79",
+                          "Ref": "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3VersionKey662F0E6F",
                         },
                       ],
                     },
@@ -47153,7 +47521,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3VersionKey4638DF79",
+                          "Ref": "AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3VersionKey662F0E6F",
                         },
                       ],
                     },
@@ -47336,7 +47704,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3Bucket95F679AA",
+            "Ref": "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3BucketAC5DE359",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -47349,7 +47717,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3VersionKeyE7A4EEDD",
+                          "Ref": "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3VersionKey503D22DC",
                         },
                       ],
                     },
@@ -47362,7 +47730,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3VersionKeyE7A4EEDD",
+                          "Ref": "AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3VersionKey503D22DC",
                         },
                       ],
                     },
@@ -47602,7 +47970,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3Bucket8AFE0D2F",
+            "Ref": "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3BucketF13820EA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -47615,7 +47983,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3VersionKey39383E8E",
+                          "Ref": "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3VersionKey52B24F16",
                         },
                       ],
                     },
@@ -47628,7 +47996,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3VersionKey39383E8E",
+                          "Ref": "AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3VersionKey52B24F16",
                         },
                       ],
                     },
@@ -48115,7 +48483,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3Bucket0A90D6D3",
+            "Ref": "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3Bucket5255533F",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -48128,7 +48496,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3VersionKeyA116EF05",
+                          "Ref": "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3VersionKey7909F675",
                         },
                       ],
                     },
@@ -48141,7 +48509,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3VersionKeyA116EF05",
+                          "Ref": "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3VersionKey7909F675",
                         },
                       ],
                     },
@@ -48325,7 +48693,7 @@ Direct link to the function: /lambda/home#/functions/",
               Object {
                 "Ref": "ConstructHubPackageDataDC5EF35E",
               },
-              "\\",\\"Prefix\\":\\"data/\\"}},\\"Is there more?\\":{\\"Type\\":\\"Choice\\",\\"Choices\\":[{\\"Variable\\":\\"$.response.NextContinuationToken\\",\\"IsPresent\\":true,\\"Next\\":\\"Continue as new\\"}],\\"Default\\":\\"Process Result\\"},\\"S3.ListObjectsV2(NextPage)\\":{\\"Next\\":\\"Is there more?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"S3.SdkClientException\\"]}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.response\\",\\"Resource\\":\\"arn:",
+              "\\",\\"Prefix\\":\\"data/\\"}},\\"Is there more?\\":{\\"Type\\":\\"Choice\\",\\"Choices\\":[{\\"Variable\\":\\"$.response.NextContinuationToken\\",\\"IsPresent\\":true,\\"Next\\":\\"Give room for on-demand work\\"}],\\"Default\\":\\"Process Result\\"},\\"S3.ListObjectsV2(NextPage)\\":{\\"Next\\":\\"Is there more?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"S3.SdkClientException\\"]}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.response\\",\\"Resource\\":\\"arn:",
               Object {
                 "Ref": "AWS::Partition",
               },
@@ -48360,7 +48728,7 @@ Direct link to the function: /lambda/home#/functions/",
               Object {
                 "Ref": "AWS::AccountId",
               },
-              ":stateMachine:Test.ConstructHub.Ingestion.ReprocessWorkflow\\"}}},\\"TimeoutSeconds\\":3600}",
+              ":stateMachine:Test.ConstructHub.Ingestion.ReprocessWorkflow\\"}},\\"Give room for on-demand work\\":{\\"Type\\":\\"Wait\\",\\"Seconds\\":300,\\"Next\\":\\"Continue as new\\"}},\\"TimeoutSeconds\\":3600}",
             ],
           ],
         },
@@ -48916,7 +49284,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3Bucket649728C0",
+            "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3Bucket5515214C",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -48929,7 +49297,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3VersionKey592D485B",
+                          "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED",
                         },
                       ],
                     },
@@ -48942,7 +49310,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3VersionKey592D485B",
+                          "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED",
                         },
                       ],
                     },
@@ -49971,7 +50339,7 @@ Direct link to function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3Bucket635A0AFA",
+            "Ref": "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3BucketE7A02ACD",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -49984,7 +50352,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3VersionKeyBB104177",
+                          "Ref": "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3VersionKeyCC994D9E",
                         },
                       ],
                     },
@@ -49997,7 +50365,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3VersionKeyBB104177",
+                          "Ref": "AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3VersionKeyCC994D9E",
                         },
                       ],
                     },
@@ -50130,7 +50498,7 @@ Direct link to function: /lambda/home#/functions/",
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"StartAt\\":\\"Track Execution Infos\\",\\"States\\":{\\"Track Execution Infos\\":{\\"Type\\":\\"Pass\\",\\"ResultPath\\":\\"$.$TaskExecution\\",\\"InputPath\\":\\"$$.Execution\\",\\"Parameters\\":{\\"Id.$\\":\\"$.Id\\",\\"Name.$\\":\\"$.Name\\",\\"RoleArn.$\\":\\"$.RoleArn\\",\\"StartTime.$\\":\\"$.StartTime\\"},\\"Next\\":\\"Prepare doc-gen ECS Command\\"},\\"Prepare doc-gen ECS Command\\":{\\"Type\\":\\"Pass\\",\\"ResultPath\\":\\"$.docGen\\",\\"Parameters\\":{\\"command.$\\":\\"States.Array(States.JsonToString($))\\"},\\"Next\\":\\"Generate docs\\"},\\"Generate docs\\":{\\"Next\\":\\"Check whether catalog needs udpating\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"jsii-docgen.NoSpaceLeftOnDevice\\"],\\"MaxAttempts\\":0},{\\"ErrorEquals\\":[\\"ECS.AmazonECSException\\",\\"ECS.InvalidParameterException\\",\\"jsii-docgen.NpmError.E429\\",\\"jsii-codgen.NpmError.EPROTO\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":30,\\"BackoffRate\\":1.1},{\\"ErrorEquals\\":[\\"jsii-docgen.NpmError.ETARGET\\"],\\"IntervalSeconds\\":300,\\"MaxAttempts\\":3,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"MaxAttempts\\":3}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"UnprocessablePackageError\\"],\\"Next\\":\\"Ignore\\"},{\\"ErrorEquals\\":[\\"States.Timeout\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"ECS.AmazonECSException\\",\\"ECS.InvalidParameterException\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Type\\":\\"Task\\",\\"TimeoutSeconds\\":3600,\\"HeartbeatSeconds\\":300,\\"InputPath\\":\\"$.docGen.command\\",\\"ResultPath\\":\\"$.docGenOutput\\",\\"Resource\\":\\"arn:",
+              "{\\"StartAt\\":\\"Track Execution Infos\\",\\"States\\":{\\"Track Execution Infos\\":{\\"Type\\":\\"Pass\\",\\"ResultPath\\":\\"$.$TaskExecution\\",\\"InputPath\\":\\"$$.Execution\\",\\"Parameters\\":{\\"Id.$\\":\\"$.Id\\",\\"Name.$\\":\\"$.Name\\",\\"RoleArn.$\\":\\"$.RoleArn\\",\\"StartTime.$\\":\\"$.StartTime\\"},\\"Next\\":\\"Prepare doc-gen ECS Command\\"},\\"Prepare doc-gen ECS Command\\":{\\"Type\\":\\"Pass\\",\\"ResultPath\\":\\"$.docGen\\",\\"Parameters\\":{\\"command.$\\":\\"States.Array(States.JsonToString($))\\"},\\"Next\\":\\"Generate docs\\"},\\"Generate docs\\":{\\"Next\\":\\"Check whether catalog needs udpating\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"jsii-docgen.NoSpaceLeftOnDevice\\"],\\"MaxAttempts\\":0},{\\"ErrorEquals\\":[\\"ECS.AmazonECSException\\",\\"ECS.InvalidParameterException\\",\\"jsii-docgen.NpmError.E429\\",\\"jsii-codgen.NpmError.EPROTO\\"],\\"IntervalSeconds\\":120,\\"MaxAttempts\\":200,\\"BackoffRate\\":1},{\\"ErrorEquals\\":[\\"jsii-docgen.NpmError.ETARGET\\"],\\"IntervalSeconds\\":300,\\"MaxAttempts\\":3,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"MaxAttempts\\":3}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"UnprocessablePackageError\\"],\\"Next\\":\\"Ignore\\"},{\\"ErrorEquals\\":[\\"States.Timeout\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"ECS.AmazonECSException\\",\\"ECS.InvalidParameterException\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Type\\":\\"Task\\",\\"TimeoutSeconds\\":7200,\\"HeartbeatSeconds\\":300,\\"InputPath\\":\\"$.docGen.command\\",\\"ResultPath\\":\\"$.docGenOutput\\",\\"Resource\\":\\"arn:",
               Object {
                 "Ref": "AWS::Partition",
               },
@@ -50177,7 +50545,7 @@ Direct link to function: /lambda/home#/functions/",
                   "GroupId",
                 ],
               },
-              "\\"]}},\\"Overrides\\":{\\"ContainerOverrides\\":[{\\"Name\\":\\"Resource\\",\\"Command.$\\":\\"$\\",\\"Environment\\":[{\\"Name\\":\\"SFN_TASK_TOKEN\\",\\"Value.$\\":\\"$$.Task.Token\\"}]}]},\\"LaunchType\\":\\"FARGATE\\",\\"PlatformVersion\\":\\"1.4.0\\"}},\\"Check whether catalog needs udpating\\":{\\"Next\\":\\"Is catalog update needed?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"Lambda.ServiceException\\",\\"Lambda.AWSLambdaException\\",\\"Lambda.SdkClientException\\"],\\"IntervalSeconds\\":2,\\"MaxAttempts\\":6,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":30,\\"BackoffRate\\":1.1}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.catalogNeedsUpdating\\",\\"Resource\\":\\"",
+              "\\"]}},\\"Overrides\\":{\\"ContainerOverrides\\":[{\\"Name\\":\\"Resource\\",\\"Command.$\\":\\"$\\",\\"Environment\\":[{\\"Name\\":\\"SFN_TASK_TOKEN\\",\\"Value.$\\":\\"$$.Task.Token\\"}]}]},\\"LaunchType\\":\\"FARGATE\\",\\"PlatformVersion\\":\\"1.4.0\\"}},\\"Check whether catalog needs udpating\\":{\\"Next\\":\\"Is catalog update needed?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"Lambda.ServiceException\\",\\"Lambda.AWSLambdaException\\",\\"Lambda.SdkClientException\\"],\\"IntervalSeconds\\":2,\\"MaxAttempts\\":6,\\"BackoffRate\\":2},{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\",\\"Lambda.Unknown\\"],\\"IntervalSeconds\\":60,\\"MaxAttempts\\":30,\\"BackoffRate\\":1.1}],\\"Catch\\":[{\\"ErrorEquals\\":[\\"Lambda.TooManyRequestsException\\",\\"Lambda.Unknown\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.TaskFailed\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"},{\\"ErrorEquals\\":[\\"States.ALL\\"],\\"ResultPath\\":\\"$.error\\",\\"Next\\":\\"Send to Dead Letter Queue\\"}],\\"Type\\":\\"Task\\",\\"ResultPath\\":\\"$.catalogNeedsUpdating\\",\\"Resource\\":\\"",
               Object {
                 "Fn::GetAtt": Array [
                   "ConstructHubOrchestrationNeedsCatalogUpdate5D7370DC",
@@ -50228,7 +50596,7 @@ Direct link to function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3Bucket2D6D8F86",
+            "Ref": "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3Bucket722FE70B",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -50241,7 +50609,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3VersionKey0ECB40A6",
+                          "Ref": "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3VersionKey8082F3BC",
                         },
                       ],
                     },
@@ -50254,7 +50622,7 @@ Direct link to function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3VersionKey0ECB40A6",
+                          "Ref": "AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3VersionKey8082F3BC",
                         },
                       ],
                     },
@@ -50657,7 +51025,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3Bucket19B71C5A",
+            "Ref": "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3BucketE78A0203",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -50670,7 +51038,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3VersionKeyDF73A6F0",
+                          "Ref": "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3VersionKey598098A7",
                         },
                       ],
                     },
@@ -50683,7 +51051,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3VersionKeyDF73A6F0",
+                          "Ref": "AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3VersionKey598098A7",
                         },
                       ],
                     },
@@ -50841,7 +51209,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3Bucket1090210F",
+            "Ref": "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3Bucket6F376B71",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -50854,7 +51222,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3VersionKeyD738CD6B",
+                          "Ref": "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3VersionKey7F6E5804",
                         },
                       ],
                     },
@@ -50867,7 +51235,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3VersionKeyD738CD6B",
+                          "Ref": "AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3VersionKey7F6E5804",
                         },
                       ],
                     },
@@ -51651,7 +52019,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                   Object {
                     "Ref": "AWS::URLSuffix",
                   },
-                  "/aws-cdk/assets:5fa39a328f34360df81ad2f478b29e7f72b6625d60d6ca775401e69a3b2c0faf",
+                  "/aws-cdk/assets:89c6683e392b08bdb9bfd8e456f82a156b228534eed332191232b4aa0beec4f2",
                 ],
               ],
             },
@@ -51933,7 +52301,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.md",
+                      "/data/*/docs-typescript.*",
                     ],
                   ],
                 },
@@ -51963,7 +52331,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.md",
+                      "/data/*/docs-*-typescript.*",
                     ],
                   ],
                 },
@@ -51993,7 +52361,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.md.not-supported",
+                      "/data/*/docs-typescript.*.not-supported",
                     ],
                   ],
                 },
@@ -52023,7 +52391,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.md.not-supported",
+                      "/data/*/docs-*-typescript.*.not-supported",
                     ],
                   ],
                 },
@@ -52053,7 +52421,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.md.corruptassembly",
+                      "/data/*/docs-typescript.*.corruptassembly",
                     ],
                   ],
                 },
@@ -52083,7 +52451,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.md.corruptassembly",
+                      "/data/*/docs-*-typescript.*.corruptassembly",
                     ],
                   ],
                 },
@@ -52102,7 +52470,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-typescript.md.corruptassembly",
+                    "/data/*/docs-typescript.*.corruptassembly",
                   ],
                 ],
               },
@@ -52120,223 +52488,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-typescript.md.corruptassembly",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.md",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.md",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.md.not-supported",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.md.not-supported",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.md.corruptassembly",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.md.corruptassembly",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": "s3:DeleteObject*",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "ConstructHubPackageDataDC5EF35E",
-                        "Arn",
-                      ],
-                    },
-                    "/data/*/docs-python.md.corruptassembly",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": "s3:DeleteObject*",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "ConstructHubPackageDataDC5EF35E",
-                        "Arn",
-                      ],
-                    },
-                    "/data/*/docs-*-python.md.corruptassembly",
+                    "/data/*/docs-*-typescript.*.corruptassembly",
                   ],
                 ],
               },
@@ -52365,7 +52517,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.md",
+                      "/data/*/docs-python.*",
                     ],
                   ],
                 },
@@ -52395,7 +52547,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.md",
+                      "/data/*/docs-*-python.*",
                     ],
                   ],
                 },
@@ -52425,7 +52577,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.md.not-supported",
+                      "/data/*/docs-python.*.not-supported",
                     ],
                   ],
                 },
@@ -52455,7 +52607,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.md.not-supported",
+                      "/data/*/docs-*-python.*.not-supported",
                     ],
                   ],
                 },
@@ -52485,7 +52637,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.md.corruptassembly",
+                      "/data/*/docs-python.*.corruptassembly",
                     ],
                   ],
                 },
@@ -52515,7 +52667,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.md.corruptassembly",
+                      "/data/*/docs-*-python.*.corruptassembly",
                     ],
                   ],
                 },
@@ -52534,7 +52686,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-java.md.corruptassembly",
+                    "/data/*/docs-python.*.corruptassembly",
                   ],
                 ],
               },
@@ -52552,7 +52704,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-java.md.corruptassembly",
+                    "/data/*/docs-*-python.*.corruptassembly",
                   ],
                 ],
               },
@@ -52581,7 +52733,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.md",
+                      "/data/*/docs-java.*",
                     ],
                   ],
                 },
@@ -52611,7 +52763,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.md",
+                      "/data/*/docs-*-java.*",
                     ],
                   ],
                 },
@@ -52641,7 +52793,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.md.not-supported",
+                      "/data/*/docs-java.*.not-supported",
                     ],
                   ],
                 },
@@ -52671,7 +52823,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.md.not-supported",
+                      "/data/*/docs-*-java.*.not-supported",
                     ],
                   ],
                 },
@@ -52701,7 +52853,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.md.corruptassembly",
+                      "/data/*/docs-java.*.corruptassembly",
                     ],
                   ],
                 },
@@ -52731,7 +52883,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.md.corruptassembly",
+                      "/data/*/docs-*-java.*.corruptassembly",
                     ],
                   ],
                 },
@@ -52750,7 +52902,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-csharp.md.corruptassembly",
+                    "/data/*/docs-java.*.corruptassembly",
                   ],
                 ],
               },
@@ -52768,7 +52920,223 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-csharp.md.corruptassembly",
+                    "/data/*/docs-*-java.*.corruptassembly",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.*.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.*.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.*.corruptassembly",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.*.corruptassembly",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": "s3:DeleteObject*",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "ConstructHubPackageDataDC5EF35E",
+                        "Arn",
+                      ],
+                    },
+                    "/data/*/docs-csharp.*.corruptassembly",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:DeleteObject*",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "ConstructHubPackageDataDC5EF35E",
+                        "Arn",
+                      ],
+                    },
+                    "/data/*/docs-*-csharp.*.corruptassembly",
                   ],
                 ],
               },
@@ -53096,7 +53464,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3Bucket901B95EB",
+            "Ref": "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3Bucket024B3DC6",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -53109,7 +53477,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3VersionKeyC6FBD6BD",
+                          "Ref": "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3VersionKeyEEA56859",
                         },
                       ],
                     },
@@ -53122,7 +53490,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3VersionKeyC6FBD6BD",
+                          "Ref": "AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3VersionKeyEEA56859",
                         },
                       ],
                     },
@@ -53179,7 +53547,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3Bucket86DBA113",
+            "Ref": "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3Bucket37F2908E",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -53192,7 +53560,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3VersionKeyF547CFB5",
+                          "Ref": "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3VersionKey2C992F11",
                         },
                       ],
                     },
@@ -53205,7 +53573,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3VersionKeyF547CFB5",
+                          "Ref": "AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3VersionKey2C992F11",
                         },
                       ],
                     },
@@ -53768,7 +54136,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3BucketFFA964C8",
+            "Ref": "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3Bucket8AF0E263",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -53781,7 +54149,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3VersionKeyA62CD84A",
+                          "Ref": "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3VersionKey5280D545",
                         },
                       ],
                     },
@@ -53794,7 +54162,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3VersionKeyA62CD84A",
+                          "Ref": "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3VersionKey5280D545",
                         },
                       ],
                     },
@@ -54204,7 +54572,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3BucketE35D2278",
+            "Ref": "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3Bucket789CA701",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -54217,7 +54585,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3VersionKey88FA0AFA",
+                          "Ref": "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3VersionKey0222399F",
                         },
                       ],
                     },
@@ -54230,7 +54598,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3VersionKey88FA0AFA",
+                          "Ref": "AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3VersionKey0222399F",
                         },
                       ],
                     },
@@ -55270,7 +55638,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.md",
+                      "/data/*/docs-typescript.*",
                     ],
                   ],
                 },
@@ -55303,7 +55671,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.md",
+                      "/data/*/docs-*-typescript.*",
                     ],
                   ],
                 },
@@ -55336,7 +55704,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.md.not-supported",
+                      "/data/*/docs-typescript.*.not-supported",
                     ],
                   ],
                 },
@@ -55369,7 +55737,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.md.not-supported",
+                      "/data/*/docs-*-typescript.*.not-supported",
                     ],
                   ],
                 },
@@ -55402,7 +55770,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.md.corruptassembly",
+                      "/data/*/docs-typescript.*.corruptassembly",
                     ],
                   ],
                 },
@@ -55435,7 +55803,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.md.corruptassembly",
+                      "/data/*/docs-*-typescript.*.corruptassembly",
                     ],
                   ],
                 },
@@ -55457,7 +55825,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-typescript.md.corruptassembly",
+                    "/data/*/docs-typescript.*.corruptassembly",
                   ],
                 ],
               },
@@ -55478,247 +55846,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-typescript.md.corruptassembly",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "s3:Abort*",
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-              ],
-              "Effect": "Allow",
-              "Principal": Object {
-                "AWS": "*",
-              },
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.md",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:Abort*",
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-              ],
-              "Effect": "Allow",
-              "Principal": Object {
-                "AWS": "*",
-              },
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.md",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:Abort*",
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-              ],
-              "Effect": "Allow",
-              "Principal": Object {
-                "AWS": "*",
-              },
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.md.not-supported",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:Abort*",
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-              ],
-              "Effect": "Allow",
-              "Principal": Object {
-                "AWS": "*",
-              },
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.md.not-supported",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:Abort*",
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-              ],
-              "Effect": "Allow",
-              "Principal": Object {
-                "AWS": "*",
-              },
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.md.corruptassembly",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:Abort*",
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-              ],
-              "Effect": "Allow",
-              "Principal": Object {
-                "AWS": "*",
-              },
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.md.corruptassembly",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": "s3:DeleteObject*",
-              "Effect": "Allow",
-              "Principal": Object {
-                "AWS": "*",
-              },
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "ConstructHubPackageDataDC5EF35E",
-                        "Arn",
-                      ],
-                    },
-                    "/data/*/docs-python.md.corruptassembly",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": "s3:DeleteObject*",
-              "Effect": "Allow",
-              "Principal": Object {
-                "AWS": "*",
-              },
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "ConstructHubPackageDataDC5EF35E",
-                        "Arn",
-                      ],
-                    },
-                    "/data/*/docs-*-python.md.corruptassembly",
+                    "/data/*/docs-*-typescript.*.corruptassembly",
                   ],
                 ],
               },
@@ -55750,7 +55878,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.md",
+                      "/data/*/docs-python.*",
                     ],
                   ],
                 },
@@ -55783,7 +55911,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.md",
+                      "/data/*/docs-*-python.*",
                     ],
                   ],
                 },
@@ -55816,7 +55944,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.md.not-supported",
+                      "/data/*/docs-python.*.not-supported",
                     ],
                   ],
                 },
@@ -55849,7 +55977,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.md.not-supported",
+                      "/data/*/docs-*-python.*.not-supported",
                     ],
                   ],
                 },
@@ -55882,7 +56010,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.md.corruptassembly",
+                      "/data/*/docs-python.*.corruptassembly",
                     ],
                   ],
                 },
@@ -55915,7 +56043,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.md.corruptassembly",
+                      "/data/*/docs-*-python.*.corruptassembly",
                     ],
                   ],
                 },
@@ -55937,7 +56065,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-java.md.corruptassembly",
+                    "/data/*/docs-python.*.corruptassembly",
                   ],
                 ],
               },
@@ -55958,7 +56086,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-java.md.corruptassembly",
+                    "/data/*/docs-*-python.*.corruptassembly",
                   ],
                 ],
               },
@@ -55990,7 +56118,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.md",
+                      "/data/*/docs-java.*",
                     ],
                   ],
                 },
@@ -56023,7 +56151,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.md",
+                      "/data/*/docs-*-java.*",
                     ],
                   ],
                 },
@@ -56056,7 +56184,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.md.not-supported",
+                      "/data/*/docs-java.*.not-supported",
                     ],
                   ],
                 },
@@ -56089,7 +56217,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.md.not-supported",
+                      "/data/*/docs-*-java.*.not-supported",
                     ],
                   ],
                 },
@@ -56122,7 +56250,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.md.corruptassembly",
+                      "/data/*/docs-java.*.corruptassembly",
                     ],
                   ],
                 },
@@ -56155,7 +56283,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.md.corruptassembly",
+                      "/data/*/docs-*-java.*.corruptassembly",
                     ],
                   ],
                 },
@@ -56177,7 +56305,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-csharp.md.corruptassembly",
+                    "/data/*/docs-java.*.corruptassembly",
                   ],
                 ],
               },
@@ -56198,7 +56326,247 @@ Direct link to Lambda function: /lambda/home#/functions/",
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-csharp.md.corruptassembly",
+                    "/data/*/docs-*-java.*.corruptassembly",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "s3:Abort*",
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:Abort*",
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:Abort*",
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.*.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:Abort*",
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.*.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:Abort*",
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.*.corruptassembly",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:Abort*",
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConstructHubPackageDataDC5EF35E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConstructHubPackageDataDC5EF35E",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.*.corruptassembly",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": "s3:DeleteObject*",
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "ConstructHubPackageDataDC5EF35E",
+                        "Arn",
+                      ],
+                    },
+                    "/data/*/docs-csharp.*.corruptassembly",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:DeleteObject*",
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "ConstructHubPackageDataDC5EF35E",
+                        "Arn",
+                      ],
+                    },
+                    "/data/*/docs-*-csharp.*.corruptassembly",
                   ],
                 ],
               },
@@ -56331,7 +56699,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3BucketF9AF3C9C",
+            "Ref": "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3Bucket86412295",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -56344,7 +56712,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3VersionKey09B12EB1",
+                          "Ref": "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3VersionKeyE42DDF01",
                         },
                       ],
                     },
@@ -56357,7 +56725,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3VersionKey09B12EB1",
+                          "Ref": "AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3VersionKeyE42DDF01",
                         },
                       ],
                     },
@@ -56773,7 +57141,10 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1",
+            "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3BucketED9FB7B0",
+          },
+          Object {
+            "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
           },
         ],
         "SourceObjectKeys": Array [
@@ -56788,7 +57159,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3VersionKeyBA1CB663",
+                          "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3VersionKeyCFEDA3D4",
                         },
                       ],
                     },
@@ -56801,7 +57172,40 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3VersionKeyBA1CB663",
+                          "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3VersionKeyCFEDA3D4",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            ],
+          },
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                Object {
+                  "Fn::Select": Array [
+                    0,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                Object {
+                  "Fn::Select": Array [
+                    1,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3VersionKeyD4005C49",
                         },
                       ],
                     },
@@ -56836,7 +57240,7 @@ function handler(event) {
         },
         "SourceBucketNames": Array [
           Object {
-            "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22",
+            "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2",
           },
         ],
         "SourceObjectKeys": Array [
@@ -56851,7 +57255,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3VersionKeyCE5C5D3B",
+                          "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3VersionKeyEC7E3301",
                         },
                       ],
                     },
@@ -56864,7 +57268,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3VersionKeyCE5C5D3B",
+                          "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3VersionKeyEC7E3301",
                         },
                       ],
                     },
@@ -57953,7 +58357,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22",
+                        "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2",
                       },
                     ],
                   ],
@@ -57968,7 +58372,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22",
+                        "Ref": "AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2",
                       },
                       "/*",
                     ],
@@ -58035,7 +58439,7 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1",
+                        "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3BucketED9FB7B0",
                       },
                     ],
                   ],
@@ -58050,7 +58454,48 @@ function handler(event) {
                       },
                       ":s3:::",
                       Object {
-                        "Ref": "AssetParameters1ef02545cadd99d0fc6793d14f2c55528cc3c1edf2efca0f2c74baaddcd12aa3S3BucketE00C5BA1",
+                        "Ref": "AssetParameters8e40194f1bb22dcfaa8ff2e11170472fa310d97b337f10421a1ae42de5cf2ee9S3BucketED9FB7B0",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
+                      },
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Ref": "AssetParameters061e88ffd868a1ff65cc53985577df8b1d2f220e28800ab309a3320c5dc5d440S3Bucket402F3054",
                       },
                       "/*",
                     ],
@@ -58278,7 +58723,7 @@ function handler(event) {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3Bucket1B95B117",
+            "Ref": "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3BucketCBEF8050",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -58291,7 +58736,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3VersionKey75D92238",
+                          "Ref": "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3VersionKey57968381",
                         },
                       ],
                     },
@@ -58304,7 +58749,7 @@ function handler(event) {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3VersionKey75D92238",
+                          "Ref": "AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3VersionKey57968381",
                         },
                       ],
                     },

--- a/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
+++ b/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
@@ -164,7 +164,7 @@ Object {
                   Object {
                     "Ref": "AWS::URLSuffix",
                   },
-                  "/aws-cdk/assets:89c6683e392b08bdb9bfd8e456f82a156b228534eed332191232b4aa0beec4f2",
+                  "/aws-cdk/assets:5fa39a328f34360df81ad2f478b29e7f72b6625d60d6ca775401e69a3b2c0faf",
                 ],
               ],
             },
@@ -484,7 +484,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.*",
+                      "/data/*/docs-typescript.md",
                     ],
                   ],
                 },
@@ -514,7 +514,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.*",
+                      "/data/*/docs-*-typescript.md",
                     ],
                   ],
                 },
@@ -544,7 +544,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.*.not-supported",
+                      "/data/*/docs-typescript.md.not-supported",
                     ],
                   ],
                 },
@@ -574,7 +574,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.*.not-supported",
+                      "/data/*/docs-*-typescript.md.not-supported",
                     ],
                   ],
                 },
@@ -604,7 +604,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.*.corruptassembly",
+                      "/data/*/docs-typescript.md.corruptassembly",
                     ],
                   ],
                 },
@@ -634,7 +634,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.*.corruptassembly",
+                      "/data/*/docs-*-typescript.md.corruptassembly",
                     ],
                   ],
                 },
@@ -653,7 +653,7 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-typescript.*.corruptassembly",
+                    "/data/*/docs-typescript.md.corruptassembly",
                   ],
                 ],
               },
@@ -671,223 +671,7 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-typescript.*.corruptassembly",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.*.not-supported",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.*.not-supported",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.*.corruptassembly",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.*.corruptassembly",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": "s3:DeleteObject*",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "Bucket83908E77",
-                        "Arn",
-                      ],
-                    },
-                    "/data/*/docs-python.*.corruptassembly",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": "s3:DeleteObject*",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "Bucket83908E77",
-                        "Arn",
-                      ],
-                    },
-                    "/data/*/docs-*-python.*.corruptassembly",
+                    "/data/*/docs-*-typescript.md.corruptassembly",
                   ],
                 ],
               },
@@ -916,7 +700,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.*",
+                      "/data/*/docs-python.md",
                     ],
                   ],
                 },
@@ -946,7 +730,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.*",
+                      "/data/*/docs-*-python.md",
                     ],
                   ],
                 },
@@ -976,7 +760,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.*.not-supported",
+                      "/data/*/docs-python.md.not-supported",
                     ],
                   ],
                 },
@@ -1006,7 +790,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.*.not-supported",
+                      "/data/*/docs-*-python.md.not-supported",
                     ],
                   ],
                 },
@@ -1036,7 +820,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.*.corruptassembly",
+                      "/data/*/docs-python.md.corruptassembly",
                     ],
                   ],
                 },
@@ -1066,7 +850,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.*.corruptassembly",
+                      "/data/*/docs-*-python.md.corruptassembly",
                     ],
                   ],
                 },
@@ -1085,7 +869,7 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-java.*.corruptassembly",
+                    "/data/*/docs-python.md.corruptassembly",
                   ],
                 ],
               },
@@ -1103,7 +887,7 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-java.*.corruptassembly",
+                    "/data/*/docs-*-python.md.corruptassembly",
                   ],
                 ],
               },
@@ -1132,7 +916,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.*",
+                      "/data/*/docs-java.md",
                     ],
                   ],
                 },
@@ -1162,7 +946,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.*",
+                      "/data/*/docs-*-java.md",
                     ],
                   ],
                 },
@@ -1192,7 +976,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.*.not-supported",
+                      "/data/*/docs-java.md.not-supported",
                     ],
                   ],
                 },
@@ -1222,7 +1006,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.*.not-supported",
+                      "/data/*/docs-*-java.md.not-supported",
                     ],
                   ],
                 },
@@ -1252,7 +1036,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.*.corruptassembly",
+                      "/data/*/docs-java.md.corruptassembly",
                     ],
                   ],
                 },
@@ -1282,7 +1066,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.*.corruptassembly",
+                      "/data/*/docs-*-java.md.corruptassembly",
                     ],
                   ],
                 },
@@ -1301,7 +1085,7 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-csharp.*.corruptassembly",
+                    "/data/*/docs-java.md.corruptassembly",
                   ],
                 ],
               },
@@ -1319,7 +1103,223 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-csharp.*.corruptassembly",
+                    "/data/*/docs-*-java.md.corruptassembly",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.md",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.md",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.md.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.md.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.md.corruptassembly",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.md.corruptassembly",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": "s3:DeleteObject*",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "Bucket83908E77",
+                        "Arn",
+                      ],
+                    },
+                    "/data/*/docs-csharp.md.corruptassembly",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:DeleteObject*",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "Bucket83908E77",
+                        "Arn",
+                      ],
+                    },
+                    "/data/*/docs-*-csharp.md.corruptassembly",
                   ],
                 ],
               },
@@ -1409,7 +1409,7 @@ Object {
                   Object {
                     "Ref": "AWS::URLSuffix",
                   },
-                  "/aws-cdk/assets:89c6683e392b08bdb9bfd8e456f82a156b228534eed332191232b4aa0beec4f2",
+                  "/aws-cdk/assets:5fa39a328f34360df81ad2f478b29e7f72b6625d60d6ca775401e69a3b2c0faf",
                 ],
               ],
             },
@@ -1691,7 +1691,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.*",
+                      "/data/*/docs-typescript.md",
                     ],
                   ],
                 },
@@ -1721,7 +1721,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.*",
+                      "/data/*/docs-*-typescript.md",
                     ],
                   ],
                 },
@@ -1751,7 +1751,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.*.not-supported",
+                      "/data/*/docs-typescript.md.not-supported",
                     ],
                   ],
                 },
@@ -1781,7 +1781,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.*.not-supported",
+                      "/data/*/docs-*-typescript.md.not-supported",
                     ],
                   ],
                 },
@@ -1811,7 +1811,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.*.corruptassembly",
+                      "/data/*/docs-typescript.md.corruptassembly",
                     ],
                   ],
                 },
@@ -1841,7 +1841,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.*.corruptassembly",
+                      "/data/*/docs-*-typescript.md.corruptassembly",
                     ],
                   ],
                 },
@@ -1860,7 +1860,7 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-typescript.*.corruptassembly",
+                    "/data/*/docs-typescript.md.corruptassembly",
                   ],
                 ],
               },
@@ -1878,223 +1878,7 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-typescript.*.corruptassembly",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.*.not-supported",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.*.not-supported",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.*.corruptassembly",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.*.corruptassembly",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": "s3:DeleteObject*",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "Bucket83908E77",
-                        "Arn",
-                      ],
-                    },
-                    "/data/*/docs-python.*.corruptassembly",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": "s3:DeleteObject*",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "Bucket83908E77",
-                        "Arn",
-                      ],
-                    },
-                    "/data/*/docs-*-python.*.corruptassembly",
+                    "/data/*/docs-*-typescript.md.corruptassembly",
                   ],
                 ],
               },
@@ -2123,7 +1907,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.*",
+                      "/data/*/docs-python.md",
                     ],
                   ],
                 },
@@ -2153,7 +1937,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.*",
+                      "/data/*/docs-*-python.md",
                     ],
                   ],
                 },
@@ -2183,7 +1967,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.*.not-supported",
+                      "/data/*/docs-python.md.not-supported",
                     ],
                   ],
                 },
@@ -2213,7 +1997,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.*.not-supported",
+                      "/data/*/docs-*-python.md.not-supported",
                     ],
                   ],
                 },
@@ -2243,7 +2027,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.*.corruptassembly",
+                      "/data/*/docs-python.md.corruptassembly",
                     ],
                   ],
                 },
@@ -2273,7 +2057,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.*.corruptassembly",
+                      "/data/*/docs-*-python.md.corruptassembly",
                     ],
                   ],
                 },
@@ -2292,7 +2076,7 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-java.*.corruptassembly",
+                    "/data/*/docs-python.md.corruptassembly",
                   ],
                 ],
               },
@@ -2310,7 +2094,7 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-java.*.corruptassembly",
+                    "/data/*/docs-*-python.md.corruptassembly",
                   ],
                 ],
               },
@@ -2339,7 +2123,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.*",
+                      "/data/*/docs-java.md",
                     ],
                   ],
                 },
@@ -2369,7 +2153,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.*",
+                      "/data/*/docs-*-java.md",
                     ],
                   ],
                 },
@@ -2399,7 +2183,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.*.not-supported",
+                      "/data/*/docs-java.md.not-supported",
                     ],
                   ],
                 },
@@ -2429,7 +2213,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.*.not-supported",
+                      "/data/*/docs-*-java.md.not-supported",
                     ],
                   ],
                 },
@@ -2459,7 +2243,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.*.corruptassembly",
+                      "/data/*/docs-java.md.corruptassembly",
                     ],
                   ],
                 },
@@ -2489,7 +2273,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.*.corruptassembly",
+                      "/data/*/docs-*-java.md.corruptassembly",
                     ],
                   ],
                 },
@@ -2508,7 +2292,7 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-csharp.*.corruptassembly",
+                    "/data/*/docs-java.md.corruptassembly",
                   ],
                 ],
               },
@@ -2526,7 +2310,223 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-csharp.*.corruptassembly",
+                    "/data/*/docs-*-java.md.corruptassembly",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.md",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.md",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.md.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.md.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.md.corruptassembly",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.md.corruptassembly",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": "s3:DeleteObject*",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "Bucket83908E77",
+                        "Arn",
+                      ],
+                    },
+                    "/data/*/docs-csharp.md.corruptassembly",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:DeleteObject*",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "Bucket83908E77",
+                        "Arn",
+                      ],
+                    },
+                    "/data/*/docs-*-csharp.md.corruptassembly",
                   ],
                 ],
               },
@@ -2768,7 +2768,7 @@ Object {
                   Object {
                     "Ref": "AWS::URLSuffix",
                   },
-                  "/aws-cdk/assets:89c6683e392b08bdb9bfd8e456f82a156b228534eed332191232b4aa0beec4f2",
+                  "/aws-cdk/assets:5fa39a328f34360df81ad2f478b29e7f72b6625d60d6ca775401e69a3b2c0faf",
                 ],
               ],
             },
@@ -3088,7 +3088,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.*",
+                      "/data/*/docs-typescript.md",
                     ],
                   ],
                 },
@@ -3118,7 +3118,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.*",
+                      "/data/*/docs-*-typescript.md",
                     ],
                   ],
                 },
@@ -3148,7 +3148,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.*.not-supported",
+                      "/data/*/docs-typescript.md.not-supported",
                     ],
                   ],
                 },
@@ -3178,7 +3178,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.*.not-supported",
+                      "/data/*/docs-*-typescript.md.not-supported",
                     ],
                   ],
                 },
@@ -3208,7 +3208,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.*.corruptassembly",
+                      "/data/*/docs-typescript.md.corruptassembly",
                     ],
                   ],
                 },
@@ -3238,7 +3238,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.*.corruptassembly",
+                      "/data/*/docs-*-typescript.md.corruptassembly",
                     ],
                   ],
                 },
@@ -3257,7 +3257,7 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-typescript.*.corruptassembly",
+                    "/data/*/docs-typescript.md.corruptassembly",
                   ],
                 ],
               },
@@ -3275,223 +3275,7 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-typescript.*.corruptassembly",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.*.not-supported",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.*.not-supported",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.*.corruptassembly",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.*.corruptassembly",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": "s3:DeleteObject*",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "Bucket83908E77",
-                        "Arn",
-                      ],
-                    },
-                    "/data/*/docs-python.*.corruptassembly",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": "s3:DeleteObject*",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "Bucket83908E77",
-                        "Arn",
-                      ],
-                    },
-                    "/data/*/docs-*-python.*.corruptassembly",
+                    "/data/*/docs-*-typescript.md.corruptassembly",
                   ],
                 ],
               },
@@ -3520,7 +3304,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.*",
+                      "/data/*/docs-python.md",
                     ],
                   ],
                 },
@@ -3550,7 +3334,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.*",
+                      "/data/*/docs-*-python.md",
                     ],
                   ],
                 },
@@ -3580,7 +3364,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.*.not-supported",
+                      "/data/*/docs-python.md.not-supported",
                     ],
                   ],
                 },
@@ -3610,7 +3394,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.*.not-supported",
+                      "/data/*/docs-*-python.md.not-supported",
                     ],
                   ],
                 },
@@ -3640,7 +3424,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.*.corruptassembly",
+                      "/data/*/docs-python.md.corruptassembly",
                     ],
                   ],
                 },
@@ -3670,7 +3454,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.*.corruptassembly",
+                      "/data/*/docs-*-python.md.corruptassembly",
                     ],
                   ],
                 },
@@ -3689,7 +3473,7 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-java.*.corruptassembly",
+                    "/data/*/docs-python.md.corruptassembly",
                   ],
                 ],
               },
@@ -3707,7 +3491,7 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-java.*.corruptassembly",
+                    "/data/*/docs-*-python.md.corruptassembly",
                   ],
                 ],
               },
@@ -3736,7 +3520,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.*",
+                      "/data/*/docs-java.md",
                     ],
                   ],
                 },
@@ -3766,7 +3550,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.*",
+                      "/data/*/docs-*-java.md",
                     ],
                   ],
                 },
@@ -3796,7 +3580,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.*.not-supported",
+                      "/data/*/docs-java.md.not-supported",
                     ],
                   ],
                 },
@@ -3826,7 +3610,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.*.not-supported",
+                      "/data/*/docs-*-java.md.not-supported",
                     ],
                   ],
                 },
@@ -3856,7 +3640,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.*.corruptassembly",
+                      "/data/*/docs-java.md.corruptassembly",
                     ],
                   ],
                 },
@@ -3886,7 +3670,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.*.corruptassembly",
+                      "/data/*/docs-*-java.md.corruptassembly",
                     ],
                   ],
                 },
@@ -3905,7 +3689,7 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-csharp.*.corruptassembly",
+                    "/data/*/docs-java.md.corruptassembly",
                   ],
                 ],
               },
@@ -3923,7 +3707,223 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-csharp.*.corruptassembly",
+                    "/data/*/docs-*-java.md.corruptassembly",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.md",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.md",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.md.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.md.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.md.corruptassembly",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.md.corruptassembly",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": "s3:DeleteObject*",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "Bucket83908E77",
+                        "Arn",
+                      ],
+                    },
+                    "/data/*/docs-csharp.md.corruptassembly",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:DeleteObject*",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "Bucket83908E77",
+                        "Arn",
+                      ],
+                    },
+                    "/data/*/docs-*-csharp.md.corruptassembly",
                   ],
                 ],
               },
@@ -4009,7 +4009,7 @@ Object {
                   Object {
                     "Ref": "AWS::URLSuffix",
                   },
-                  "/aws-cdk/assets:89c6683e392b08bdb9bfd8e456f82a156b228534eed332191232b4aa0beec4f2",
+                  "/aws-cdk/assets:5fa39a328f34360df81ad2f478b29e7f72b6625d60d6ca775401e69a3b2c0faf",
                 ],
               ],
             },
@@ -4291,7 +4291,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.*",
+                      "/data/*/docs-typescript.md",
                     ],
                   ],
                 },
@@ -4321,7 +4321,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.*",
+                      "/data/*/docs-*-typescript.md",
                     ],
                   ],
                 },
@@ -4351,7 +4351,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.*.not-supported",
+                      "/data/*/docs-typescript.md.not-supported",
                     ],
                   ],
                 },
@@ -4381,7 +4381,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.*.not-supported",
+                      "/data/*/docs-*-typescript.md.not-supported",
                     ],
                   ],
                 },
@@ -4411,7 +4411,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.*.corruptassembly",
+                      "/data/*/docs-typescript.md.corruptassembly",
                     ],
                   ],
                 },
@@ -4441,7 +4441,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.*.corruptassembly",
+                      "/data/*/docs-*-typescript.md.corruptassembly",
                     ],
                   ],
                 },
@@ -4460,7 +4460,7 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-typescript.*.corruptassembly",
+                    "/data/*/docs-typescript.md.corruptassembly",
                   ],
                 ],
               },
@@ -4478,223 +4478,7 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-typescript.*.corruptassembly",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.*.not-supported",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.*.not-supported",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.*.corruptassembly",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.*.corruptassembly",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": "s3:DeleteObject*",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "Bucket83908E77",
-                        "Arn",
-                      ],
-                    },
-                    "/data/*/docs-python.*.corruptassembly",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": "s3:DeleteObject*",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "Bucket83908E77",
-                        "Arn",
-                      ],
-                    },
-                    "/data/*/docs-*-python.*.corruptassembly",
+                    "/data/*/docs-*-typescript.md.corruptassembly",
                   ],
                 ],
               },
@@ -4723,7 +4507,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.*",
+                      "/data/*/docs-python.md",
                     ],
                   ],
                 },
@@ -4753,7 +4537,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.*",
+                      "/data/*/docs-*-python.md",
                     ],
                   ],
                 },
@@ -4783,7 +4567,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.*.not-supported",
+                      "/data/*/docs-python.md.not-supported",
                     ],
                   ],
                 },
@@ -4813,7 +4597,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.*.not-supported",
+                      "/data/*/docs-*-python.md.not-supported",
                     ],
                   ],
                 },
@@ -4843,7 +4627,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.*.corruptassembly",
+                      "/data/*/docs-python.md.corruptassembly",
                     ],
                   ],
                 },
@@ -4873,7 +4657,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.*.corruptassembly",
+                      "/data/*/docs-*-python.md.corruptassembly",
                     ],
                   ],
                 },
@@ -4892,7 +4676,7 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-java.*.corruptassembly",
+                    "/data/*/docs-python.md.corruptassembly",
                   ],
                 ],
               },
@@ -4910,7 +4694,7 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-java.*.corruptassembly",
+                    "/data/*/docs-*-python.md.corruptassembly",
                   ],
                 ],
               },
@@ -4939,7 +4723,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.*",
+                      "/data/*/docs-java.md",
                     ],
                   ],
                 },
@@ -4969,7 +4753,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.*",
+                      "/data/*/docs-*-java.md",
                     ],
                   ],
                 },
@@ -4999,7 +4783,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.*.not-supported",
+                      "/data/*/docs-java.md.not-supported",
                     ],
                   ],
                 },
@@ -5029,7 +4813,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.*.not-supported",
+                      "/data/*/docs-*-java.md.not-supported",
                     ],
                   ],
                 },
@@ -5059,7 +4843,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.*.corruptassembly",
+                      "/data/*/docs-java.md.corruptassembly",
                     ],
                   ],
                 },
@@ -5089,7 +4873,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.*.corruptassembly",
+                      "/data/*/docs-*-java.md.corruptassembly",
                     ],
                   ],
                 },
@@ -5108,7 +4892,7 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-csharp.*.corruptassembly",
+                    "/data/*/docs-java.md.corruptassembly",
                   ],
                 ],
               },
@@ -5126,7 +4910,223 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-csharp.*.corruptassembly",
+                    "/data/*/docs-*-java.md.corruptassembly",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.md",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.md",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.md.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.md.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.md.corruptassembly",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.md.corruptassembly",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": "s3:DeleteObject*",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "Bucket83908E77",
+                        "Arn",
+                      ],
+                    },
+                    "/data/*/docs-csharp.md.corruptassembly",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:DeleteObject*",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "Bucket83908E77",
+                        "Arn",
+                      ],
+                    },
+                    "/data/*/docs-*-csharp.md.corruptassembly",
                   ],
                 ],
               },

--- a/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
+++ b/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
@@ -164,7 +164,7 @@ Object {
                   Object {
                     "Ref": "AWS::URLSuffix",
                   },
-                  "/aws-cdk/assets:5fa39a328f34360df81ad2f478b29e7f72b6625d60d6ca775401e69a3b2c0faf",
+                  "/aws-cdk/assets:89c6683e392b08bdb9bfd8e456f82a156b228534eed332191232b4aa0beec4f2",
                 ],
               ],
             },
@@ -484,7 +484,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.md",
+                      "/data/*/docs-typescript.*",
                     ],
                   ],
                 },
@@ -514,7 +514,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.md",
+                      "/data/*/docs-*-typescript.*",
                     ],
                   ],
                 },
@@ -544,7 +544,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.md.not-supported",
+                      "/data/*/docs-typescript.*.not-supported",
                     ],
                   ],
                 },
@@ -574,7 +574,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.md.not-supported",
+                      "/data/*/docs-*-typescript.*.not-supported",
                     ],
                   ],
                 },
@@ -604,7 +604,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.md.corruptassembly",
+                      "/data/*/docs-typescript.*.corruptassembly",
                     ],
                   ],
                 },
@@ -634,7 +634,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.md.corruptassembly",
+                      "/data/*/docs-*-typescript.*.corruptassembly",
                     ],
                   ],
                 },
@@ -653,7 +653,7 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-typescript.md.corruptassembly",
+                    "/data/*/docs-typescript.*.corruptassembly",
                   ],
                 ],
               },
@@ -671,223 +671,7 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-typescript.md.corruptassembly",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.md",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.md",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.md.not-supported",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.md.not-supported",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.md.corruptassembly",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.md.corruptassembly",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": "s3:DeleteObject*",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "Bucket83908E77",
-                        "Arn",
-                      ],
-                    },
-                    "/data/*/docs-python.md.corruptassembly",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": "s3:DeleteObject*",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "Bucket83908E77",
-                        "Arn",
-                      ],
-                    },
-                    "/data/*/docs-*-python.md.corruptassembly",
+                    "/data/*/docs-*-typescript.*.corruptassembly",
                   ],
                 ],
               },
@@ -916,7 +700,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.md",
+                      "/data/*/docs-python.*",
                     ],
                   ],
                 },
@@ -946,7 +730,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.md",
+                      "/data/*/docs-*-python.*",
                     ],
                   ],
                 },
@@ -976,7 +760,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.md.not-supported",
+                      "/data/*/docs-python.*.not-supported",
                     ],
                   ],
                 },
@@ -1006,7 +790,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.md.not-supported",
+                      "/data/*/docs-*-python.*.not-supported",
                     ],
                   ],
                 },
@@ -1036,7 +820,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.md.corruptassembly",
+                      "/data/*/docs-python.*.corruptassembly",
                     ],
                   ],
                 },
@@ -1066,7 +850,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.md.corruptassembly",
+                      "/data/*/docs-*-python.*.corruptassembly",
                     ],
                   ],
                 },
@@ -1085,7 +869,7 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-java.md.corruptassembly",
+                    "/data/*/docs-python.*.corruptassembly",
                   ],
                 ],
               },
@@ -1103,7 +887,7 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-java.md.corruptassembly",
+                    "/data/*/docs-*-python.*.corruptassembly",
                   ],
                 ],
               },
@@ -1132,7 +916,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.md",
+                      "/data/*/docs-java.*",
                     ],
                   ],
                 },
@@ -1162,7 +946,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.md",
+                      "/data/*/docs-*-java.*",
                     ],
                   ],
                 },
@@ -1192,7 +976,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.md.not-supported",
+                      "/data/*/docs-java.*.not-supported",
                     ],
                   ],
                 },
@@ -1222,7 +1006,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.md.not-supported",
+                      "/data/*/docs-*-java.*.not-supported",
                     ],
                   ],
                 },
@@ -1252,7 +1036,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.md.corruptassembly",
+                      "/data/*/docs-java.*.corruptassembly",
                     ],
                   ],
                 },
@@ -1282,7 +1066,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.md.corruptassembly",
+                      "/data/*/docs-*-java.*.corruptassembly",
                     ],
                   ],
                 },
@@ -1301,7 +1085,7 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-csharp.md.corruptassembly",
+                    "/data/*/docs-java.*.corruptassembly",
                   ],
                 ],
               },
@@ -1319,7 +1103,223 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-csharp.md.corruptassembly",
+                    "/data/*/docs-*-java.*.corruptassembly",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.*.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.*.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.*.corruptassembly",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.*.corruptassembly",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": "s3:DeleteObject*",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "Bucket83908E77",
+                        "Arn",
+                      ],
+                    },
+                    "/data/*/docs-csharp.*.corruptassembly",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:DeleteObject*",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "Bucket83908E77",
+                        "Arn",
+                      ],
+                    },
+                    "/data/*/docs-*-csharp.*.corruptassembly",
                   ],
                 ],
               },
@@ -1409,7 +1409,7 @@ Object {
                   Object {
                     "Ref": "AWS::URLSuffix",
                   },
-                  "/aws-cdk/assets:5fa39a328f34360df81ad2f478b29e7f72b6625d60d6ca775401e69a3b2c0faf",
+                  "/aws-cdk/assets:89c6683e392b08bdb9bfd8e456f82a156b228534eed332191232b4aa0beec4f2",
                 ],
               ],
             },
@@ -1691,7 +1691,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.md",
+                      "/data/*/docs-typescript.*",
                     ],
                   ],
                 },
@@ -1721,7 +1721,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.md",
+                      "/data/*/docs-*-typescript.*",
                     ],
                   ],
                 },
@@ -1751,7 +1751,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.md.not-supported",
+                      "/data/*/docs-typescript.*.not-supported",
                     ],
                   ],
                 },
@@ -1781,7 +1781,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.md.not-supported",
+                      "/data/*/docs-*-typescript.*.not-supported",
                     ],
                   ],
                 },
@@ -1811,7 +1811,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.md.corruptassembly",
+                      "/data/*/docs-typescript.*.corruptassembly",
                     ],
                   ],
                 },
@@ -1841,7 +1841,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.md.corruptassembly",
+                      "/data/*/docs-*-typescript.*.corruptassembly",
                     ],
                   ],
                 },
@@ -1860,7 +1860,7 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-typescript.md.corruptassembly",
+                    "/data/*/docs-typescript.*.corruptassembly",
                   ],
                 ],
               },
@@ -1878,223 +1878,7 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-typescript.md.corruptassembly",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.md",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.md",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.md.not-supported",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.md.not-supported",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.md.corruptassembly",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.md.corruptassembly",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": "s3:DeleteObject*",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "Bucket83908E77",
-                        "Arn",
-                      ],
-                    },
-                    "/data/*/docs-python.md.corruptassembly",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": "s3:DeleteObject*",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "Bucket83908E77",
-                        "Arn",
-                      ],
-                    },
-                    "/data/*/docs-*-python.md.corruptassembly",
+                    "/data/*/docs-*-typescript.*.corruptassembly",
                   ],
                 ],
               },
@@ -2123,7 +1907,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.md",
+                      "/data/*/docs-python.*",
                     ],
                   ],
                 },
@@ -2153,7 +1937,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.md",
+                      "/data/*/docs-*-python.*",
                     ],
                   ],
                 },
@@ -2183,7 +1967,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.md.not-supported",
+                      "/data/*/docs-python.*.not-supported",
                     ],
                   ],
                 },
@@ -2213,7 +1997,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.md.not-supported",
+                      "/data/*/docs-*-python.*.not-supported",
                     ],
                   ],
                 },
@@ -2243,7 +2027,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.md.corruptassembly",
+                      "/data/*/docs-python.*.corruptassembly",
                     ],
                   ],
                 },
@@ -2273,7 +2057,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.md.corruptassembly",
+                      "/data/*/docs-*-python.*.corruptassembly",
                     ],
                   ],
                 },
@@ -2292,7 +2076,7 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-java.md.corruptassembly",
+                    "/data/*/docs-python.*.corruptassembly",
                   ],
                 ],
               },
@@ -2310,7 +2094,7 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-java.md.corruptassembly",
+                    "/data/*/docs-*-python.*.corruptassembly",
                   ],
                 ],
               },
@@ -2339,7 +2123,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.md",
+                      "/data/*/docs-java.*",
                     ],
                   ],
                 },
@@ -2369,7 +2153,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.md",
+                      "/data/*/docs-*-java.*",
                     ],
                   ],
                 },
@@ -2399,7 +2183,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.md.not-supported",
+                      "/data/*/docs-java.*.not-supported",
                     ],
                   ],
                 },
@@ -2429,7 +2213,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.md.not-supported",
+                      "/data/*/docs-*-java.*.not-supported",
                     ],
                   ],
                 },
@@ -2459,7 +2243,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.md.corruptassembly",
+                      "/data/*/docs-java.*.corruptassembly",
                     ],
                   ],
                 },
@@ -2489,7 +2273,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.md.corruptassembly",
+                      "/data/*/docs-*-java.*.corruptassembly",
                     ],
                   ],
                 },
@@ -2508,7 +2292,7 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-csharp.md.corruptassembly",
+                    "/data/*/docs-java.*.corruptassembly",
                   ],
                 ],
               },
@@ -2526,7 +2310,223 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-csharp.md.corruptassembly",
+                    "/data/*/docs-*-java.*.corruptassembly",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.*.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.*.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.*.corruptassembly",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.*.corruptassembly",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": "s3:DeleteObject*",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "Bucket83908E77",
+                        "Arn",
+                      ],
+                    },
+                    "/data/*/docs-csharp.*.corruptassembly",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:DeleteObject*",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "Bucket83908E77",
+                        "Arn",
+                      ],
+                    },
+                    "/data/*/docs-*-csharp.*.corruptassembly",
                   ],
                 ],
               },
@@ -2768,7 +2768,7 @@ Object {
                   Object {
                     "Ref": "AWS::URLSuffix",
                   },
-                  "/aws-cdk/assets:5fa39a328f34360df81ad2f478b29e7f72b6625d60d6ca775401e69a3b2c0faf",
+                  "/aws-cdk/assets:89c6683e392b08bdb9bfd8e456f82a156b228534eed332191232b4aa0beec4f2",
                 ],
               ],
             },
@@ -3088,7 +3088,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.md",
+                      "/data/*/docs-typescript.*",
                     ],
                   ],
                 },
@@ -3118,7 +3118,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.md",
+                      "/data/*/docs-*-typescript.*",
                     ],
                   ],
                 },
@@ -3148,7 +3148,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.md.not-supported",
+                      "/data/*/docs-typescript.*.not-supported",
                     ],
                   ],
                 },
@@ -3178,7 +3178,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.md.not-supported",
+                      "/data/*/docs-*-typescript.*.not-supported",
                     ],
                   ],
                 },
@@ -3208,7 +3208,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.md.corruptassembly",
+                      "/data/*/docs-typescript.*.corruptassembly",
                     ],
                   ],
                 },
@@ -3238,7 +3238,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.md.corruptassembly",
+                      "/data/*/docs-*-typescript.*.corruptassembly",
                     ],
                   ],
                 },
@@ -3257,7 +3257,7 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-typescript.md.corruptassembly",
+                    "/data/*/docs-typescript.*.corruptassembly",
                   ],
                 ],
               },
@@ -3275,223 +3275,7 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-typescript.md.corruptassembly",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.md",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.md",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.md.not-supported",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.md.not-supported",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.md.corruptassembly",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.md.corruptassembly",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": "s3:DeleteObject*",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "Bucket83908E77",
-                        "Arn",
-                      ],
-                    },
-                    "/data/*/docs-python.md.corruptassembly",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": "s3:DeleteObject*",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "Bucket83908E77",
-                        "Arn",
-                      ],
-                    },
-                    "/data/*/docs-*-python.md.corruptassembly",
+                    "/data/*/docs-*-typescript.*.corruptassembly",
                   ],
                 ],
               },
@@ -3520,7 +3304,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.md",
+                      "/data/*/docs-python.*",
                     ],
                   ],
                 },
@@ -3550,7 +3334,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.md",
+                      "/data/*/docs-*-python.*",
                     ],
                   ],
                 },
@@ -3580,7 +3364,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.md.not-supported",
+                      "/data/*/docs-python.*.not-supported",
                     ],
                   ],
                 },
@@ -3610,7 +3394,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.md.not-supported",
+                      "/data/*/docs-*-python.*.not-supported",
                     ],
                   ],
                 },
@@ -3640,7 +3424,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.md.corruptassembly",
+                      "/data/*/docs-python.*.corruptassembly",
                     ],
                   ],
                 },
@@ -3670,7 +3454,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.md.corruptassembly",
+                      "/data/*/docs-*-python.*.corruptassembly",
                     ],
                   ],
                 },
@@ -3689,7 +3473,7 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-java.md.corruptassembly",
+                    "/data/*/docs-python.*.corruptassembly",
                   ],
                 ],
               },
@@ -3707,7 +3491,7 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-java.md.corruptassembly",
+                    "/data/*/docs-*-python.*.corruptassembly",
                   ],
                 ],
               },
@@ -3736,7 +3520,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.md",
+                      "/data/*/docs-java.*",
                     ],
                   ],
                 },
@@ -3766,7 +3550,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.md",
+                      "/data/*/docs-*-java.*",
                     ],
                   ],
                 },
@@ -3796,7 +3580,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.md.not-supported",
+                      "/data/*/docs-java.*.not-supported",
                     ],
                   ],
                 },
@@ -3826,7 +3610,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.md.not-supported",
+                      "/data/*/docs-*-java.*.not-supported",
                     ],
                   ],
                 },
@@ -3856,7 +3640,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.md.corruptassembly",
+                      "/data/*/docs-java.*.corruptassembly",
                     ],
                   ],
                 },
@@ -3886,7 +3670,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.md.corruptassembly",
+                      "/data/*/docs-*-java.*.corruptassembly",
                     ],
                   ],
                 },
@@ -3905,7 +3689,7 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-csharp.md.corruptassembly",
+                    "/data/*/docs-java.*.corruptassembly",
                   ],
                 ],
               },
@@ -3923,7 +3707,223 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-csharp.md.corruptassembly",
+                    "/data/*/docs-*-java.*.corruptassembly",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.*.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.*.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.*.corruptassembly",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.*.corruptassembly",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": "s3:DeleteObject*",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "Bucket83908E77",
+                        "Arn",
+                      ],
+                    },
+                    "/data/*/docs-csharp.*.corruptassembly",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:DeleteObject*",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "Bucket83908E77",
+                        "Arn",
+                      ],
+                    },
+                    "/data/*/docs-*-csharp.*.corruptassembly",
                   ],
                 ],
               },
@@ -4009,7 +4009,7 @@ Object {
                   Object {
                     "Ref": "AWS::URLSuffix",
                   },
-                  "/aws-cdk/assets:5fa39a328f34360df81ad2f478b29e7f72b6625d60d6ca775401e69a3b2c0faf",
+                  "/aws-cdk/assets:89c6683e392b08bdb9bfd8e456f82a156b228534eed332191232b4aa0beec4f2",
                 ],
               ],
             },
@@ -4291,7 +4291,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.md",
+                      "/data/*/docs-typescript.*",
                     ],
                   ],
                 },
@@ -4321,7 +4321,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.md",
+                      "/data/*/docs-*-typescript.*",
                     ],
                   ],
                 },
@@ -4351,7 +4351,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.md.not-supported",
+                      "/data/*/docs-typescript.*.not-supported",
                     ],
                   ],
                 },
@@ -4381,7 +4381,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.md.not-supported",
+                      "/data/*/docs-*-typescript.*.not-supported",
                     ],
                   ],
                 },
@@ -4411,7 +4411,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-typescript.md.corruptassembly",
+                      "/data/*/docs-typescript.*.corruptassembly",
                     ],
                   ],
                 },
@@ -4441,7 +4441,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-typescript.md.corruptassembly",
+                      "/data/*/docs-*-typescript.*.corruptassembly",
                     ],
                   ],
                 },
@@ -4460,7 +4460,7 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-typescript.md.corruptassembly",
+                    "/data/*/docs-typescript.*.corruptassembly",
                   ],
                 ],
               },
@@ -4478,223 +4478,7 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-typescript.md.corruptassembly",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.md",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.md",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.md.not-supported",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.md.not-supported",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-python.md.corruptassembly",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Bucket83908E77",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "Bucket83908E77",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/docs-*-python.md.corruptassembly",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": "s3:DeleteObject*",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "Bucket83908E77",
-                        "Arn",
-                      ],
-                    },
-                    "/data/*/docs-python.md.corruptassembly",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": "s3:DeleteObject*",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "Bucket83908E77",
-                        "Arn",
-                      ],
-                    },
-                    "/data/*/docs-*-python.md.corruptassembly",
+                    "/data/*/docs-*-typescript.*.corruptassembly",
                   ],
                 ],
               },
@@ -4723,7 +4507,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.md",
+                      "/data/*/docs-python.*",
                     ],
                   ],
                 },
@@ -4753,7 +4537,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.md",
+                      "/data/*/docs-*-python.*",
                     ],
                   ],
                 },
@@ -4783,7 +4567,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.md.not-supported",
+                      "/data/*/docs-python.*.not-supported",
                     ],
                   ],
                 },
@@ -4813,7 +4597,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.md.not-supported",
+                      "/data/*/docs-*-python.*.not-supported",
                     ],
                   ],
                 },
@@ -4843,7 +4627,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-java.md.corruptassembly",
+                      "/data/*/docs-python.*.corruptassembly",
                     ],
                   ],
                 },
@@ -4873,7 +4657,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-java.md.corruptassembly",
+                      "/data/*/docs-*-python.*.corruptassembly",
                     ],
                   ],
                 },
@@ -4892,7 +4676,7 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-java.md.corruptassembly",
+                    "/data/*/docs-python.*.corruptassembly",
                   ],
                 ],
               },
@@ -4910,7 +4694,7 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-java.md.corruptassembly",
+                    "/data/*/docs-*-python.*.corruptassembly",
                   ],
                 ],
               },
@@ -4939,7 +4723,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.md",
+                      "/data/*/docs-java.*",
                     ],
                   ],
                 },
@@ -4969,7 +4753,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.md",
+                      "/data/*/docs-*-java.*",
                     ],
                   ],
                 },
@@ -4999,7 +4783,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.md.not-supported",
+                      "/data/*/docs-java.*.not-supported",
                     ],
                   ],
                 },
@@ -5029,7 +4813,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.md.not-supported",
+                      "/data/*/docs-*-java.*.not-supported",
                     ],
                   ],
                 },
@@ -5059,7 +4843,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-csharp.md.corruptassembly",
+                      "/data/*/docs-java.*.corruptassembly",
                     ],
                   ],
                 },
@@ -5089,7 +4873,7 @@ Object {
                           "Arn",
                         ],
                       },
-                      "/data/*/docs-*-csharp.md.corruptassembly",
+                      "/data/*/docs-*-java.*.corruptassembly",
                     ],
                   ],
                 },
@@ -5108,7 +4892,7 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-csharp.md.corruptassembly",
+                    "/data/*/docs-java.*.corruptassembly",
                   ],
                 ],
               },
@@ -5126,7 +4910,223 @@ Object {
                         "Arn",
                       ],
                     },
-                    "/data/*/docs-*-csharp.md.corruptassembly",
+                    "/data/*/docs-*-java.*.corruptassembly",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.*.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.*.not-supported",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-csharp.*.corruptassembly",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Bucket83908E77",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Bucket83908E77",
+                          "Arn",
+                        ],
+                      },
+                      "/data/*/docs-*-csharp.*.corruptassembly",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": "s3:DeleteObject*",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "Bucket83908E77",
+                        "Arn",
+                      ],
+                    },
+                    "/data/*/docs-csharp.*.corruptassembly",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:DeleteObject*",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "Bucket83908E77",
+                        "Arn",
+                      ],
+                    },
+                    "/data/*/docs-*-csharp.*.corruptassembly",
                   ],
                 ],
               },

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -281,7 +281,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3BucketE7A02ACD
+          Ref: AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3Bucket635A0AFA
         S3Key:
           Fn::Join:
             - ""
@@ -289,12 +289,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3VersionKeyCC994D9E
+                      - Ref: AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3VersionKeyBB104177
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3VersionKeyCC994D9E
+                      - Ref: AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3VersionKeyBB104177
       Role:
         Fn::GetAtt:
           - ConstructHubMonitoringWebCanaryHomePageHttpGetFunctionServiceRole9AAAD93C
@@ -1263,7 +1263,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-typescript.*
+                    - /data/*/docs-typescript.md
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1280,7 +1280,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-typescript.*
+                    - /data/*/docs-*-typescript.md
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1297,7 +1297,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-typescript.*.not-supported
+                    - /data/*/docs-typescript.md.not-supported
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1314,7 +1314,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-typescript.*.not-supported
+                    - /data/*/docs-*-typescript.md.not-supported
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1331,7 +1331,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-typescript.*.corruptassembly
+                    - /data/*/docs-typescript.md.corruptassembly
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1348,7 +1348,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-typescript.*.corruptassembly
+                    - /data/*/docs-*-typescript.md.corruptassembly
           - Action: s3:DeleteObject*
             Effect: Allow
             Principal:
@@ -1359,7 +1359,7 @@ Resources:
                 - - Fn::GetAtt:
                       - ConstructHubPackageDataDC5EF35E
                       - Arn
-                  - /data/*/docs-typescript.*.corruptassembly
+                  - /data/*/docs-typescript.md.corruptassembly
           - Action: s3:DeleteObject*
             Effect: Allow
             Principal:
@@ -1370,7 +1370,7 @@ Resources:
                 - - Fn::GetAtt:
                       - ConstructHubPackageDataDC5EF35E
                       - Arn
-                  - /data/*/docs-*-typescript.*.corruptassembly
+                  - /data/*/docs-*-typescript.md.corruptassembly
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1387,7 +1387,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-python.*
+                    - /data/*/docs-python.md
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1404,7 +1404,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-python.*
+                    - /data/*/docs-*-python.md
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1421,7 +1421,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-python.*.not-supported
+                    - /data/*/docs-python.md.not-supported
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1438,7 +1438,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-python.*.not-supported
+                    - /data/*/docs-*-python.md.not-supported
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1455,7 +1455,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-python.*.corruptassembly
+                    - /data/*/docs-python.md.corruptassembly
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1472,7 +1472,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-python.*.corruptassembly
+                    - /data/*/docs-*-python.md.corruptassembly
           - Action: s3:DeleteObject*
             Effect: Allow
             Principal:
@@ -1483,7 +1483,7 @@ Resources:
                 - - Fn::GetAtt:
                       - ConstructHubPackageDataDC5EF35E
                       - Arn
-                  - /data/*/docs-python.*.corruptassembly
+                  - /data/*/docs-python.md.corruptassembly
           - Action: s3:DeleteObject*
             Effect: Allow
             Principal:
@@ -1494,7 +1494,7 @@ Resources:
                 - - Fn::GetAtt:
                       - ConstructHubPackageDataDC5EF35E
                       - Arn
-                  - /data/*/docs-*-python.*.corruptassembly
+                  - /data/*/docs-*-python.md.corruptassembly
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1511,7 +1511,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-java.*
+                    - /data/*/docs-java.md
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1528,7 +1528,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-java.*
+                    - /data/*/docs-*-java.md
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1545,7 +1545,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-java.*.not-supported
+                    - /data/*/docs-java.md.not-supported
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1562,7 +1562,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-java.*.not-supported
+                    - /data/*/docs-*-java.md.not-supported
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1579,7 +1579,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-java.*.corruptassembly
+                    - /data/*/docs-java.md.corruptassembly
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1596,7 +1596,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-java.*.corruptassembly
+                    - /data/*/docs-*-java.md.corruptassembly
           - Action: s3:DeleteObject*
             Effect: Allow
             Principal:
@@ -1607,7 +1607,7 @@ Resources:
                 - - Fn::GetAtt:
                       - ConstructHubPackageDataDC5EF35E
                       - Arn
-                  - /data/*/docs-java.*.corruptassembly
+                  - /data/*/docs-java.md.corruptassembly
           - Action: s3:DeleteObject*
             Effect: Allow
             Principal:
@@ -1618,7 +1618,7 @@ Resources:
                 - - Fn::GetAtt:
                       - ConstructHubPackageDataDC5EF35E
                       - Arn
-                  - /data/*/docs-*-java.*.corruptassembly
+                  - /data/*/docs-*-java.md.corruptassembly
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1635,7 +1635,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-csharp.*
+                    - /data/*/docs-csharp.md
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1652,7 +1652,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-csharp.*
+                    - /data/*/docs-*-csharp.md
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1669,7 +1669,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-csharp.*.not-supported
+                    - /data/*/docs-csharp.md.not-supported
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1686,7 +1686,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-csharp.*.not-supported
+                    - /data/*/docs-*-csharp.md.not-supported
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1703,7 +1703,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-csharp.*.corruptassembly
+                    - /data/*/docs-csharp.md.corruptassembly
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1720,7 +1720,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-csharp.*.corruptassembly
+                    - /data/*/docs-*-csharp.md.corruptassembly
           - Action: s3:DeleteObject*
             Effect: Allow
             Principal:
@@ -1731,7 +1731,7 @@ Resources:
                 - - Fn::GetAtt:
                       - ConstructHubPackageDataDC5EF35E
                       - Arn
-                  - /data/*/docs-csharp.*.corruptassembly
+                  - /data/*/docs-csharp.md.corruptassembly
           - Action: s3:DeleteObject*
             Effect: Allow
             Principal:
@@ -1742,7 +1742,7 @@ Resources:
                 - - Fn::GetAtt:
                       - ConstructHubPackageDataDC5EF35E
                       - Arn
-                  - /data/*/docs-*-csharp.*.corruptassembly
+                  - /data/*/docs-*-csharp.md.corruptassembly
         Version: 2012-10-17
       RouteTableIds:
         - Ref: ConstructHubVPCIsolatedSubnet1RouteTable750E6F36
@@ -2141,7 +2141,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3BucketAE80D773
+          Ref: AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3Bucket288D5551
         S3Key:
           Fn::Join:
             - ""
@@ -2149,12 +2149,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3VersionKey662F0E6F
+                      - Ref: AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3VersionKey4638DF79
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3VersionKey662F0E6F
+                      - Ref: AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3VersionKey4638DF79
       Role:
         Fn::GetAtt:
           - ConstructHubDenyListPrunePruneHandlerServiceRole58BDE1FE
@@ -2230,7 +2230,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3BucketAC5DE359
+          Ref: AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3Bucket95F679AA
         S3Key:
           Fn::Join:
             - ""
@@ -2238,12 +2238,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3VersionKey503D22DC
+                      - Ref: AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3VersionKeyE7A4EEDD
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3VersionKey503D22DC
+                      - Ref: AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3VersionKeyE7A4EEDD
       Role:
         Fn::GetAtt:
           - ConstructHubDenyListPrunePruneQueueHandlerServiceRoleC10AC418
@@ -2345,7 +2345,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3Bucket789CA701
+          Ref: AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3BucketE35D2278
         S3Key:
           Fn::Join:
             - ""
@@ -2353,12 +2353,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3VersionKey0222399F
+                      - Ref: AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3VersionKey88FA0AFA
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3VersionKey0222399F
+                      - Ref: AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3VersionKey88FA0AFA
       Role:
         Fn::GetAtt:
           - ConstructHubStatsServiceRole48DCA379
@@ -2504,7 +2504,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3Bucket86412295
+          Ref: AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3BucketF9AF3C9C
         S3Key:
           Fn::Join:
             - ""
@@ -2512,12 +2512,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3VersionKeyE42DDF01
+                      - Ref: AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3VersionKey09B12EB1
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3VersionKeyE42DDF01
+                      - Ref: AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3VersionKey09B12EB1
       Role:
         Fn::GetAtt:
           - ConstructHubVersionTrackerServiceRole721EE863
@@ -2791,7 +2791,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3Bucket722FE70B
+          Ref: AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3Bucket2D6D8F86
         S3Key:
           Fn::Join:
             - ""
@@ -2799,12 +2799,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3VersionKey8082F3BC
+                      - Ref: AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3VersionKey0ECB40A6
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3VersionKey8082F3BC
+                      - Ref: AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3VersionKey0ECB40A6
       Role:
         Fn::GetAtt:
           - ConstructHubOrchestrationCatalogBuilderServiceRole851C750C
@@ -2930,7 +2930,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3BucketE78A0203
+          Ref: AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3Bucket19B71C5A
         S3Key:
           Fn::Join:
             - ""
@@ -2938,12 +2938,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3VersionKey598098A7
+                      - Ref: AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3VersionKeyDF73A6F0
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3VersionKey598098A7
+                      - Ref: AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3VersionKeyDF73A6F0
       Role:
         Fn::GetAtt:
           - ConstructHubOrchestrationNeedsCatalogUpdateServiceRoleE6BF31C3
@@ -3093,7 +3093,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-typescript.*
+                    - /data/*/docs-typescript.md
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3108,7 +3108,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-typescript.*
+                    - /data/*/docs-*-typescript.md
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3123,7 +3123,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-typescript.*.not-supported
+                    - /data/*/docs-typescript.md.not-supported
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3138,7 +3138,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-typescript.*.not-supported
+                    - /data/*/docs-*-typescript.md.not-supported
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3153,7 +3153,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-typescript.*.corruptassembly
+                    - /data/*/docs-typescript.md.corruptassembly
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3168,7 +3168,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-typescript.*.corruptassembly
+                    - /data/*/docs-*-typescript.md.corruptassembly
           - Action: s3:DeleteObject*
             Effect: Allow
             Resource:
@@ -3177,7 +3177,7 @@ Resources:
                 - - Fn::GetAtt:
                       - ConstructHubPackageDataDC5EF35E
                       - Arn
-                  - /data/*/docs-typescript.*.corruptassembly
+                  - /data/*/docs-typescript.md.corruptassembly
           - Action: s3:DeleteObject*
             Effect: Allow
             Resource:
@@ -3186,7 +3186,7 @@ Resources:
                 - - Fn::GetAtt:
                       - ConstructHubPackageDataDC5EF35E
                       - Arn
-                  - /data/*/docs-*-typescript.*.corruptassembly
+                  - /data/*/docs-*-typescript.md.corruptassembly
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3201,7 +3201,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-python.*
+                    - /data/*/docs-python.md
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3216,7 +3216,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-python.*
+                    - /data/*/docs-*-python.md
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3231,7 +3231,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-python.*.not-supported
+                    - /data/*/docs-python.md.not-supported
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3246,7 +3246,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-python.*.not-supported
+                    - /data/*/docs-*-python.md.not-supported
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3261,7 +3261,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-python.*.corruptassembly
+                    - /data/*/docs-python.md.corruptassembly
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3276,7 +3276,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-python.*.corruptassembly
+                    - /data/*/docs-*-python.md.corruptassembly
           - Action: s3:DeleteObject*
             Effect: Allow
             Resource:
@@ -3285,7 +3285,7 @@ Resources:
                 - - Fn::GetAtt:
                       - ConstructHubPackageDataDC5EF35E
                       - Arn
-                  - /data/*/docs-python.*.corruptassembly
+                  - /data/*/docs-python.md.corruptassembly
           - Action: s3:DeleteObject*
             Effect: Allow
             Resource:
@@ -3294,7 +3294,7 @@ Resources:
                 - - Fn::GetAtt:
                       - ConstructHubPackageDataDC5EF35E
                       - Arn
-                  - /data/*/docs-*-python.*.corruptassembly
+                  - /data/*/docs-*-python.md.corruptassembly
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3309,7 +3309,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-java.*
+                    - /data/*/docs-java.md
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3324,7 +3324,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-java.*
+                    - /data/*/docs-*-java.md
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3339,7 +3339,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-java.*.not-supported
+                    - /data/*/docs-java.md.not-supported
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3354,7 +3354,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-java.*.not-supported
+                    - /data/*/docs-*-java.md.not-supported
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3369,7 +3369,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-java.*.corruptassembly
+                    - /data/*/docs-java.md.corruptassembly
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3384,7 +3384,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-java.*.corruptassembly
+                    - /data/*/docs-*-java.md.corruptassembly
           - Action: s3:DeleteObject*
             Effect: Allow
             Resource:
@@ -3393,7 +3393,7 @@ Resources:
                 - - Fn::GetAtt:
                       - ConstructHubPackageDataDC5EF35E
                       - Arn
-                  - /data/*/docs-java.*.corruptassembly
+                  - /data/*/docs-java.md.corruptassembly
           - Action: s3:DeleteObject*
             Effect: Allow
             Resource:
@@ -3402,7 +3402,7 @@ Resources:
                 - - Fn::GetAtt:
                       - ConstructHubPackageDataDC5EF35E
                       - Arn
-                  - /data/*/docs-*-java.*.corruptassembly
+                  - /data/*/docs-*-java.md.corruptassembly
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3417,7 +3417,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-csharp.*
+                    - /data/*/docs-csharp.md
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3432,7 +3432,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-csharp.*
+                    - /data/*/docs-*-csharp.md
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3447,7 +3447,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-csharp.*.not-supported
+                    - /data/*/docs-csharp.md.not-supported
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3462,7 +3462,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-csharp.*.not-supported
+                    - /data/*/docs-*-csharp.md.not-supported
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3477,7 +3477,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-csharp.*.corruptassembly
+                    - /data/*/docs-csharp.md.corruptassembly
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3492,7 +3492,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-csharp.*.corruptassembly
+                    - /data/*/docs-*-csharp.md.corruptassembly
           - Action: s3:DeleteObject*
             Effect: Allow
             Resource:
@@ -3501,7 +3501,7 @@ Resources:
                 - - Fn::GetAtt:
                       - ConstructHubPackageDataDC5EF35E
                       - Arn
-                  - /data/*/docs-csharp.*.corruptassembly
+                  - /data/*/docs-csharp.md.corruptassembly
           - Action: s3:DeleteObject*
             Effect: Allow
             Resource:
@@ -3510,7 +3510,7 @@ Resources:
                 - - Fn::GetAtt:
                       - ConstructHubPackageDataDC5EF35E
                       - Arn
-                  - /data/*/docs-*-csharp.*.corruptassembly
+                  - /data/*/docs-*-csharp.md.corruptassembly
         Version: 2012-10-17
       PolicyName: ConstructHubOrchestrationTransliteratorTaskDefinitionTaskRoleDefaultPolicyE0EED0F8
       Roles:
@@ -3559,7 +3559,7 @@ Resources:
                 - Ref: AWS::Region
                 - .
                 - Ref: AWS::URLSuffix
-                - /aws-cdk/assets:89c6683e392b08bdb9bfd8e456f82a156b228534eed332191232b4aa0beec4f2
+                - /aws-cdk/assets:5fa39a328f34360df81ad2f478b29e7f72b6625d60d6ca775401e69a3b2c0faf
           LogConfiguration:
             LogDriver: awslogs
             Options:
@@ -3769,7 +3769,7 @@ Resources:
               doc-gen ECS Command"},"Prepare doc-gen ECS
               Command":{"Type":"Pass","ResultPath":"$.docGen","Parameters":{"command.$":"States.Array(States.JsonToString($))"},"Next":"Generate
               docs"},"Generate docs":{"Next":"Check whether catalog needs
-              udpating","Retry":[{"ErrorEquals":["jsii-docgen.NoSpaceLeftOnDevice"],"MaxAttempts":0},{"ErrorEquals":["ECS.AmazonECSException","ECS.InvalidParameterException","jsii-docgen.NpmError.E429","jsii-codgen.NpmError.EPROTO"],"IntervalSeconds":120,"MaxAttempts":200,"BackoffRate":1},{"ErrorEquals":["jsii-docgen.NpmError.ETARGET"],"IntervalSeconds":300,"MaxAttempts":3,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"MaxAttempts":3}],"Catch":[{"ErrorEquals":["UnprocessablePackageError"],"Next":"Ignore"},{"ErrorEquals":["States.Timeout"],"ResultPath":"$.error","Next":"Send
+              udpating","Retry":[{"ErrorEquals":["jsii-docgen.NoSpaceLeftOnDevice"],"MaxAttempts":0},{"ErrorEquals":["ECS.AmazonECSException","ECS.InvalidParameterException","jsii-docgen.NpmError.E429","jsii-codgen.NpmError.EPROTO"],"IntervalSeconds":60,"MaxAttempts":30,"BackoffRate":1.1},{"ErrorEquals":["jsii-docgen.NpmError.ETARGET"],"IntervalSeconds":300,"MaxAttempts":3,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"MaxAttempts":3}],"Catch":[{"ErrorEquals":["UnprocessablePackageError"],"Next":"Ignore"},{"ErrorEquals":["States.Timeout"],"ResultPath":"$.error","Next":"Send
               to Dead Letter
               Queue"},{"ErrorEquals":["ECS.AmazonECSException","ECS.InvalidParameterException"],"ResultPath":"$.error","Next":"Send
               to Dead Letter
@@ -3777,7 +3777,7 @@ Resources:
               to Dead Letter
               Queue"},{"ErrorEquals":["States.ALL"],"ResultPath":"$.error","Next":"Send
               to Dead Letter
-              Queue"}],"Type":"Task","TimeoutSeconds":7200,"HeartbeatSeconds":300,"InputPath":"$.docGen.command","ResultPath":"$.docGenOutput","Resource":"arn:'
+              Queue"}],"Type":"Task","TimeoutSeconds":3600,"HeartbeatSeconds":300,"InputPath":"$.docGen.command","ResultPath":"$.docGenOutput","Resource":"arn:'
             - Ref: AWS::Partition
             - :states:::ecs:runTask.waitForTaskToken","Parameters":{"Cluster":"
             - Fn::GetAtt:
@@ -3793,7 +3793,7 @@ Resources:
                 - GroupId
             - '"]}},"Overrides":{"ContainerOverrides":[{"Name":"Resource","Command.$":"$","Environment":[{"Name":"SFN_TASK_TOKEN","Value.$":"$$.Task.Token"}]}]},"LaunchType":"FARGATE","PlatformVersion":"1.4.0"}},"Check
               whether catalog needs udpating":{"Next":"Is catalog update
-              needed?","Retry":[{"ErrorEquals":["Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["Lambda.TooManyRequestsException","Lambda.Unknown"],"IntervalSeconds":60,"MaxAttempts":30,"BackoffRate":1.1}],"Catch":[{"ErrorEquals":["Lambda.TooManyRequestsException","Lambda.Unknown"],"ResultPath":"$.error","Next":"Send
+              needed?","Retry":[{"ErrorEquals":["Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["Lambda.TooManyRequestsException"],"IntervalSeconds":60,"MaxAttempts":30,"BackoffRate":1.1}],"Catch":[{"ErrorEquals":["Lambda.TooManyRequestsException"],"ResultPath":"$.error","Next":"Send
               to Dead Letter
               Queue"},{"ErrorEquals":["States.TaskFailed"],"ResultPath":"$.error","Next":"Send
               to Dead Letter
@@ -3914,7 +3914,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3Bucket6F376B71
+          Ref: AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3Bucket1090210F
         S3Key:
           Fn::Join:
             - ""
@@ -3922,12 +3922,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3VersionKey7F6E5804
+                      - Ref: AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3VersionKeyD738CD6B
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3VersionKey7F6E5804
+                      - Ref: AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3VersionKeyD738CD6B
       Role:
         Fn::GetAtt:
           - ConstructHubOrchestrationRedriveServiceRoleB84EFF33
@@ -4341,7 +4341,7 @@ Resources:
           - CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536
           - Arn
       SourceBucketNames:
-        - Ref: AssetParametersb32de5d6fb92c01b03e93e387691b3f444ac4e9800273abf834874c427c640f0S3Bucket0D334DA1
+        - Ref: AssetParametersb69f8e77829ba765ee3a37c088671f56d5982ab8e2a57c2f3103bea15181e67bS3BucketCECA6DD1
       SourceObjectKeys:
         - Fn::Join:
             - ""
@@ -4349,12 +4349,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersb32de5d6fb92c01b03e93e387691b3f444ac4e9800273abf834874c427c640f0S3VersionKeyB04BC588
+                      - Ref: AssetParametersb69f8e77829ba765ee3a37c088671f56d5982ab8e2a57c2f3103bea15181e67bS3VersionKeyAD3D5992
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersb32de5d6fb92c01b03e93e387691b3f444ac4e9800273abf834874c427c640f0S3VersionKeyB04BC588
+                      - Ref: AssetParametersb69f8e77829ba765ee3a37c088671f56d5982ab8e2a57c2f3103bea15181e67bS3VersionKeyAD3D5992
       DestinationBucketName:
         Ref: ConstructHubIngestionConfigBucket0F0ED0B6
       Prune: true
@@ -4535,7 +4535,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3BucketF13820EA
+          Ref: AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3Bucket8AFE0D2F
         S3Key:
           Fn::Join:
             - ""
@@ -4543,12 +4543,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3VersionKey52B24F16
+                      - Ref: AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3VersionKey39383E8E
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3VersionKey52B24F16
+                      - Ref: AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3VersionKey39383E8E
       Role:
         Fn::GetAtt:
           - ConstructHubIngestionServiceRole6380BAB6
@@ -4718,7 +4718,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3Bucket5255533F
+          Ref: AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3Bucket0A90D6D3
         S3Key:
           Fn::Join:
             - ""
@@ -4726,12 +4726,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3VersionKey7909F675
+                      - Ref: AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3VersionKeyA116EF05
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3VersionKey7909F675
+                      - Ref: AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3VersionKeyA116EF05
       Role:
         Fn::GetAtt:
           - ConstructHubIngestionReprocessWorkflowFunctionServiceRoleA59056B1
@@ -5350,7 +5350,7 @@ Resources:
           - CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536
           - Arn
       SourceBucketNames:
-        - Ref: AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2
+        - Ref: AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22
       SourceObjectKeys:
         - Fn::Join:
             - ""
@@ -5358,12 +5358,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3VersionKeyEC7E3301
+                      - Ref: AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3VersionKeyCE5C5D3B
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3VersionKeyEC7E3301
+                      - Ref: AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3VersionKeyCE5C5D3B
       DestinationBucketName:
         Ref: ConstructHubWebAppWebsiteBucket4B2B9DB2
       Prune: false
@@ -5401,8 +5401,7 @@ Resources:
           - CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536
           - Arn
       SourceBucketNames:
-        - Ref: AssetParameterse55830a9b80764bba7a1d95af568e482da15437ad646619e8f6c76dc8c098c91S3Bucket880B69C6
-        - Ref: AssetParametersd7eba45c105712349db08f8edd1c547cd768fb9c92dadc0bfd2403ecc4127f96S3BucketEBD7DE4E
+        - Ref: AssetParameters219b0e6bde7859b1caead1a417b318db5db660d51d0e582d6a303062ee4eae16S3BucketA2579CB9
       SourceObjectKeys:
         - Fn::Join:
             - ""
@@ -5410,24 +5409,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameterse55830a9b80764bba7a1d95af568e482da15437ad646619e8f6c76dc8c098c91S3VersionKey08B8FEF5
+                      - Ref: AssetParameters219b0e6bde7859b1caead1a417b318db5db660d51d0e582d6a303062ee4eae16S3VersionKey49CF574B
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameterse55830a9b80764bba7a1d95af568e482da15437ad646619e8f6c76dc8c098c91S3VersionKey08B8FEF5
-        - Fn::Join:
-            - ""
-            - - Fn::Select:
-                  - 0
-                  - Fn::Split:
-                      - "||"
-                      - Ref: AssetParametersd7eba45c105712349db08f8edd1c547cd768fb9c92dadc0bfd2403ecc4127f96S3VersionKey2B839AE6
-              - Fn::Select:
-                  - 1
-                  - Fn::Split:
-                      - "||"
-                      - Ref: AssetParametersd7eba45c105712349db08f8edd1c547cd768fb9c92dadc0bfd2403ecc4127f96S3VersionKey2B839AE6
+                      - Ref: AssetParameters219b0e6bde7859b1caead1a417b318db5db660d51d0e582d6a303062ee4eae16S3VersionKey49CF574B
       DestinationBucketName:
         Ref: ConstructHubWebAppWebsiteBucket4B2B9DB2
       Prune: false
@@ -5622,7 +5609,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3Bucket8AF0E263
+          Ref: AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3BucketFFA964C8
         S3Key:
           Fn::Join:
             - ""
@@ -5630,12 +5617,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3VersionKey5280D545
+                      - Ref: AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3VersionKeyA62CD84A
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3VersionKey5280D545
+                      - Ref: AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3VersionKeyA62CD84A
       Role:
         Fn::GetAtt:
           - ConstructHubSourcesNpmJsStageAndNotifyServiceRoleD5BB5B50
@@ -5779,7 +5766,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3Bucket024B3DC6
+          Ref: AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3Bucket901B95EB
         S3Key:
           Fn::Join:
             - ""
@@ -5787,12 +5774,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3VersionKeyEEA56859
+                      - Ref: AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3VersionKeyC6FBD6BD
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3VersionKeyEEA56859
+                      - Ref: AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3VersionKeyC6FBD6BD
       Role:
         Fn::GetAtt:
           - ConstructHubSourcesNpmJsServiceRoleAC3F7AA6
@@ -5878,7 +5865,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3Bucket37F2908E
+          Ref: AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3Bucket86DBA113
         S3Key:
           Fn::Join:
             - ""
@@ -5886,12 +5873,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3VersionKey2C992F11
+                      - Ref: AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3VersionKeyF547CFB5
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3VersionKey2C992F11
+                      - Ref: AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3VersionKeyF547CFB5
       Role:
         Fn::GetAtt:
           - ConstructHubSourcesNpmJsCanaryServiceRoleC4CBCDA2
@@ -6249,7 +6236,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3Bucket5515214C
+          Ref: AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3Bucket649728C0
         S3Key:
           Fn::Join:
             - ""
@@ -6257,12 +6244,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED
+                      - Ref: AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3VersionKey592D485B
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED
+                      - Ref: AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3VersionKey592D485B
       Role:
         Fn::GetAtt:
           - ConstructHubInventoryCanaryServiceRole7684EDDE
@@ -7088,13 +7075,13 @@ Resources:
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParametersb32de5d6fb92c01b03e93e387691b3f444ac4e9800273abf834874c427c640f0S3Bucket0D334DA1
+                    - Ref: AssetParametersb69f8e77829ba765ee3a37c088671f56d5982ab8e2a57c2f3103bea15181e67bS3BucketCECA6DD1
               - Fn::Join:
                   - ""
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParametersb32de5d6fb92c01b03e93e387691b3f444ac4e9800273abf834874c427c640f0S3Bucket0D334DA1
+                    - Ref: AssetParametersb69f8e77829ba765ee3a37c088671f56d5982ab8e2a57c2f3103bea15181e67bS3BucketCECA6DD1
                     - /*
           - Action:
               - s3:GetObject*
@@ -7162,13 +7149,13 @@ Resources:
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2
+                    - Ref: AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22
               - Fn::Join:
                   - ""
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2
+                    - Ref: AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22
                     - /*
           - Action:
               - s3:GetObject*
@@ -7204,32 +7191,13 @@ Resources:
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParameterse55830a9b80764bba7a1d95af568e482da15437ad646619e8f6c76dc8c098c91S3Bucket880B69C6
+                    - Ref: AssetParameters219b0e6bde7859b1caead1a417b318db5db660d51d0e582d6a303062ee4eae16S3BucketA2579CB9
               - Fn::Join:
                   - ""
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParameterse55830a9b80764bba7a1d95af568e482da15437ad646619e8f6c76dc8c098c91S3Bucket880B69C6
-                    - /*
-          - Action:
-              - s3:GetObject*
-              - s3:GetBucket*
-              - s3:List*
-            Effect: Allow
-            Resource:
-              - Fn::Join:
-                  - ""
-                  - - "arn:"
-                    - Ref: AWS::Partition
-                    - ":s3:::"
-                    - Ref: AssetParametersd7eba45c105712349db08f8edd1c547cd768fb9c92dadc0bfd2403ecc4127f96S3BucketEBD7DE4E
-              - Fn::Join:
-                  - ""
-                  - - "arn:"
-                    - Ref: AWS::Partition
-                    - ":s3:::"
-                    - Ref: AssetParametersd7eba45c105712349db08f8edd1c547cd768fb9c92dadc0bfd2403ecc4127f96S3BucketEBD7DE4E
+                    - Ref: AssetParameters219b0e6bde7859b1caead1a417b318db5db660d51d0e582d6a303062ee4eae16S3BucketA2579CB9
                     - /*
         Version: 2012-10-17
       PolicyName: CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF
@@ -7644,7 +7612,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3BucketCBEF8050
+          Ref: AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3Bucket1B95B117
         S3Key:
           Fn::Join:
             - ""
@@ -7652,12 +7620,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3VersionKey57968381
+                      - Ref: AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3VersionKey75D92238
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3VersionKey57968381
+                      - Ref: AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3VersionKey75D92238
       Role:
         Fn::GetAtt:
           - PackageVersionsTableWidgetHandler5fa848259c1d5e388c0df69f05c016dfServiceRole060BA12C
@@ -7810,42 +7778,42 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "6f1f07e70de63d5afdbcab762f8f867a2aedb494b30cd360d5deb518d3914263"
-  AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3BucketAE80D773:
+  AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3Bucket288D5551:
     Type: String
     Description: S3 bucket for asset
-      "da314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17a"
-  AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3VersionKey662F0E6F:
+      "0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362ead"
+  AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3VersionKey4638DF79:
     Type: String
     Description: S3 key for asset version
-      "da314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17a"
-  AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aArtifactHash0386B8EC:
+      "0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362ead"
+  AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadArtifactHash3158CABD:
     Type: String
     Description: Artifact hash for asset
-      "da314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17a"
-  AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3BucketAC5DE359:
+      "0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362ead"
+  AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3Bucket95F679AA:
     Type: String
     Description: S3 bucket for asset
-      "f48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3"
-  AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3VersionKey503D22DC:
+      "205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612c"
+  AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3VersionKeyE7A4EEDD:
     Type: String
     Description: S3 key for asset version
-      "f48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3"
-  AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3ArtifactHash11DB5971:
+      "205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612c"
+  AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cArtifactHash8D005B5F:
     Type: String
     Description: Artifact hash for asset
-      "f48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3"
-  AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3Bucket789CA701:
+      "205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612c"
+  AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3BucketE35D2278:
     Type: String
     Description: S3 bucket for asset
-      "0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4a"
-  AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3VersionKey0222399F:
+      "55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0"
+  AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3VersionKey88FA0AFA:
     Type: String
     Description: S3 key for asset version
-      "0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4a"
-  AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aArtifactHash82449A4A:
+      "55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0"
+  AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0ArtifactHash6F14CF3C:
     Type: String
     Description: Artifact hash for asset
-      "0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4a"
+      "55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0"
   AssetParametersb120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827S3Bucket2070BA0A:
     Type: String
     Description: S3 bucket for asset
@@ -7858,90 +7826,90 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "b120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827"
-  AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3Bucket86412295:
+  AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3BucketF9AF3C9C:
     Type: String
     Description: S3 bucket for asset
-      "04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6"
-  AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3VersionKeyE42DDF01:
+      "adb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbd"
+  AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3VersionKey09B12EB1:
     Type: String
     Description: S3 key for asset version
-      "04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6"
-  AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6ArtifactHashF2EEEBFF:
+      "adb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbd"
+  AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdArtifactHash22ECD1BE:
     Type: String
     Description: Artifact hash for asset
-      "04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6"
-  AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3Bucket722FE70B:
+      "adb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbd"
+  AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3Bucket2D6D8F86:
     Type: String
     Description: S3 bucket for asset
-      "37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5"
-  AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3VersionKey8082F3BC:
+      "3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934b"
+  AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3VersionKey0ECB40A6:
     Type: String
     Description: S3 key for asset version
-      "37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5"
-  AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5ArtifactHash0AFE0939:
+      "3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934b"
+  AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bArtifactHash270470CC:
     Type: String
     Description: Artifact hash for asset
-      "37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5"
-  AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3BucketE78A0203:
+      "3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934b"
+  AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3Bucket19B71C5A:
     Type: String
     Description: S3 bucket for asset
-      "98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4"
-  AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3VersionKey598098A7:
+      "73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06c"
+  AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3VersionKeyDF73A6F0:
     Type: String
     Description: S3 key for asset version
-      "98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4"
-  AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4ArtifactHash660A50B8:
+      "73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06c"
+  AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cArtifactHashD2B94368:
     Type: String
     Description: Artifact hash for asset
-      "98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4"
-  AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3Bucket6F376B71:
+      "73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06c"
+  AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3Bucket1090210F:
     Type: String
     Description: S3 bucket for asset
-      "4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeee"
-  AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3VersionKey7F6E5804:
+      "782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0"
+  AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3VersionKeyD738CD6B:
     Type: String
     Description: S3 key for asset version
-      "4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeee"
-  AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeArtifactHash3FAC57D3:
+      "782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0"
+  AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0ArtifactHashF4B56B1E:
     Type: String
     Description: Artifact hash for asset
-      "4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeee"
-  AssetParametersb32de5d6fb92c01b03e93e387691b3f444ac4e9800273abf834874c427c640f0S3Bucket0D334DA1:
+      "782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0"
+  AssetParametersb69f8e77829ba765ee3a37c088671f56d5982ab8e2a57c2f3103bea15181e67bS3BucketCECA6DD1:
     Type: String
     Description: S3 bucket for asset
-      "b32de5d6fb92c01b03e93e387691b3f444ac4e9800273abf834874c427c640f0"
-  AssetParametersb32de5d6fb92c01b03e93e387691b3f444ac4e9800273abf834874c427c640f0S3VersionKeyB04BC588:
+      "b69f8e77829ba765ee3a37c088671f56d5982ab8e2a57c2f3103bea15181e67b"
+  AssetParametersb69f8e77829ba765ee3a37c088671f56d5982ab8e2a57c2f3103bea15181e67bS3VersionKeyAD3D5992:
     Type: String
     Description: S3 key for asset version
-      "b32de5d6fb92c01b03e93e387691b3f444ac4e9800273abf834874c427c640f0"
-  AssetParametersb32de5d6fb92c01b03e93e387691b3f444ac4e9800273abf834874c427c640f0ArtifactHash6C1CDCF8:
+      "b69f8e77829ba765ee3a37c088671f56d5982ab8e2a57c2f3103bea15181e67b"
+  AssetParametersb69f8e77829ba765ee3a37c088671f56d5982ab8e2a57c2f3103bea15181e67bArtifactHashD3064179:
     Type: String
     Description: Artifact hash for asset
-      "b32de5d6fb92c01b03e93e387691b3f444ac4e9800273abf834874c427c640f0"
-  AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3BucketF13820EA:
+      "b69f8e77829ba765ee3a37c088671f56d5982ab8e2a57c2f3103bea15181e67b"
+  AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3Bucket8AFE0D2F:
     Type: String
     Description: S3 bucket for asset
-      "864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680"
-  AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3VersionKey52B24F16:
+      "25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534"
+  AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3VersionKey39383E8E:
     Type: String
     Description: S3 key for asset version
-      "864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680"
-  AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680ArtifactHash316B2926:
+      "25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534"
+  AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534ArtifactHash89381734:
     Type: String
     Description: Artifact hash for asset
-      "864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680"
-  AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3Bucket5255533F:
+      "25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534"
+  AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3Bucket0A90D6D3:
     Type: String
     Description: S3 bucket for asset
-      "c62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafc"
-  AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3VersionKey7909F675:
+      "7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965"
+  AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3VersionKeyA116EF05:
     Type: String
     Description: S3 key for asset version
-      "c62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafc"
-  AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcArtifactHash4E26EEC4:
+      "7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965"
+  AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965ArtifactHashD4D3C5A6:
     Type: String
     Description: Artifact hash for asset
-      "c62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafc"
+      "7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965"
   AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3BucketB2DE6865:
     Type: String
     Description: S3 bucket for asset
@@ -7954,113 +7922,101 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900"
-  AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2:
+  AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22:
     Type: String
     Description: S3 bucket for asset
-      "af643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfba"
-  AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3VersionKeyEC7E3301:
+      "778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6f"
+  AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3VersionKeyCE5C5D3B:
     Type: String
     Description: S3 key for asset version
-      "af643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfba"
-  AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaArtifactHash8CCAA809:
+      "778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6f"
+  AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fArtifactHash2005F882:
     Type: String
     Description: Artifact hash for asset
-      "af643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfba"
-  AssetParameterse55830a9b80764bba7a1d95af568e482da15437ad646619e8f6c76dc8c098c91S3Bucket880B69C6:
+      "778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6f"
+  AssetParameters219b0e6bde7859b1caead1a417b318db5db660d51d0e582d6a303062ee4eae16S3BucketA2579CB9:
     Type: String
     Description: S3 bucket for asset
-      "e55830a9b80764bba7a1d95af568e482da15437ad646619e8f6c76dc8c098c91"
-  AssetParameterse55830a9b80764bba7a1d95af568e482da15437ad646619e8f6c76dc8c098c91S3VersionKey08B8FEF5:
+      "219b0e6bde7859b1caead1a417b318db5db660d51d0e582d6a303062ee4eae16"
+  AssetParameters219b0e6bde7859b1caead1a417b318db5db660d51d0e582d6a303062ee4eae16S3VersionKey49CF574B:
     Type: String
     Description: S3 key for asset version
-      "e55830a9b80764bba7a1d95af568e482da15437ad646619e8f6c76dc8c098c91"
-  AssetParameterse55830a9b80764bba7a1d95af568e482da15437ad646619e8f6c76dc8c098c91ArtifactHash49660294:
+      "219b0e6bde7859b1caead1a417b318db5db660d51d0e582d6a303062ee4eae16"
+  AssetParameters219b0e6bde7859b1caead1a417b318db5db660d51d0e582d6a303062ee4eae16ArtifactHash01251331:
     Type: String
     Description: Artifact hash for asset
-      "e55830a9b80764bba7a1d95af568e482da15437ad646619e8f6c76dc8c098c91"
-  AssetParametersd7eba45c105712349db08f8edd1c547cd768fb9c92dadc0bfd2403ecc4127f96S3BucketEBD7DE4E:
+      "219b0e6bde7859b1caead1a417b318db5db660d51d0e582d6a303062ee4eae16"
+  AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3Bucket635A0AFA:
     Type: String
     Description: S3 bucket for asset
-      "d7eba45c105712349db08f8edd1c547cd768fb9c92dadc0bfd2403ecc4127f96"
-  AssetParametersd7eba45c105712349db08f8edd1c547cd768fb9c92dadc0bfd2403ecc4127f96S3VersionKey2B839AE6:
+      "0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9ae"
+  AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3VersionKeyBB104177:
     Type: String
     Description: S3 key for asset version
-      "d7eba45c105712349db08f8edd1c547cd768fb9c92dadc0bfd2403ecc4127f96"
-  AssetParametersd7eba45c105712349db08f8edd1c547cd768fb9c92dadc0bfd2403ecc4127f96ArtifactHashA9044145:
+      "0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9ae"
+  AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeArtifactHash322D47B8:
     Type: String
     Description: Artifact hash for asset
-      "d7eba45c105712349db08f8edd1c547cd768fb9c92dadc0bfd2403ecc4127f96"
-  AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3BucketE7A02ACD:
+      "0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9ae"
+  AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3BucketFFA964C8:
     Type: String
     Description: S3 bucket for asset
-      "b55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04"
-  AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3VersionKeyCC994D9E:
+      "1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67"
+  AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3VersionKeyA62CD84A:
     Type: String
     Description: S3 key for asset version
-      "b55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04"
-  AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04ArtifactHash394183E9:
+      "1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67"
+  AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67ArtifactHashCF96E147:
     Type: String
     Description: Artifact hash for asset
-      "b55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04"
-  AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3Bucket8AF0E263:
+      "1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67"
+  AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3Bucket901B95EB:
     Type: String
     Description: S3 bucket for asset
-      "42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2b"
-  AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3VersionKey5280D545:
+      "1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33ae"
+  AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3VersionKeyC6FBD6BD:
     Type: String
     Description: S3 key for asset version
-      "42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2b"
-  AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bArtifactHash5ABBFB9B:
+      "1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33ae"
+  AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeArtifactHashD1A9CF6A:
     Type: String
     Description: Artifact hash for asset
-      "42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2b"
-  AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3Bucket024B3DC6:
+      "1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33ae"
+  AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3Bucket86DBA113:
     Type: String
     Description: S3 bucket for asset
-      "fbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5"
-  AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3VersionKeyEEA56859:
+      "c8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8"
+  AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3VersionKeyF547CFB5:
     Type: String
     Description: S3 key for asset version
-      "fbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5"
-  AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5ArtifactHash185A4671:
+      "c8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8"
+  AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8ArtifactHashBB72DCC8:
     Type: String
     Description: Artifact hash for asset
-      "fbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5"
-  AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3Bucket37F2908E:
+      "c8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8"
+  AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3Bucket649728C0:
     Type: String
     Description: S3 bucket for asset
-      "3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5"
-  AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3VersionKey2C992F11:
+      "6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420"
+  AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3VersionKey592D485B:
     Type: String
     Description: S3 key for asset version
-      "3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5"
-  AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5ArtifactHash499F6DFF:
+      "6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420"
+  AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420ArtifactHashC847AA8D:
     Type: String
     Description: Artifact hash for asset
-      "3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5"
-  AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3Bucket5515214C:
+      "6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420"
+  AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3Bucket1B95B117:
     Type: String
     Description: S3 bucket for asset
-      "3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af"
-  AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED:
+      "9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8"
+  AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3VersionKey75D92238:
     Type: String
     Description: S3 key for asset version
-      "3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af"
-  AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afArtifactHash7F8A76FC:
+      "9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8"
+  AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8ArtifactHash8DC0C383:
     Type: String
     Description: Artifact hash for asset
-      "3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af"
-  AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3BucketCBEF8050:
-    Type: String
-    Description: S3 bucket for asset
-      "3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880d"
-  AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3VersionKey57968381:
-    Type: String
-    Description: S3 key for asset version
-      "3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880d"
-  AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dArtifactHash3B82A2B3:
-    Type: String
-    Description: Artifact hash for asset
-      "3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880d"
+      "9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8"
 
 `;

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -281,7 +281,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3Bucket635A0AFA
+          Ref: AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3BucketE7A02ACD
         S3Key:
           Fn::Join:
             - ""
@@ -289,12 +289,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3VersionKeyBB104177
+                      - Ref: AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3VersionKeyCC994D9E
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3VersionKeyBB104177
+                      - Ref: AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3VersionKeyCC994D9E
       Role:
         Fn::GetAtt:
           - ConstructHubMonitoringWebCanaryHomePageHttpGetFunctionServiceRole9AAAD93C
@@ -1263,7 +1263,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-typescript.md
+                    - /data/*/docs-typescript.*
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1280,7 +1280,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-typescript.md
+                    - /data/*/docs-*-typescript.*
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1297,7 +1297,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-typescript.md.not-supported
+                    - /data/*/docs-typescript.*.not-supported
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1314,7 +1314,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-typescript.md.not-supported
+                    - /data/*/docs-*-typescript.*.not-supported
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1331,7 +1331,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-typescript.md.corruptassembly
+                    - /data/*/docs-typescript.*.corruptassembly
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1348,7 +1348,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-typescript.md.corruptassembly
+                    - /data/*/docs-*-typescript.*.corruptassembly
           - Action: s3:DeleteObject*
             Effect: Allow
             Principal:
@@ -1359,7 +1359,7 @@ Resources:
                 - - Fn::GetAtt:
                       - ConstructHubPackageDataDC5EF35E
                       - Arn
-                  - /data/*/docs-typescript.md.corruptassembly
+                  - /data/*/docs-typescript.*.corruptassembly
           - Action: s3:DeleteObject*
             Effect: Allow
             Principal:
@@ -1370,7 +1370,7 @@ Resources:
                 - - Fn::GetAtt:
                       - ConstructHubPackageDataDC5EF35E
                       - Arn
-                  - /data/*/docs-*-typescript.md.corruptassembly
+                  - /data/*/docs-*-typescript.*.corruptassembly
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1387,7 +1387,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-python.md
+                    - /data/*/docs-python.*
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1404,7 +1404,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-python.md
+                    - /data/*/docs-*-python.*
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1421,7 +1421,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-python.md.not-supported
+                    - /data/*/docs-python.*.not-supported
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1438,7 +1438,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-python.md.not-supported
+                    - /data/*/docs-*-python.*.not-supported
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1455,7 +1455,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-python.md.corruptassembly
+                    - /data/*/docs-python.*.corruptassembly
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1472,7 +1472,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-python.md.corruptassembly
+                    - /data/*/docs-*-python.*.corruptassembly
           - Action: s3:DeleteObject*
             Effect: Allow
             Principal:
@@ -1483,7 +1483,7 @@ Resources:
                 - - Fn::GetAtt:
                       - ConstructHubPackageDataDC5EF35E
                       - Arn
-                  - /data/*/docs-python.md.corruptassembly
+                  - /data/*/docs-python.*.corruptassembly
           - Action: s3:DeleteObject*
             Effect: Allow
             Principal:
@@ -1494,7 +1494,7 @@ Resources:
                 - - Fn::GetAtt:
                       - ConstructHubPackageDataDC5EF35E
                       - Arn
-                  - /data/*/docs-*-python.md.corruptassembly
+                  - /data/*/docs-*-python.*.corruptassembly
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1511,7 +1511,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-java.md
+                    - /data/*/docs-java.*
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1528,7 +1528,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-java.md
+                    - /data/*/docs-*-java.*
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1545,7 +1545,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-java.md.not-supported
+                    - /data/*/docs-java.*.not-supported
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1562,7 +1562,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-java.md.not-supported
+                    - /data/*/docs-*-java.*.not-supported
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1579,7 +1579,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-java.md.corruptassembly
+                    - /data/*/docs-java.*.corruptassembly
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1596,7 +1596,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-java.md.corruptassembly
+                    - /data/*/docs-*-java.*.corruptassembly
           - Action: s3:DeleteObject*
             Effect: Allow
             Principal:
@@ -1607,7 +1607,7 @@ Resources:
                 - - Fn::GetAtt:
                       - ConstructHubPackageDataDC5EF35E
                       - Arn
-                  - /data/*/docs-java.md.corruptassembly
+                  - /data/*/docs-java.*.corruptassembly
           - Action: s3:DeleteObject*
             Effect: Allow
             Principal:
@@ -1618,7 +1618,7 @@ Resources:
                 - - Fn::GetAtt:
                       - ConstructHubPackageDataDC5EF35E
                       - Arn
-                  - /data/*/docs-*-java.md.corruptassembly
+                  - /data/*/docs-*-java.*.corruptassembly
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1635,7 +1635,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-csharp.md
+                    - /data/*/docs-csharp.*
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1652,7 +1652,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-csharp.md
+                    - /data/*/docs-*-csharp.*
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1669,7 +1669,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-csharp.md.not-supported
+                    - /data/*/docs-csharp.*.not-supported
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1686,7 +1686,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-csharp.md.not-supported
+                    - /data/*/docs-*-csharp.*.not-supported
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1703,7 +1703,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-csharp.md.corruptassembly
+                    - /data/*/docs-csharp.*.corruptassembly
           - Action:
               - s3:Abort*
               - s3:DeleteObject*
@@ -1720,7 +1720,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-csharp.md.corruptassembly
+                    - /data/*/docs-*-csharp.*.corruptassembly
           - Action: s3:DeleteObject*
             Effect: Allow
             Principal:
@@ -1731,7 +1731,7 @@ Resources:
                 - - Fn::GetAtt:
                       - ConstructHubPackageDataDC5EF35E
                       - Arn
-                  - /data/*/docs-csharp.md.corruptassembly
+                  - /data/*/docs-csharp.*.corruptassembly
           - Action: s3:DeleteObject*
             Effect: Allow
             Principal:
@@ -1742,7 +1742,7 @@ Resources:
                 - - Fn::GetAtt:
                       - ConstructHubPackageDataDC5EF35E
                       - Arn
-                  - /data/*/docs-*-csharp.md.corruptassembly
+                  - /data/*/docs-*-csharp.*.corruptassembly
         Version: 2012-10-17
       RouteTableIds:
         - Ref: ConstructHubVPCIsolatedSubnet1RouteTable750E6F36
@@ -2141,7 +2141,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3Bucket288D5551
+          Ref: AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3BucketAE80D773
         S3Key:
           Fn::Join:
             - ""
@@ -2149,12 +2149,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3VersionKey4638DF79
+                      - Ref: AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3VersionKey662F0E6F
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3VersionKey4638DF79
+                      - Ref: AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3VersionKey662F0E6F
       Role:
         Fn::GetAtt:
           - ConstructHubDenyListPrunePruneHandlerServiceRole58BDE1FE
@@ -2230,7 +2230,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3Bucket95F679AA
+          Ref: AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3BucketAC5DE359
         S3Key:
           Fn::Join:
             - ""
@@ -2238,12 +2238,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3VersionKeyE7A4EEDD
+                      - Ref: AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3VersionKey503D22DC
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3VersionKeyE7A4EEDD
+                      - Ref: AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3VersionKey503D22DC
       Role:
         Fn::GetAtt:
           - ConstructHubDenyListPrunePruneQueueHandlerServiceRoleC10AC418
@@ -2345,7 +2345,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3BucketE35D2278
+          Ref: AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3Bucket789CA701
         S3Key:
           Fn::Join:
             - ""
@@ -2353,12 +2353,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3VersionKey88FA0AFA
+                      - Ref: AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3VersionKey0222399F
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3VersionKey88FA0AFA
+                      - Ref: AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3VersionKey0222399F
       Role:
         Fn::GetAtt:
           - ConstructHubStatsServiceRole48DCA379
@@ -2504,7 +2504,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3BucketF9AF3C9C
+          Ref: AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3Bucket86412295
         S3Key:
           Fn::Join:
             - ""
@@ -2512,12 +2512,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3VersionKey09B12EB1
+                      - Ref: AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3VersionKeyE42DDF01
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3VersionKey09B12EB1
+                      - Ref: AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3VersionKeyE42DDF01
       Role:
         Fn::GetAtt:
           - ConstructHubVersionTrackerServiceRole721EE863
@@ -2791,7 +2791,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3Bucket2D6D8F86
+          Ref: AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3Bucket722FE70B
         S3Key:
           Fn::Join:
             - ""
@@ -2799,12 +2799,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3VersionKey0ECB40A6
+                      - Ref: AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3VersionKey8082F3BC
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3VersionKey0ECB40A6
+                      - Ref: AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3VersionKey8082F3BC
       Role:
         Fn::GetAtt:
           - ConstructHubOrchestrationCatalogBuilderServiceRole851C750C
@@ -2930,7 +2930,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3Bucket19B71C5A
+          Ref: AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3BucketE78A0203
         S3Key:
           Fn::Join:
             - ""
@@ -2938,12 +2938,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3VersionKeyDF73A6F0
+                      - Ref: AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3VersionKey598098A7
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3VersionKeyDF73A6F0
+                      - Ref: AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3VersionKey598098A7
       Role:
         Fn::GetAtt:
           - ConstructHubOrchestrationNeedsCatalogUpdateServiceRoleE6BF31C3
@@ -3093,7 +3093,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-typescript.md
+                    - /data/*/docs-typescript.*
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3108,7 +3108,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-typescript.md
+                    - /data/*/docs-*-typescript.*
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3123,7 +3123,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-typescript.md.not-supported
+                    - /data/*/docs-typescript.*.not-supported
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3138,7 +3138,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-typescript.md.not-supported
+                    - /data/*/docs-*-typescript.*.not-supported
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3153,7 +3153,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-typescript.md.corruptassembly
+                    - /data/*/docs-typescript.*.corruptassembly
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3168,7 +3168,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-typescript.md.corruptassembly
+                    - /data/*/docs-*-typescript.*.corruptassembly
           - Action: s3:DeleteObject*
             Effect: Allow
             Resource:
@@ -3177,7 +3177,7 @@ Resources:
                 - - Fn::GetAtt:
                       - ConstructHubPackageDataDC5EF35E
                       - Arn
-                  - /data/*/docs-typescript.md.corruptassembly
+                  - /data/*/docs-typescript.*.corruptassembly
           - Action: s3:DeleteObject*
             Effect: Allow
             Resource:
@@ -3186,7 +3186,7 @@ Resources:
                 - - Fn::GetAtt:
                       - ConstructHubPackageDataDC5EF35E
                       - Arn
-                  - /data/*/docs-*-typescript.md.corruptassembly
+                  - /data/*/docs-*-typescript.*.corruptassembly
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3201,7 +3201,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-python.md
+                    - /data/*/docs-python.*
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3216,7 +3216,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-python.md
+                    - /data/*/docs-*-python.*
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3231,7 +3231,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-python.md.not-supported
+                    - /data/*/docs-python.*.not-supported
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3246,7 +3246,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-python.md.not-supported
+                    - /data/*/docs-*-python.*.not-supported
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3261,7 +3261,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-python.md.corruptassembly
+                    - /data/*/docs-python.*.corruptassembly
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3276,7 +3276,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-python.md.corruptassembly
+                    - /data/*/docs-*-python.*.corruptassembly
           - Action: s3:DeleteObject*
             Effect: Allow
             Resource:
@@ -3285,7 +3285,7 @@ Resources:
                 - - Fn::GetAtt:
                       - ConstructHubPackageDataDC5EF35E
                       - Arn
-                  - /data/*/docs-python.md.corruptassembly
+                  - /data/*/docs-python.*.corruptassembly
           - Action: s3:DeleteObject*
             Effect: Allow
             Resource:
@@ -3294,7 +3294,7 @@ Resources:
                 - - Fn::GetAtt:
                       - ConstructHubPackageDataDC5EF35E
                       - Arn
-                  - /data/*/docs-*-python.md.corruptassembly
+                  - /data/*/docs-*-python.*.corruptassembly
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3309,7 +3309,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-java.md
+                    - /data/*/docs-java.*
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3324,7 +3324,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-java.md
+                    - /data/*/docs-*-java.*
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3339,7 +3339,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-java.md.not-supported
+                    - /data/*/docs-java.*.not-supported
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3354,7 +3354,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-java.md.not-supported
+                    - /data/*/docs-*-java.*.not-supported
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3369,7 +3369,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-java.md.corruptassembly
+                    - /data/*/docs-java.*.corruptassembly
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3384,7 +3384,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-java.md.corruptassembly
+                    - /data/*/docs-*-java.*.corruptassembly
           - Action: s3:DeleteObject*
             Effect: Allow
             Resource:
@@ -3393,7 +3393,7 @@ Resources:
                 - - Fn::GetAtt:
                       - ConstructHubPackageDataDC5EF35E
                       - Arn
-                  - /data/*/docs-java.md.corruptassembly
+                  - /data/*/docs-java.*.corruptassembly
           - Action: s3:DeleteObject*
             Effect: Allow
             Resource:
@@ -3402,7 +3402,7 @@ Resources:
                 - - Fn::GetAtt:
                       - ConstructHubPackageDataDC5EF35E
                       - Arn
-                  - /data/*/docs-*-java.md.corruptassembly
+                  - /data/*/docs-*-java.*.corruptassembly
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3417,7 +3417,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-csharp.md
+                    - /data/*/docs-csharp.*
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3432,7 +3432,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-csharp.md
+                    - /data/*/docs-*-csharp.*
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3447,7 +3447,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-csharp.md.not-supported
+                    - /data/*/docs-csharp.*.not-supported
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3462,7 +3462,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-csharp.md.not-supported
+                    - /data/*/docs-*-csharp.*.not-supported
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3477,7 +3477,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-csharp.md.corruptassembly
+                    - /data/*/docs-csharp.*.corruptassembly
           - Action:
               - s3:DeleteObject*
               - s3:PutObject*
@@ -3492,7 +3492,7 @@ Resources:
                   - - Fn::GetAtt:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
-                    - /data/*/docs-*-csharp.md.corruptassembly
+                    - /data/*/docs-*-csharp.*.corruptassembly
           - Action: s3:DeleteObject*
             Effect: Allow
             Resource:
@@ -3501,7 +3501,7 @@ Resources:
                 - - Fn::GetAtt:
                       - ConstructHubPackageDataDC5EF35E
                       - Arn
-                  - /data/*/docs-csharp.md.corruptassembly
+                  - /data/*/docs-csharp.*.corruptassembly
           - Action: s3:DeleteObject*
             Effect: Allow
             Resource:
@@ -3510,7 +3510,7 @@ Resources:
                 - - Fn::GetAtt:
                       - ConstructHubPackageDataDC5EF35E
                       - Arn
-                  - /data/*/docs-*-csharp.md.corruptassembly
+                  - /data/*/docs-*-csharp.*.corruptassembly
         Version: 2012-10-17
       PolicyName: ConstructHubOrchestrationTransliteratorTaskDefinitionTaskRoleDefaultPolicyE0EED0F8
       Roles:
@@ -3559,7 +3559,7 @@ Resources:
                 - Ref: AWS::Region
                 - .
                 - Ref: AWS::URLSuffix
-                - /aws-cdk/assets:5fa39a328f34360df81ad2f478b29e7f72b6625d60d6ca775401e69a3b2c0faf
+                - /aws-cdk/assets:89c6683e392b08bdb9bfd8e456f82a156b228534eed332191232b4aa0beec4f2
           LogConfiguration:
             LogDriver: awslogs
             Options:
@@ -3769,7 +3769,7 @@ Resources:
               doc-gen ECS Command"},"Prepare doc-gen ECS
               Command":{"Type":"Pass","ResultPath":"$.docGen","Parameters":{"command.$":"States.Array(States.JsonToString($))"},"Next":"Generate
               docs"},"Generate docs":{"Next":"Check whether catalog needs
-              udpating","Retry":[{"ErrorEquals":["jsii-docgen.NoSpaceLeftOnDevice"],"MaxAttempts":0},{"ErrorEquals":["ECS.AmazonECSException","ECS.InvalidParameterException","jsii-docgen.NpmError.E429","jsii-codgen.NpmError.EPROTO"],"IntervalSeconds":60,"MaxAttempts":30,"BackoffRate":1.1},{"ErrorEquals":["jsii-docgen.NpmError.ETARGET"],"IntervalSeconds":300,"MaxAttempts":3,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"MaxAttempts":3}],"Catch":[{"ErrorEquals":["UnprocessablePackageError"],"Next":"Ignore"},{"ErrorEquals":["States.Timeout"],"ResultPath":"$.error","Next":"Send
+              udpating","Retry":[{"ErrorEquals":["jsii-docgen.NoSpaceLeftOnDevice"],"MaxAttempts":0},{"ErrorEquals":["ECS.AmazonECSException","ECS.InvalidParameterException","jsii-docgen.NpmError.E429","jsii-codgen.NpmError.EPROTO"],"IntervalSeconds":120,"MaxAttempts":200,"BackoffRate":1},{"ErrorEquals":["jsii-docgen.NpmError.ETARGET"],"IntervalSeconds":300,"MaxAttempts":3,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"MaxAttempts":3}],"Catch":[{"ErrorEquals":["UnprocessablePackageError"],"Next":"Ignore"},{"ErrorEquals":["States.Timeout"],"ResultPath":"$.error","Next":"Send
               to Dead Letter
               Queue"},{"ErrorEquals":["ECS.AmazonECSException","ECS.InvalidParameterException"],"ResultPath":"$.error","Next":"Send
               to Dead Letter
@@ -3777,7 +3777,7 @@ Resources:
               to Dead Letter
               Queue"},{"ErrorEquals":["States.ALL"],"ResultPath":"$.error","Next":"Send
               to Dead Letter
-              Queue"}],"Type":"Task","TimeoutSeconds":3600,"HeartbeatSeconds":300,"InputPath":"$.docGen.command","ResultPath":"$.docGenOutput","Resource":"arn:'
+              Queue"}],"Type":"Task","TimeoutSeconds":7200,"HeartbeatSeconds":300,"InputPath":"$.docGen.command","ResultPath":"$.docGenOutput","Resource":"arn:'
             - Ref: AWS::Partition
             - :states:::ecs:runTask.waitForTaskToken","Parameters":{"Cluster":"
             - Fn::GetAtt:
@@ -3793,7 +3793,7 @@ Resources:
                 - GroupId
             - '"]}},"Overrides":{"ContainerOverrides":[{"Name":"Resource","Command.$":"$","Environment":[{"Name":"SFN_TASK_TOKEN","Value.$":"$$.Task.Token"}]}]},"LaunchType":"FARGATE","PlatformVersion":"1.4.0"}},"Check
               whether catalog needs udpating":{"Next":"Is catalog update
-              needed?","Retry":[{"ErrorEquals":["Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["Lambda.TooManyRequestsException"],"IntervalSeconds":60,"MaxAttempts":30,"BackoffRate":1.1}],"Catch":[{"ErrorEquals":["Lambda.TooManyRequestsException"],"ResultPath":"$.error","Next":"Send
+              needed?","Retry":[{"ErrorEquals":["Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["Lambda.TooManyRequestsException","Lambda.Unknown"],"IntervalSeconds":60,"MaxAttempts":30,"BackoffRate":1.1}],"Catch":[{"ErrorEquals":["Lambda.TooManyRequestsException","Lambda.Unknown"],"ResultPath":"$.error","Next":"Send
               to Dead Letter
               Queue"},{"ErrorEquals":["States.TaskFailed"],"ResultPath":"$.error","Next":"Send
               to Dead Letter
@@ -3914,7 +3914,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3Bucket1090210F
+          Ref: AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3Bucket6F376B71
         S3Key:
           Fn::Join:
             - ""
@@ -3922,12 +3922,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3VersionKeyD738CD6B
+                      - Ref: AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3VersionKey7F6E5804
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3VersionKeyD738CD6B
+                      - Ref: AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3VersionKey7F6E5804
       Role:
         Fn::GetAtt:
           - ConstructHubOrchestrationRedriveServiceRoleB84EFF33
@@ -4341,7 +4341,7 @@ Resources:
           - CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536
           - Arn
       SourceBucketNames:
-        - Ref: AssetParametersb69f8e77829ba765ee3a37c088671f56d5982ab8e2a57c2f3103bea15181e67bS3BucketCECA6DD1
+        - Ref: AssetParametersb32de5d6fb92c01b03e93e387691b3f444ac4e9800273abf834874c427c640f0S3Bucket0D334DA1
       SourceObjectKeys:
         - Fn::Join:
             - ""
@@ -4349,12 +4349,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersb69f8e77829ba765ee3a37c088671f56d5982ab8e2a57c2f3103bea15181e67bS3VersionKeyAD3D5992
+                      - Ref: AssetParametersb32de5d6fb92c01b03e93e387691b3f444ac4e9800273abf834874c427c640f0S3VersionKeyB04BC588
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersb69f8e77829ba765ee3a37c088671f56d5982ab8e2a57c2f3103bea15181e67bS3VersionKeyAD3D5992
+                      - Ref: AssetParametersb32de5d6fb92c01b03e93e387691b3f444ac4e9800273abf834874c427c640f0S3VersionKeyB04BC588
       DestinationBucketName:
         Ref: ConstructHubIngestionConfigBucket0F0ED0B6
       Prune: true
@@ -4535,7 +4535,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3Bucket8AFE0D2F
+          Ref: AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3BucketF13820EA
         S3Key:
           Fn::Join:
             - ""
@@ -4543,12 +4543,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3VersionKey39383E8E
+                      - Ref: AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3VersionKey52B24F16
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3VersionKey39383E8E
+                      - Ref: AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3VersionKey52B24F16
       Role:
         Fn::GetAtt:
           - ConstructHubIngestionServiceRole6380BAB6
@@ -4718,7 +4718,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3Bucket0A90D6D3
+          Ref: AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3Bucket5255533F
         S3Key:
           Fn::Join:
             - ""
@@ -4726,12 +4726,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3VersionKeyA116EF05
+                      - Ref: AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3VersionKey7909F675
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3VersionKeyA116EF05
+                      - Ref: AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3VersionKey7909F675
       Role:
         Fn::GetAtt:
           - ConstructHubIngestionReprocessWorkflowFunctionServiceRoleA59056B1
@@ -4843,8 +4843,8 @@ Resources:
             - :states:::aws-sdk:s3:listObjectsV2","Parameters":{"Bucket":"
             - Ref: ConstructHubPackageDataDC5EF35E
             - '","Prefix":"data/"}},"Is there
-              more?":{"Type":"Choice","Choices":[{"Variable":"$.response.NextContinuationToken","IsPresent":true,"Next":"Continue
-              as new"}],"Default":"Process
+              more?":{"Type":"Choice","Choices":[{"Variable":"$.response.NextContinuationToken","IsPresent":true,"Next":"Give
+              room for on-demand work"}],"Default":"Process
               Result"},"S3.ListObjectsV2(NextPage)":{"Next":"Is there
               more?","Retry":[{"ErrorEquals":["S3.SdkClientException"]}],"Type":"Task","ResultPath":"$.response","Resource":"arn:'
             - Ref: AWS::Partition
@@ -4872,7 +4872,10 @@ Resources:
             - Ref: AWS::Region
             - ":"
             - Ref: AWS::AccountId
-            - :stateMachine:dev.ConstructHub.Ingestion.ReprocessWorkflow"}}},"TimeoutSeconds":3600}
+            - :stateMachine:dev.ConstructHub.Ingestion.ReprocessWorkflow"}},"Give
+              room for on-demand
+              work":{"Type":"Wait","Seconds":300,"Next":"Continue as
+              new"}},"TimeoutSeconds":3600}
       StateMachineName: dev.ConstructHub.Ingestion.ReprocessWorkflow
     DependsOn:
       - ConstructHubIngestionReprocessWorkflowStateMachineRoleDefaultPolicy3A21E747
@@ -5350,7 +5353,7 @@ Resources:
           - CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536
           - Arn
       SourceBucketNames:
-        - Ref: AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22
+        - Ref: AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2
       SourceObjectKeys:
         - Fn::Join:
             - ""
@@ -5358,12 +5361,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3VersionKeyCE5C5D3B
+                      - Ref: AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3VersionKeyEC7E3301
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3VersionKeyCE5C5D3B
+                      - Ref: AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3VersionKeyEC7E3301
       DestinationBucketName:
         Ref: ConstructHubWebAppWebsiteBucket4B2B9DB2
       Prune: false
@@ -5401,7 +5404,8 @@ Resources:
           - CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536
           - Arn
       SourceBucketNames:
-        - Ref: AssetParameters219b0e6bde7859b1caead1a417b318db5db660d51d0e582d6a303062ee4eae16S3BucketA2579CB9
+        - Ref: AssetParameterse55830a9b80764bba7a1d95af568e482da15437ad646619e8f6c76dc8c098c91S3Bucket880B69C6
+        - Ref: AssetParametersd7eba45c105712349db08f8edd1c547cd768fb9c92dadc0bfd2403ecc4127f96S3BucketEBD7DE4E
       SourceObjectKeys:
         - Fn::Join:
             - ""
@@ -5409,12 +5413,24 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters219b0e6bde7859b1caead1a417b318db5db660d51d0e582d6a303062ee4eae16S3VersionKey49CF574B
+                      - Ref: AssetParameterse55830a9b80764bba7a1d95af568e482da15437ad646619e8f6c76dc8c098c91S3VersionKey08B8FEF5
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters219b0e6bde7859b1caead1a417b318db5db660d51d0e582d6a303062ee4eae16S3VersionKey49CF574B
+                      - Ref: AssetParameterse55830a9b80764bba7a1d95af568e482da15437ad646619e8f6c76dc8c098c91S3VersionKey08B8FEF5
+        - Fn::Join:
+            - ""
+            - - Fn::Select:
+                  - 0
+                  - Fn::Split:
+                      - "||"
+                      - Ref: AssetParametersd7eba45c105712349db08f8edd1c547cd768fb9c92dadc0bfd2403ecc4127f96S3VersionKey2B839AE6
+              - Fn::Select:
+                  - 1
+                  - Fn::Split:
+                      - "||"
+                      - Ref: AssetParametersd7eba45c105712349db08f8edd1c547cd768fb9c92dadc0bfd2403ecc4127f96S3VersionKey2B839AE6
       DestinationBucketName:
         Ref: ConstructHubWebAppWebsiteBucket4B2B9DB2
       Prune: false
@@ -5609,7 +5625,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3BucketFFA964C8
+          Ref: AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3Bucket8AF0E263
         S3Key:
           Fn::Join:
             - ""
@@ -5617,12 +5633,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3VersionKeyA62CD84A
+                      - Ref: AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3VersionKey5280D545
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3VersionKeyA62CD84A
+                      - Ref: AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3VersionKey5280D545
       Role:
         Fn::GetAtt:
           - ConstructHubSourcesNpmJsStageAndNotifyServiceRoleD5BB5B50
@@ -5766,7 +5782,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3Bucket901B95EB
+          Ref: AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3Bucket024B3DC6
         S3Key:
           Fn::Join:
             - ""
@@ -5774,12 +5790,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3VersionKeyC6FBD6BD
+                      - Ref: AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3VersionKeyEEA56859
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3VersionKeyC6FBD6BD
+                      - Ref: AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3VersionKeyEEA56859
       Role:
         Fn::GetAtt:
           - ConstructHubSourcesNpmJsServiceRoleAC3F7AA6
@@ -5865,7 +5881,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3Bucket86DBA113
+          Ref: AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3Bucket37F2908E
         S3Key:
           Fn::Join:
             - ""
@@ -5873,12 +5889,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3VersionKeyF547CFB5
+                      - Ref: AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3VersionKey2C992F11
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3VersionKeyF547CFB5
+                      - Ref: AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3VersionKey2C992F11
       Role:
         Fn::GetAtt:
           - ConstructHubSourcesNpmJsCanaryServiceRoleC4CBCDA2
@@ -6236,7 +6252,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3Bucket649728C0
+          Ref: AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3Bucket5515214C
         S3Key:
           Fn::Join:
             - ""
@@ -6244,12 +6260,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3VersionKey592D485B
+                      - Ref: AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3VersionKey592D485B
+                      - Ref: AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED
       Role:
         Fn::GetAtt:
           - ConstructHubInventoryCanaryServiceRole7684EDDE
@@ -7075,13 +7091,13 @@ Resources:
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParametersb69f8e77829ba765ee3a37c088671f56d5982ab8e2a57c2f3103bea15181e67bS3BucketCECA6DD1
+                    - Ref: AssetParametersb32de5d6fb92c01b03e93e387691b3f444ac4e9800273abf834874c427c640f0S3Bucket0D334DA1
               - Fn::Join:
                   - ""
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParametersb69f8e77829ba765ee3a37c088671f56d5982ab8e2a57c2f3103bea15181e67bS3BucketCECA6DD1
+                    - Ref: AssetParametersb32de5d6fb92c01b03e93e387691b3f444ac4e9800273abf834874c427c640f0S3Bucket0D334DA1
                     - /*
           - Action:
               - s3:GetObject*
@@ -7149,13 +7165,13 @@ Resources:
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22
+                    - Ref: AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2
               - Fn::Join:
                   - ""
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22
+                    - Ref: AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2
                     - /*
           - Action:
               - s3:GetObject*
@@ -7191,13 +7207,32 @@ Resources:
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParameters219b0e6bde7859b1caead1a417b318db5db660d51d0e582d6a303062ee4eae16S3BucketA2579CB9
+                    - Ref: AssetParameterse55830a9b80764bba7a1d95af568e482da15437ad646619e8f6c76dc8c098c91S3Bucket880B69C6
               - Fn::Join:
                   - ""
                   - - "arn:"
                     - Ref: AWS::Partition
                     - ":s3:::"
-                    - Ref: AssetParameters219b0e6bde7859b1caead1a417b318db5db660d51d0e582d6a303062ee4eae16S3BucketA2579CB9
+                    - Ref: AssetParameterse55830a9b80764bba7a1d95af568e482da15437ad646619e8f6c76dc8c098c91S3Bucket880B69C6
+                    - /*
+          - Action:
+              - s3:GetObject*
+              - s3:GetBucket*
+              - s3:List*
+            Effect: Allow
+            Resource:
+              - Fn::Join:
+                  - ""
+                  - - "arn:"
+                    - Ref: AWS::Partition
+                    - ":s3:::"
+                    - Ref: AssetParametersd7eba45c105712349db08f8edd1c547cd768fb9c92dadc0bfd2403ecc4127f96S3BucketEBD7DE4E
+              - Fn::Join:
+                  - ""
+                  - - "arn:"
+                    - Ref: AWS::Partition
+                    - ":s3:::"
+                    - Ref: AssetParametersd7eba45c105712349db08f8edd1c547cd768fb9c92dadc0bfd2403ecc4127f96S3BucketEBD7DE4E
                     - /*
         Version: 2012-10-17
       PolicyName: CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF
@@ -7612,7 +7647,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3Bucket1B95B117
+          Ref: AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3BucketCBEF8050
         S3Key:
           Fn::Join:
             - ""
@@ -7620,12 +7655,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3VersionKey75D92238
+                      - Ref: AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3VersionKey57968381
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3VersionKey75D92238
+                      - Ref: AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3VersionKey57968381
       Role:
         Fn::GetAtt:
           - PackageVersionsTableWidgetHandler5fa848259c1d5e388c0df69f05c016dfServiceRole060BA12C
@@ -7778,42 +7813,42 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "6f1f07e70de63d5afdbcab762f8f867a2aedb494b30cd360d5deb518d3914263"
-  AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3Bucket288D5551:
+  AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3BucketAE80D773:
     Type: String
     Description: S3 bucket for asset
-      "0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362ead"
-  AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadS3VersionKey4638DF79:
+      "da314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17a"
+  AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aS3VersionKey662F0E6F:
     Type: String
     Description: S3 key for asset version
-      "0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362ead"
-  AssetParameters0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362eadArtifactHash3158CABD:
+      "da314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17a"
+  AssetParametersda314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17aArtifactHash0386B8EC:
     Type: String
     Description: Artifact hash for asset
-      "0b8edd9afaa288257bbe7e7143a360ecb9ec99e191de1580bb2a0673e3362ead"
-  AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3Bucket95F679AA:
+      "da314a367a18f33751a5eb7ce225a83303de022e561b22ab1f6d4cbc1a71f17a"
+  AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3BucketAC5DE359:
     Type: String
     Description: S3 bucket for asset
-      "205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612c"
-  AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cS3VersionKeyE7A4EEDD:
+      "f48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3"
+  AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3S3VersionKey503D22DC:
     Type: String
     Description: S3 key for asset version
-      "205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612c"
-  AssetParameters205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612cArtifactHash8D005B5F:
+      "f48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3"
+  AssetParametersf48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3ArtifactHash11DB5971:
     Type: String
     Description: Artifact hash for asset
-      "205e30eaf1c762d7fd9e6e51bf4958ae592956b46f87d0d1005c762d9303612c"
-  AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3BucketE35D2278:
+      "f48a57855b9215d276824d60336ec8a3f6c5ee595499a28309a24fc59cf387b3"
+  AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3Bucket789CA701:
     Type: String
     Description: S3 bucket for asset
-      "55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0"
-  AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0S3VersionKey88FA0AFA:
+      "0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4a"
+  AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aS3VersionKey0222399F:
     Type: String
     Description: S3 key for asset version
-      "55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0"
-  AssetParameters55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0ArtifactHash6F14CF3C:
+      "0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4a"
+  AssetParameters0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4aArtifactHash82449A4A:
     Type: String
     Description: Artifact hash for asset
-      "55c639e50b46d314114e7123d10198d651ab1ddb1a8f577b9dbbece6a53638c0"
+      "0de01972063263c1521462918f3381103f6030c04db94d1ff2b848611c120f4a"
   AssetParametersb120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827S3Bucket2070BA0A:
     Type: String
     Description: S3 bucket for asset
@@ -7826,90 +7861,90 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "b120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827"
-  AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3BucketF9AF3C9C:
+  AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3Bucket86412295:
     Type: String
     Description: S3 bucket for asset
-      "adb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbd"
-  AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdS3VersionKey09B12EB1:
+      "04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6"
+  AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6S3VersionKeyE42DDF01:
     Type: String
     Description: S3 key for asset version
-      "adb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbd"
-  AssetParametersadb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbdArtifactHash22ECD1BE:
+      "04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6"
+  AssetParameters04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6ArtifactHashF2EEEBFF:
     Type: String
     Description: Artifact hash for asset
-      "adb53fa836b78d6ff5ecbef054b7629d3ca32ced7e0b17abde4ebf59b8663fbd"
-  AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3Bucket2D6D8F86:
+      "04cbbafd6f76d9a919d4684e2c818df430e00e50af6187a88ab2862ca8f147c6"
+  AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3Bucket722FE70B:
     Type: String
     Description: S3 bucket for asset
-      "3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934b"
-  AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bS3VersionKey0ECB40A6:
+      "37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5"
+  AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5S3VersionKey8082F3BC:
     Type: String
     Description: S3 key for asset version
-      "3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934b"
-  AssetParameters3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934bArtifactHash270470CC:
+      "37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5"
+  AssetParameters37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5ArtifactHash0AFE0939:
     Type: String
     Description: Artifact hash for asset
-      "3911df15c7abb56caee13e56b802a36c0b26d07d14a3a2eab3f933857491934b"
-  AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3Bucket19B71C5A:
+      "37cf9d5a80b367f9633bf3facfab1df583455ce0c1f9c4b7f3e826e294f38ad5"
+  AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3BucketE78A0203:
     Type: String
     Description: S3 bucket for asset
-      "73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06c"
-  AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cS3VersionKeyDF73A6F0:
+      "98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4"
+  AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4S3VersionKey598098A7:
     Type: String
     Description: S3 key for asset version
-      "73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06c"
-  AssetParameters73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06cArtifactHashD2B94368:
+      "98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4"
+  AssetParameters98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4ArtifactHash660A50B8:
     Type: String
     Description: Artifact hash for asset
-      "73d88c7f668f66617c357b7379cef7207cc8aa17da4c56a0182bdd7505c8e06c"
-  AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3Bucket1090210F:
+      "98bea99b2d22c2c4ee995993647845984433c94a85141f7abea19bc4b52d63f4"
+  AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3Bucket6F376B71:
     Type: String
     Description: S3 bucket for asset
-      "782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0"
-  AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0S3VersionKeyD738CD6B:
+      "4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeee"
+  AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeS3VersionKey7F6E5804:
     Type: String
     Description: S3 key for asset version
-      "782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0"
-  AssetParameters782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0ArtifactHashF4B56B1E:
+      "4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeee"
+  AssetParameters4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeeeArtifactHash3FAC57D3:
     Type: String
     Description: Artifact hash for asset
-      "782864ac6322b0cbb75edb2c7181827b68330887f7bf024541667f7e5c6b66e0"
-  AssetParametersb69f8e77829ba765ee3a37c088671f56d5982ab8e2a57c2f3103bea15181e67bS3BucketCECA6DD1:
+      "4fde181996dd55dac5327e33370d0f56e8113987f7a7f05afb374768e0f4eeee"
+  AssetParametersb32de5d6fb92c01b03e93e387691b3f444ac4e9800273abf834874c427c640f0S3Bucket0D334DA1:
     Type: String
     Description: S3 bucket for asset
-      "b69f8e77829ba765ee3a37c088671f56d5982ab8e2a57c2f3103bea15181e67b"
-  AssetParametersb69f8e77829ba765ee3a37c088671f56d5982ab8e2a57c2f3103bea15181e67bS3VersionKeyAD3D5992:
+      "b32de5d6fb92c01b03e93e387691b3f444ac4e9800273abf834874c427c640f0"
+  AssetParametersb32de5d6fb92c01b03e93e387691b3f444ac4e9800273abf834874c427c640f0S3VersionKeyB04BC588:
     Type: String
     Description: S3 key for asset version
-      "b69f8e77829ba765ee3a37c088671f56d5982ab8e2a57c2f3103bea15181e67b"
-  AssetParametersb69f8e77829ba765ee3a37c088671f56d5982ab8e2a57c2f3103bea15181e67bArtifactHashD3064179:
+      "b32de5d6fb92c01b03e93e387691b3f444ac4e9800273abf834874c427c640f0"
+  AssetParametersb32de5d6fb92c01b03e93e387691b3f444ac4e9800273abf834874c427c640f0ArtifactHash6C1CDCF8:
     Type: String
     Description: Artifact hash for asset
-      "b69f8e77829ba765ee3a37c088671f56d5982ab8e2a57c2f3103bea15181e67b"
-  AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3Bucket8AFE0D2F:
+      "b32de5d6fb92c01b03e93e387691b3f444ac4e9800273abf834874c427c640f0"
+  AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3BucketF13820EA:
     Type: String
     Description: S3 bucket for asset
-      "25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534"
-  AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534S3VersionKey39383E8E:
+      "864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680"
+  AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680S3VersionKey52B24F16:
     Type: String
     Description: S3 key for asset version
-      "25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534"
-  AssetParameters25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534ArtifactHash89381734:
+      "864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680"
+  AssetParameters864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680ArtifactHash316B2926:
     Type: String
     Description: Artifact hash for asset
-      "25c4344215ab24b90f188cfc95424ef45109c8d698919fcb28cfa9bb898c1534"
-  AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3Bucket0A90D6D3:
+      "864d02ed02fce8294fba35ebdc16db00a289149d3e9d2e71cd2d5faa3b424680"
+  AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3Bucket5255533F:
     Type: String
     Description: S3 bucket for asset
-      "7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965"
-  AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965S3VersionKeyA116EF05:
+      "c62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafc"
+  AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcS3VersionKey7909F675:
     Type: String
     Description: S3 key for asset version
-      "7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965"
-  AssetParameters7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965ArtifactHashD4D3C5A6:
+      "c62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafc"
+  AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcArtifactHash4E26EEC4:
     Type: String
     Description: Artifact hash for asset
-      "7ebd173e1f2198061b1be73640fca7e1864bfdea054e5a53c88e32e619871965"
+      "c62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafc"
   AssetParameters8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900S3BucketB2DE6865:
     Type: String
     Description: S3 bucket for asset
@@ -7922,101 +7957,113 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "8d968e7576898e39de27ff4cf5f336e8f112a4de9757412123e2dd725f451900"
-  AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3Bucket8BEADE22:
+  AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3BucketE65BEBC2:
     Type: String
     Description: S3 bucket for asset
-      "778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6f"
-  AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fS3VersionKeyCE5C5D3B:
+      "af643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfba"
+  AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaS3VersionKeyEC7E3301:
     Type: String
     Description: S3 key for asset version
-      "778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6f"
-  AssetParameters778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6fArtifactHash2005F882:
+      "af643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfba"
+  AssetParametersaf643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfbaArtifactHash8CCAA809:
     Type: String
     Description: Artifact hash for asset
-      "778794c21077551a93a1366e9a59ac74ab8fba5e38adb0b6f13401a4aaf67b6f"
-  AssetParameters219b0e6bde7859b1caead1a417b318db5db660d51d0e582d6a303062ee4eae16S3BucketA2579CB9:
+      "af643e5566a0312128cd71b1e1fac9f5075a2e8ce5ce8f95249461a0ef6dbfba"
+  AssetParameterse55830a9b80764bba7a1d95af568e482da15437ad646619e8f6c76dc8c098c91S3Bucket880B69C6:
     Type: String
     Description: S3 bucket for asset
-      "219b0e6bde7859b1caead1a417b318db5db660d51d0e582d6a303062ee4eae16"
-  AssetParameters219b0e6bde7859b1caead1a417b318db5db660d51d0e582d6a303062ee4eae16S3VersionKey49CF574B:
+      "e55830a9b80764bba7a1d95af568e482da15437ad646619e8f6c76dc8c098c91"
+  AssetParameterse55830a9b80764bba7a1d95af568e482da15437ad646619e8f6c76dc8c098c91S3VersionKey08B8FEF5:
     Type: String
     Description: S3 key for asset version
-      "219b0e6bde7859b1caead1a417b318db5db660d51d0e582d6a303062ee4eae16"
-  AssetParameters219b0e6bde7859b1caead1a417b318db5db660d51d0e582d6a303062ee4eae16ArtifactHash01251331:
+      "e55830a9b80764bba7a1d95af568e482da15437ad646619e8f6c76dc8c098c91"
+  AssetParameterse55830a9b80764bba7a1d95af568e482da15437ad646619e8f6c76dc8c098c91ArtifactHash49660294:
     Type: String
     Description: Artifact hash for asset
-      "219b0e6bde7859b1caead1a417b318db5db660d51d0e582d6a303062ee4eae16"
-  AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3Bucket635A0AFA:
+      "e55830a9b80764bba7a1d95af568e482da15437ad646619e8f6c76dc8c098c91"
+  AssetParametersd7eba45c105712349db08f8edd1c547cd768fb9c92dadc0bfd2403ecc4127f96S3BucketEBD7DE4E:
     Type: String
     Description: S3 bucket for asset
-      "0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9ae"
-  AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeS3VersionKeyBB104177:
+      "d7eba45c105712349db08f8edd1c547cd768fb9c92dadc0bfd2403ecc4127f96"
+  AssetParametersd7eba45c105712349db08f8edd1c547cd768fb9c92dadc0bfd2403ecc4127f96S3VersionKey2B839AE6:
     Type: String
     Description: S3 key for asset version
-      "0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9ae"
-  AssetParameters0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9aeArtifactHash322D47B8:
+      "d7eba45c105712349db08f8edd1c547cd768fb9c92dadc0bfd2403ecc4127f96"
+  AssetParametersd7eba45c105712349db08f8edd1c547cd768fb9c92dadc0bfd2403ecc4127f96ArtifactHashA9044145:
     Type: String
     Description: Artifact hash for asset
-      "0460b097267753850bf3dc5fd4c5e05e5a03a6b64e74624d863a588dc831c9ae"
-  AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3BucketFFA964C8:
+      "d7eba45c105712349db08f8edd1c547cd768fb9c92dadc0bfd2403ecc4127f96"
+  AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3BucketE7A02ACD:
     Type: String
     Description: S3 bucket for asset
-      "1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67"
-  AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67S3VersionKeyA62CD84A:
+      "b55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04"
+  AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04S3VersionKeyCC994D9E:
     Type: String
     Description: S3 key for asset version
-      "1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67"
-  AssetParameters1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67ArtifactHashCF96E147:
+      "b55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04"
+  AssetParametersb55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04ArtifactHash394183E9:
     Type: String
     Description: Artifact hash for asset
-      "1d119700cea4a3378aed5a01bdd2dec1e8c2fcdb0e3afafe52403b9feea6eb67"
-  AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3Bucket901B95EB:
+      "b55b3f3c6e028a2da2d20d0c4e3ed5b585237f1019b8a8ff6de42515015bde04"
+  AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3Bucket8AF0E263:
     Type: String
     Description: S3 bucket for asset
-      "1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33ae"
-  AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeS3VersionKeyC6FBD6BD:
+      "42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2b"
+  AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bS3VersionKey5280D545:
     Type: String
     Description: S3 key for asset version
-      "1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33ae"
-  AssetParameters1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33aeArtifactHashD1A9CF6A:
+      "42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2b"
+  AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bArtifactHash5ABBFB9B:
     Type: String
     Description: Artifact hash for asset
-      "1f56963e316e36b4b373df52fd62e50d899ddd63855a21600325d673a2fb33ae"
-  AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3Bucket86DBA113:
+      "42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2b"
+  AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3Bucket024B3DC6:
     Type: String
     Description: S3 bucket for asset
-      "c8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8"
-  AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8S3VersionKeyF547CFB5:
+      "fbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5"
+  AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5S3VersionKeyEEA56859:
     Type: String
     Description: S3 key for asset version
-      "c8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8"
-  AssetParametersc8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8ArtifactHashBB72DCC8:
+      "fbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5"
+  AssetParametersfbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5ArtifactHash185A4671:
     Type: String
     Description: Artifact hash for asset
-      "c8e8fea4fb08b8e03afe3cf8bff5787da1e6999f7220c9426befb46158df06e8"
-  AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3Bucket649728C0:
+      "fbd99e02e6418682af9619fe06593b0eaeefe6d0e3a6c137323a651e5cf4b4f5"
+  AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3Bucket37F2908E:
     Type: String
     Description: S3 bucket for asset
-      "6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420"
-  AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420S3VersionKey592D485B:
+      "3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5"
+  AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5S3VersionKey2C992F11:
     Type: String
     Description: S3 key for asset version
-      "6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420"
-  AssetParameters6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420ArtifactHashC847AA8D:
+      "3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5"
+  AssetParameters3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5ArtifactHash499F6DFF:
     Type: String
     Description: Artifact hash for asset
-      "6bcd6a089403cbbe23f34e0e5bc21663cd4095ac302249b193053d0194550420"
-  AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3Bucket1B95B117:
+      "3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5"
+  AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3Bucket5515214C:
     Type: String
     Description: S3 bucket for asset
-      "9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8"
-  AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8S3VersionKey75D92238:
+      "3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af"
+  AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED:
     Type: String
     Description: S3 key for asset version
-      "9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8"
-  AssetParameters9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8ArtifactHash8DC0C383:
+      "3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af"
+  AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afArtifactHash7F8A76FC:
     Type: String
     Description: Artifact hash for asset
-      "9e3411fb6b9549e3dafb256c0de7089fa6fc24c1261cf300b3ec98c26741ada8"
+      "3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af"
+  AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3BucketCBEF8050:
+    Type: String
+    Description: S3 bucket for asset
+      "3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880d"
+  AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3VersionKey57968381:
+    Type: String
+    Description: S3 key for asset version
+      "3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880d"
+  AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dArtifactHash3B82A2B3:
+    Type: String
+    Description: Artifact hash for asset
+      "3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880d"
 
 `;


### PR DESCRIPTION
The daily reprocessing job enqueues 60,000 packages all at once
every day to be reprocessed. This completely overloads the ECS
cluster, with the following consequences:

* On-demand work (like the NPM follower) suffers from being drowned
  out by 60k work items, and our latency on processing package updates
  spikes to 30 minutes or sometimes even more than an hour, triggering
  alarms.
* Since there is no backpressure, we keep on hammering the ECS cluster
  trying to start tasks, retrying until it succeeds. Eventually this
  sometimes still fails and messages end up in the DLQ, triggering
  alarms and requiring human intervention.

This PR mellows the reprocessing driver out a bit, by not having it fill
the worker queue as fast as it can: instead, we will feed the system
work at about the pace we know it can process it, with a little extra
margin for on-demand work. We do that by sleeping in between the redrive
batches.

Based on estimes I've done, it takes on average about 4 minutes to
process a single package. We use 1000 ECS workers to process 60,000
items in 4 hours.

This PR raises the delay between batches of 1000 jobs to 5 minutes (20%
margin). This will make us process the 60k items in 5 hours instead of
4, but at least we won't be triggering as many alarms as we used to.

Backpressure and fair queueing would have been a better solution,
but that requires a more thorough rearchitecting of the system. In the
mean time, this solution will alleviate the worst pressure.

The parameters of the wait calculation are directly available in the
code, and will be easy to change once this is deployed and we can
see how it behaves.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*