### PR TITLE
fix: inventory canary reporting packages as unknown

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -225,18 +225,6 @@ Object {
       "Description": "S3 key for asset version \\"3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880d\\"",
       "Type": "String",
     },
-    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afArtifactHash7F8A76FC": Object {
-      "Description": "Artifact hash for asset \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
-      "Type": "String",
-    },
-    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3Bucket5515214C": Object {
-      "Description": "S3 bucket for asset \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
-      "Type": "String",
-    },
-    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED": Object {
-      "Description": "S3 key for asset version \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
-      "Type": "String",
-    },
     "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bArtifactHash5ABBFB9B": Object {
       "Description": "Artifact hash for asset \\"42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2b\\"",
       "Type": "String",
@@ -343,6 +331,18 @@ Object {
     },
     "AssetParametersb120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827S3VersionKeyB95D17C3": Object {
       "Description": "S3 key for asset version \\"b120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827\\"",
+      "Type": "String",
+    },
+    "AssetParametersc15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73ArtifactHashE8AF1E10": Object {
+      "Description": "Artifact hash for asset \\"c15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73\\"",
+      "Type": "String",
+    },
+    "AssetParametersc15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73S3Bucket9A67A1B5": Object {
+      "Description": "S3 bucket for asset \\"c15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73\\"",
+      "Type": "String",
+    },
+    "AssetParametersc15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73S3VersionKey1FAC44E5": Object {
+      "Description": "S3 key for asset version \\"c15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73\\"",
       "Type": "String",
     },
     "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcArtifactHash4E26EEC4": Object {
@@ -3350,7 +3350,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3Bucket5515214C",
+            "Ref": "AssetParametersc15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73S3Bucket9A67A1B5",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -3363,7 +3363,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED",
+                          "Ref": "AssetParametersc15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73S3VersionKey1FAC44E5",
                         },
                       ],
                     },
@@ -3376,7 +3376,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED",
+                          "Ref": "AssetParametersc15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73S3VersionKey1FAC44E5",
                         },
                       ],
                     },
@@ -11383,18 +11383,6 @@ Object {
       "Description": "S3 key for asset version \\"3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880d\\"",
       "Type": "String",
     },
-    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afArtifactHash7F8A76FC": Object {
-      "Description": "Artifact hash for asset \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
-      "Type": "String",
-    },
-    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3Bucket5515214C": Object {
-      "Description": "S3 bucket for asset \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
-      "Type": "String",
-    },
-    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED": Object {
-      "Description": "S3 key for asset version \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
-      "Type": "String",
-    },
     "AssetParameters4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbcArtifactHashF236251A": Object {
       "Description": "Artifact hash for asset \\"4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbc\\"",
       "Type": "String",
@@ -11513,6 +11501,18 @@ Object {
     },
     "AssetParametersb120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827S3VersionKeyB95D17C3": Object {
       "Description": "S3 key for asset version \\"b120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827\\"",
+      "Type": "String",
+    },
+    "AssetParametersc15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73ArtifactHashE8AF1E10": Object {
+      "Description": "Artifact hash for asset \\"c15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73\\"",
+      "Type": "String",
+    },
+    "AssetParametersc15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73S3Bucket9A67A1B5": Object {
+      "Description": "S3 bucket for asset \\"c15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73\\"",
+      "Type": "String",
+    },
+    "AssetParametersc15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73S3VersionKey1FAC44E5": Object {
+      "Description": "S3 key for asset version \\"c15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73\\"",
       "Type": "String",
     },
     "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcArtifactHash4E26EEC4": Object {
@@ -14907,7 +14907,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3Bucket5515214C",
+            "Ref": "AssetParametersc15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73S3Bucket9A67A1B5",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -14920,7 +14920,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED",
+                          "Ref": "AssetParametersc15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73S3VersionKey1FAC44E5",
                         },
                       ],
                     },
@@ -14933,7 +14933,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED",
+                          "Ref": "AssetParametersc15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73S3VersionKey1FAC44E5",
                         },
                       ],
                     },
@@ -23013,18 +23013,6 @@ Object {
       "Description": "S3 key for asset version \\"3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880d\\"",
       "Type": "String",
     },
-    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afArtifactHash7F8A76FC": Object {
-      "Description": "Artifact hash for asset \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
-      "Type": "String",
-    },
-    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3Bucket5515214C": Object {
-      "Description": "S3 bucket for asset \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
-      "Type": "String",
-    },
-    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED": Object {
-      "Description": "S3 key for asset version \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
-      "Type": "String",
-    },
     "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bArtifactHash5ABBFB9B": Object {
       "Description": "Artifact hash for asset \\"42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2b\\"",
       "Type": "String",
@@ -23131,6 +23119,18 @@ Object {
     },
     "AssetParametersb120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827S3VersionKeyB95D17C3": Object {
       "Description": "S3 key for asset version \\"b120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827\\"",
+      "Type": "String",
+    },
+    "AssetParametersc15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73ArtifactHashE8AF1E10": Object {
+      "Description": "Artifact hash for asset \\"c15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73\\"",
+      "Type": "String",
+    },
+    "AssetParametersc15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73S3Bucket9A67A1B5": Object {
+      "Description": "S3 bucket for asset \\"c15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73\\"",
+      "Type": "String",
+    },
+    "AssetParametersc15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73S3VersionKey1FAC44E5": Object {
+      "Description": "S3 key for asset version \\"c15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73\\"",
       "Type": "String",
     },
     "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcArtifactHash4E26EEC4": Object {
@@ -26138,7 +26138,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3Bucket5515214C",
+            "Ref": "AssetParametersc15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73S3Bucket9A67A1B5",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -26151,7 +26151,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED",
+                          "Ref": "AssetParametersc15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73S3VersionKey1FAC44E5",
                         },
                       ],
                     },
@@ -26164,7 +26164,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED",
+                          "Ref": "AssetParametersc15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73S3VersionKey1FAC44E5",
                         },
                       ],
                     },
@@ -34193,18 +34193,6 @@ Object {
       "Description": "S3 key for asset version \\"3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880d\\"",
       "Type": "String",
     },
-    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afArtifactHash7F8A76FC": Object {
-      "Description": "Artifact hash for asset \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
-      "Type": "String",
-    },
-    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3Bucket5515214C": Object {
-      "Description": "S3 bucket for asset \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
-      "Type": "String",
-    },
-    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED": Object {
-      "Description": "S3 key for asset version \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
-      "Type": "String",
-    },
     "AssetParameters42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2bArtifactHash5ABBFB9B": Object {
       "Description": "Artifact hash for asset \\"42242d331d9eb24f823fd3bf6f8cb33ccdecd491ae17b49ab9f70add851c9a2b\\"",
       "Type": "String",
@@ -34323,6 +34311,18 @@ Object {
     },
     "AssetParametersb120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827S3VersionKeyB95D17C3": Object {
       "Description": "S3 key for asset version \\"b120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827\\"",
+      "Type": "String",
+    },
+    "AssetParametersc15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73ArtifactHashE8AF1E10": Object {
+      "Description": "Artifact hash for asset \\"c15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73\\"",
+      "Type": "String",
+    },
+    "AssetParametersc15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73S3Bucket9A67A1B5": Object {
+      "Description": "S3 bucket for asset \\"c15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73\\"",
+      "Type": "String",
+    },
+    "AssetParametersc15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73S3VersionKey1FAC44E5": Object {
+      "Description": "S3 key for asset version \\"c15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73\\"",
       "Type": "String",
     },
     "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcArtifactHash4E26EEC4": Object {
@@ -37479,7 +37479,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3Bucket5515214C",
+            "Ref": "AssetParametersc15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73S3Bucket9A67A1B5",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -37492,7 +37492,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED",
+                          "Ref": "AssetParametersc15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73S3VersionKey1FAC44E5",
                         },
                       ],
                     },
@@ -37505,7 +37505,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED",
+                          "Ref": "AssetParametersc15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73S3VersionKey1FAC44E5",
                         },
                       ],
                     },
@@ -45800,18 +45800,6 @@ Object {
       "Description": "S3 key for asset version \\"3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880d\\"",
       "Type": "String",
     },
-    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afArtifactHash7F8A76FC": Object {
-      "Description": "Artifact hash for asset \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
-      "Type": "String",
-    },
-    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3Bucket5515214C": Object {
-      "Description": "S3 bucket for asset \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
-      "Type": "String",
-    },
-    "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED": Object {
-      "Description": "S3 key for asset version \\"3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af\\"",
-      "Type": "String",
-    },
     "AssetParameters4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbcArtifactHashF236251A": Object {
       "Description": "Artifact hash for asset \\"4074092ab8b435c90a773e082601fa36def54c91cadfae59451bd0beda547cbc\\"",
       "Type": "String",
@@ -45930,6 +45918,18 @@ Object {
     },
     "AssetParametersb120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827S3VersionKeyB95D17C3": Object {
       "Description": "S3 key for asset version \\"b120b13d9d868c7622e7db1b68bae4c0f82ffd0227b8c15f2cef38e186ff3827\\"",
+      "Type": "String",
+    },
+    "AssetParametersc15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73ArtifactHashE8AF1E10": Object {
+      "Description": "Artifact hash for asset \\"c15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73\\"",
+      "Type": "String",
+    },
+    "AssetParametersc15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73S3Bucket9A67A1B5": Object {
+      "Description": "S3 bucket for asset \\"c15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73\\"",
+      "Type": "String",
+    },
+    "AssetParametersc15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73S3VersionKey1FAC44E5": Object {
+      "Description": "S3 key for asset version \\"c15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73\\"",
       "Type": "String",
     },
     "AssetParametersc62e083d24b48a05afd7c23f907a4f029563679317f06e6a8f4fc8604d07cafcArtifactHash4E26EEC4": Object {
@@ -49172,7 +49172,7 @@ Direct link to the function: /lambda/home#/functions/",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3Bucket5515214C",
+            "Ref": "AssetParametersc15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73S3Bucket9A67A1B5",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -49185,7 +49185,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED",
+                          "Ref": "AssetParametersc15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73S3VersionKey1FAC44E5",
                         },
                       ],
                     },
@@ -49198,7 +49198,7 @@ Direct link to the function: /lambda/home#/functions/",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED",
+                          "Ref": "AssetParametersc15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73S3VersionKey1FAC44E5",
                         },
                       ],
                     },

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -6238,7 +6238,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3Bucket5515214C
+          Ref: AssetParametersc15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73S3Bucket9A67A1B5
         S3Key:
           Fn::Join:
             - ""
@@ -6246,12 +6246,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED
+                      - Ref: AssetParametersc15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73S3VersionKey1FAC44E5
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED
+                      - Ref: AssetParametersc15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73S3VersionKey1FAC44E5
       Role:
         Fn::GetAtt:
           - ConstructHubInventoryCanaryServiceRole7684EDDE
@@ -8027,18 +8027,18 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "3870b20307cc608daccb2fee12cb05779bef5f63a673e46f3b1fce6ecfcb73e5"
-  AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3Bucket5515214C:
+  AssetParametersc15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73S3Bucket9A67A1B5:
     Type: String
     Description: S3 bucket for asset
-      "3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af"
-  AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afS3VersionKey5A15A9ED:
+      "c15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73"
+  AssetParametersc15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73S3VersionKey1FAC44E5:
     Type: String
     Description: S3 key for asset version
-      "3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af"
-  AssetParameters3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0afArtifactHash7F8A76FC:
+      "c15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73"
+  AssetParametersc15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73ArtifactHashE8AF1E10:
     Type: String
     Description: Artifact hash for asset
-      "3cd8df6e5bc44b55ad09d7cc673dfafdb457403f0f909791b9060da05e61e0af"
+      "c15e4d7d406ff1e3d372053b4c71f3b1b32bc7d3081fff77ad88907c41489e73"
   AssetParameters3a01b7768b85490df938bd83982d28d5bc2417457fbc70c07eaa72e455e9880dS3BucketCBEF8050:
     Type: String
     Description: S3 bucket for asset


### PR DESCRIPTION
Our package canary was reporting most packages as unknown or missing because of a bug where we were matching against keys incorrectly. This PR fixes the bug, and cleans up the rest of the canary code to properly handle the fact that we are generating both json and markdown documents, but do not want to double count the number of identified packages (nor count either type of file as "unknown").

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*