### PR TITLE
docs: package canary triggers high severity alarm

### DIFF
--- a/docs/application-overview.md
+++ b/docs/application-overview.md
@@ -212,7 +212,7 @@ emits metrics that help understand how much time elapses between the package
 publication to npmjs.com (`construct-hub-probe` gets a new version approximately
 every 3 hours), and when those packages are available to browse in ConstructHub.
 
-A **low-severity** alarm triggers if the canary function is either
+A **high-severity** alarm triggers if the canary function is either
 malfunctioning or detects discovery SLA breaches. Troubleshooting these alarms
 is described in the operator runbook.
 


### PR DESCRIPTION
The severity of the alarm was changed in https://github.com/cdklabs/construct-hub/pull/597, but wasn't updated here.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*