### PR TITLE
fix: transliterator fails when reprocessing an uninstallable package

### DIFF
--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -703,3 +703,16 @@ ECS tasks emit logs into CloudWatch under a log group called
 `ConstructHubOrchestrationTransliteratorLogGroup`
 in its name and the log stream `transliterator/Resource/$TASKID` (e.g.
 `transliterator/Resource/6b5c48f0a7624396899c6a3c8474d5c7`).
+
+## Errors encountered in the past
+
+### `Forbidden: null`
+
+Usually, "Forbidden" with no additional details comes when you attempt to read
+S3 objects that are SSE-encrypted, but you don't have permissions to decrypt
+using the KMS key that encrypted the object; or when you attempt to read an
+object from S3 that does not exist, or when you simply don't have the
+appropriate IAM permissions for.
+
+If you see this error, try checking that IAM permissions are configured
+correctly for the respective backend component.

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -6640,6 +6640,9 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             },
             Object {
               "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
                 "s3:DeleteObject*",
                 "s3:PutObject*",
                 "s3:Abort*",
@@ -18270,6 +18273,9 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             },
             Object {
               "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
                 "s3:DeleteObject*",
                 "s3:PutObject*",
                 "s3:Abort*",
@@ -29428,6 +29434,9 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             },
             Object {
               "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
                 "s3:DeleteObject*",
                 "s3:PutObject*",
                 "s3:Abort*",
@@ -40791,6 +40800,9 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             },
             Object {
               "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
                 "s3:DeleteObject*",
                 "s3:PutObject*",
                 "s3:Abort*",
@@ -52091,6 +52103,9 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             },
             Object {
               "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
                 "s3:DeleteObject*",
                 "s3:PutObject*",
                 "s3:Abort*",
@@ -55412,39 +55427,6 @@ Direct link to Lambda function: /lambda/home#/functions/",
                         ],
                       },
                       "/data/*/package.tgz",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:Abort*",
-                "s3:DeleteObject*",
-                "s3:PutObject*",
-              ],
-              "Effect": "Allow",
-              "Principal": Object {
-                "AWS": "*",
-              },
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ConstructHubPackageDataDC5EF35E",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ConstructHubPackageDataDC5EF35E",
-                          "Arn",
-                        ],
-                      },
-                      "/data/*/uninstallable",
                     ],
                   ],
                 },

--- a/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
+++ b/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
@@ -414,6 +414,9 @@ Object {
             },
             Object {
               "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
                 "s3:DeleteObject*",
                 "s3:PutObject*",
                 "s3:Abort*",
@@ -1621,6 +1624,9 @@ Object {
             },
             Object {
               "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
                 "s3:DeleteObject*",
                 "s3:PutObject*",
                 "s3:Abort*",
@@ -3018,6 +3024,9 @@ Object {
             },
             Object {
               "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
                 "s3:DeleteObject*",
                 "s3:PutObject*",
                 "s3:Abort*",
@@ -4221,6 +4230,9 @@ Object {
             },
             Object {
               "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
                 "s3:DeleteObject*",
                 "s3:PutObject*",
                 "s3:Abort*",

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -1205,23 +1205,6 @@ Resources:
                         - ConstructHubPackageDataDC5EF35E
                         - Arn
                     - /data/*/package.tgz
-          - Action:
-              - s3:Abort*
-              - s3:DeleteObject*
-              - s3:PutObject*
-            Effect: Allow
-            Principal:
-              AWS: "*"
-            Resource:
-              - Fn::GetAtt:
-                  - ConstructHubPackageDataDC5EF35E
-                  - Arn
-              - Fn::Join:
-                  - ""
-                  - - Fn::GetAtt:
-                        - ConstructHubPackageDataDC5EF35E
-                        - Arn
-                    - /data/*/uninstallable
           - Action: s3:DeleteObject*
             Effect: Allow
             Principal:
@@ -3042,6 +3025,9 @@ Resources:
                         - Arn
                     - /data/*/package.tgz
           - Action:
+              - s3:GetObject*
+              - s3:GetBucket*
+              - s3:List*
               - s3:DeleteObject*
               - s3:PutObject*
               - s3:Abort*

--- a/src/backend/transliterator/index.ts
+++ b/src/backend/transliterator/index.ts
@@ -139,7 +139,7 @@ export class Transliterator extends Construct {
     // The task handler reads & writes to this bucket.
     bucket.grantRead(this.taskDefinition.taskRole, `${constants.STORAGE_KEY_PREFIX}*${constants.ASSEMBLY_KEY_SUFFIX}`);
     bucket.grantRead(this.taskDefinition.taskRole, `${constants.STORAGE_KEY_PREFIX}*${constants.PACKAGE_KEY_SUFFIX}`);
-    bucket.grantWrite(this.taskDefinition.taskRole, `${constants.STORAGE_KEY_PREFIX}*${constants.UNINSTALLABLE_PACKAGE_SUFFIX}`);
+    bucket.grantReadWrite(this.taskDefinition.taskRole, `${constants.STORAGE_KEY_PREFIX}*${constants.UNINSTALLABLE_PACKAGE_SUFFIX}`);
     bucket.grantDelete(this.taskDefinition.taskRole, `${constants.STORAGE_KEY_PREFIX}*${constants.UNINSTALLABLE_PACKAGE_SUFFIX}`);
     for (const language of DocumentationLanguage.ALL) {
       bucket.grantWrite(this.taskDefinition.taskRole, `${constants.STORAGE_KEY_PREFIX}*${constants.docsKeySuffix(language)}`);


### PR DESCRIPTION
Fixes #759

In some cases, we noticed messages appearing in our Orchestration DLQ with the message "Forbidden: null". This message suggests a permission error. We identified the most likely cause was the transliterator ECS task did not have the correct permission to read "uninstallable" object markers that we assign to packages that fail to install with `npm install`. We were currently granting write and delete permissions, but not read permissions.

I would add a unit test for our transliterator to prevent a regression for this path in the code, but the cause of this bug is a permission error so it wouldn't really be caught by any test we write unless it was a full-on integration test, which is a bit out of the scope of this PR. 

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*