### PR TITLE
fix: remove error messages from redriven messages

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -307,6 +307,18 @@ Object {
       "Description": "S3 key for asset version \\"1eb1a8b09c010aa386d0860d47a3865354b523d00a55795cfa68aa5b99ea916c\\"",
       "Type": "String",
     },
+    "AssetParameters31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867daceArtifactHash4DF9DAC8": Object {
+      "Description": "Artifact hash for asset \\"31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867dace\\"",
+      "Type": "String",
+    },
+    "AssetParameters31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867daceS3Bucket4E159600": Object {
+      "Description": "S3 bucket for asset \\"31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867dace\\"",
+      "Type": "String",
+    },
+    "AssetParameters31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867daceS3VersionKey61669188": Object {
+      "Description": "S3 key for asset version \\"31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867dace\\"",
+      "Type": "String",
+    },
     "AssetParameters3291be6767d37fffafc188da9b85e5084da3e5ce0565205d3b36ce549726bf14ArtifactHashD2367AE9": Object {
       "Description": "Artifact hash for asset \\"3291be6767d37fffafc188da9b85e5084da3e5ce0565205d3b36ce549726bf14\\"",
       "Type": "String",
@@ -425,18 +437,6 @@ Object {
     },
     "AssetParametersa102f24681b309963ff381a0e6bd1dccf236191a34f18f5f5866dde24c598f73S3VersionKey84870974": Object {
       "Description": "S3 key for asset version \\"a102f24681b309963ff381a0e6bd1dccf236191a34f18f5f5866dde24c598f73\\"",
-      "Type": "String",
-    },
-    "AssetParametersa71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6ArtifactHash02C9FC1F": Object {
-      "Description": "Artifact hash for asset \\"a71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6\\"",
-      "Type": "String",
-    },
-    "AssetParametersa71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6S3BucketC44050A1": Object {
-      "Description": "S3 bucket for asset \\"a71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6\\"",
-      "Type": "String",
-    },
-    "AssetParametersa71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6S3VersionKey4894796F": Object {
-      "Description": "S3 key for asset version \\"a71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6\\"",
       "Type": "String",
     },
     "AssetParametersb1828dc5c59a67cdab0912fddf1877c214999f3b0b9852b89e70683c185c4c08ArtifactHash10AF57DA": Object {
@@ -5770,7 +5770,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersa71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6S3BucketC44050A1",
+            "Ref": "AssetParameters31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867daceS3Bucket4E159600",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -5783,7 +5783,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersa71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6S3VersionKey4894796F",
+                          "Ref": "AssetParameters31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867daceS3VersionKey61669188",
                         },
                       ],
                     },
@@ -5796,7 +5796,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersa71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6S3VersionKey4894796F",
+                          "Ref": "AssetParameters31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867daceS3VersionKey61669188",
                         },
                       ],
                     },
@@ -11690,6 +11690,18 @@ Object {
       "Description": "S3 key for asset version \\"1eb1a8b09c010aa386d0860d47a3865354b523d00a55795cfa68aa5b99ea916c\\"",
       "Type": "String",
     },
+    "AssetParameters31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867daceArtifactHash4DF9DAC8": Object {
+      "Description": "Artifact hash for asset \\"31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867dace\\"",
+      "Type": "String",
+    },
+    "AssetParameters31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867daceS3Bucket4E159600": Object {
+      "Description": "S3 bucket for asset \\"31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867dace\\"",
+      "Type": "String",
+    },
+    "AssetParameters31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867daceS3VersionKey61669188": Object {
+      "Description": "S3 key for asset version \\"31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867dace\\"",
+      "Type": "String",
+    },
     "AssetParameters3291be6767d37fffafc188da9b85e5084da3e5ce0565205d3b36ce549726bf14ArtifactHashD2367AE9": Object {
       "Description": "Artifact hash for asset \\"3291be6767d37fffafc188da9b85e5084da3e5ce0565205d3b36ce549726bf14\\"",
       "Type": "String",
@@ -11820,18 +11832,6 @@ Object {
     },
     "AssetParametersa102f24681b309963ff381a0e6bd1dccf236191a34f18f5f5866dde24c598f73S3VersionKey84870974": Object {
       "Description": "S3 key for asset version \\"a102f24681b309963ff381a0e6bd1dccf236191a34f18f5f5866dde24c598f73\\"",
-      "Type": "String",
-    },
-    "AssetParametersa71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6ArtifactHash02C9FC1F": Object {
-      "Description": "Artifact hash for asset \\"a71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6\\"",
-      "Type": "String",
-    },
-    "AssetParametersa71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6S3BucketC44050A1": Object {
-      "Description": "S3 bucket for asset \\"a71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6\\"",
-      "Type": "String",
-    },
-    "AssetParametersa71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6S3VersionKey4894796F": Object {
-      "Description": "S3 key for asset version \\"a71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6\\"",
       "Type": "String",
     },
     "AssetParametersb1828dc5c59a67cdab0912fddf1877c214999f3b0b9852b89e70683c185c4c08ArtifactHash10AF57DA": Object {
@@ -17552,7 +17552,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersa71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6S3BucketC44050A1",
+            "Ref": "AssetParameters31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867daceS3Bucket4E159600",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -17565,7 +17565,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersa71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6S3VersionKey4894796F",
+                          "Ref": "AssetParameters31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867daceS3VersionKey61669188",
                         },
                       ],
                     },
@@ -17578,7 +17578,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersa71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6S3VersionKey4894796F",
+                          "Ref": "AssetParameters31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867daceS3VersionKey61669188",
                         },
                       ],
                     },
@@ -23545,6 +23545,18 @@ Object {
       "Description": "S3 key for asset version \\"1eb1a8b09c010aa386d0860d47a3865354b523d00a55795cfa68aa5b99ea916c\\"",
       "Type": "String",
     },
+    "AssetParameters31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867daceArtifactHash4DF9DAC8": Object {
+      "Description": "Artifact hash for asset \\"31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867dace\\"",
+      "Type": "String",
+    },
+    "AssetParameters31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867daceS3Bucket4E159600": Object {
+      "Description": "S3 bucket for asset \\"31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867dace\\"",
+      "Type": "String",
+    },
+    "AssetParameters31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867daceS3VersionKey61669188": Object {
+      "Description": "S3 key for asset version \\"31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867dace\\"",
+      "Type": "String",
+    },
     "AssetParameters3291be6767d37fffafc188da9b85e5084da3e5ce0565205d3b36ce549726bf14ArtifactHashD2367AE9": Object {
       "Description": "Artifact hash for asset \\"3291be6767d37fffafc188da9b85e5084da3e5ce0565205d3b36ce549726bf14\\"",
       "Type": "String",
@@ -23663,18 +23675,6 @@ Object {
     },
     "AssetParametersa102f24681b309963ff381a0e6bd1dccf236191a34f18f5f5866dde24c598f73S3VersionKey84870974": Object {
       "Description": "S3 key for asset version \\"a102f24681b309963ff381a0e6bd1dccf236191a34f18f5f5866dde24c598f73\\"",
-      "Type": "String",
-    },
-    "AssetParametersa71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6ArtifactHash02C9FC1F": Object {
-      "Description": "Artifact hash for asset \\"a71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6\\"",
-      "Type": "String",
-    },
-    "AssetParametersa71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6S3BucketC44050A1": Object {
-      "Description": "S3 bucket for asset \\"a71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6\\"",
-      "Type": "String",
-    },
-    "AssetParametersa71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6S3VersionKey4894796F": Object {
-      "Description": "S3 key for asset version \\"a71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6\\"",
       "Type": "String",
     },
     "AssetParametersb1828dc5c59a67cdab0912fddf1877c214999f3b0b9852b89e70683c185c4c08ArtifactHash10AF57DA": Object {
@@ -29008,7 +29008,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersa71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6S3BucketC44050A1",
+            "Ref": "AssetParameters31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867daceS3Bucket4E159600",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -29021,7 +29021,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersa71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6S3VersionKey4894796F",
+                          "Ref": "AssetParameters31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867daceS3VersionKey61669188",
                         },
                       ],
                     },
@@ -29034,7 +29034,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersa71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6S3VersionKey4894796F",
+                          "Ref": "AssetParameters31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867daceS3VersionKey61669188",
                         },
                       ],
                     },
@@ -34936,6 +34936,18 @@ Object {
       "Description": "S3 key for asset version \\"1eb1a8b09c010aa386d0860d47a3865354b523d00a55795cfa68aa5b99ea916c\\"",
       "Type": "String",
     },
+    "AssetParameters31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867daceArtifactHash4DF9DAC8": Object {
+      "Description": "Artifact hash for asset \\"31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867dace\\"",
+      "Type": "String",
+    },
+    "AssetParameters31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867daceS3Bucket4E159600": Object {
+      "Description": "S3 bucket for asset \\"31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867dace\\"",
+      "Type": "String",
+    },
+    "AssetParameters31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867daceS3VersionKey61669188": Object {
+      "Description": "S3 key for asset version \\"31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867dace\\"",
+      "Type": "String",
+    },
     "AssetParameters3291be6767d37fffafc188da9b85e5084da3e5ce0565205d3b36ce549726bf14ArtifactHashD2367AE9": Object {
       "Description": "Artifact hash for asset \\"3291be6767d37fffafc188da9b85e5084da3e5ce0565205d3b36ce549726bf14\\"",
       "Type": "String",
@@ -35054,18 +35066,6 @@ Object {
     },
     "AssetParametersa102f24681b309963ff381a0e6bd1dccf236191a34f18f5f5866dde24c598f73S3VersionKey84870974": Object {
       "Description": "S3 key for asset version \\"a102f24681b309963ff381a0e6bd1dccf236191a34f18f5f5866dde24c598f73\\"",
-      "Type": "String",
-    },
-    "AssetParametersa71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6ArtifactHash02C9FC1F": Object {
-      "Description": "Artifact hash for asset \\"a71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6\\"",
-      "Type": "String",
-    },
-    "AssetParametersa71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6S3BucketC44050A1": Object {
-      "Description": "S3 bucket for asset \\"a71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6\\"",
-      "Type": "String",
-    },
-    "AssetParametersa71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6S3VersionKey4894796F": Object {
-      "Description": "S3 key for asset version \\"a71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6\\"",
       "Type": "String",
     },
     "AssetParametersb1828dc5c59a67cdab0912fddf1877c214999f3b0b9852b89e70683c185c4c08ArtifactHash10AF57DA": Object {
@@ -40594,7 +40594,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersa71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6S3BucketC44050A1",
+            "Ref": "AssetParameters31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867daceS3Bucket4E159600",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -40607,7 +40607,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersa71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6S3VersionKey4894796F",
+                          "Ref": "AssetParameters31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867daceS3VersionKey61669188",
                         },
                       ],
                     },
@@ -40620,7 +40620,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersa71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6S3VersionKey4894796F",
+                          "Ref": "AssetParameters31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867daceS3VersionKey61669188",
                         },
                       ],
                     },
@@ -46780,6 +46780,18 @@ Object {
       "Description": "S3 key for asset version \\"1eb1a8b09c010aa386d0860d47a3865354b523d00a55795cfa68aa5b99ea916c\\"",
       "Type": "String",
     },
+    "AssetParameters31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867daceArtifactHash4DF9DAC8": Object {
+      "Description": "Artifact hash for asset \\"31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867dace\\"",
+      "Type": "String",
+    },
+    "AssetParameters31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867daceS3Bucket4E159600": Object {
+      "Description": "S3 bucket for asset \\"31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867dace\\"",
+      "Type": "String",
+    },
+    "AssetParameters31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867daceS3VersionKey61669188": Object {
+      "Description": "S3 key for asset version \\"31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867dace\\"",
+      "Type": "String",
+    },
     "AssetParameters3291be6767d37fffafc188da9b85e5084da3e5ce0565205d3b36ce549726bf14ArtifactHashD2367AE9": Object {
       "Description": "Artifact hash for asset \\"3291be6767d37fffafc188da9b85e5084da3e5ce0565205d3b36ce549726bf14\\"",
       "Type": "String",
@@ -46910,18 +46922,6 @@ Object {
     },
     "AssetParametersa102f24681b309963ff381a0e6bd1dccf236191a34f18f5f5866dde24c598f73S3VersionKey84870974": Object {
       "Description": "S3 key for asset version \\"a102f24681b309963ff381a0e6bd1dccf236191a34f18f5f5866dde24c598f73\\"",
-      "Type": "String",
-    },
-    "AssetParametersa71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6ArtifactHash02C9FC1F": Object {
-      "Description": "Artifact hash for asset \\"a71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6\\"",
-      "Type": "String",
-    },
-    "AssetParametersa71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6S3BucketC44050A1": Object {
-      "Description": "S3 bucket for asset \\"a71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6\\"",
-      "Type": "String",
-    },
-    "AssetParametersa71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6S3VersionKey4894796F": Object {
-      "Description": "S3 key for asset version \\"a71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6\\"",
       "Type": "String",
     },
     "AssetParametersb1828dc5c59a67cdab0912fddf1877c214999f3b0b9852b89e70683c185c4c08ArtifactHash10AF57DA": Object {
@@ -52113,7 +52113,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersa71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6S3BucketC44050A1",
+            "Ref": "AssetParameters31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867daceS3Bucket4E159600",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -52126,7 +52126,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersa71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6S3VersionKey4894796F",
+                          "Ref": "AssetParameters31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867daceS3VersionKey61669188",
                         },
                       ],
                     },
@@ -52139,7 +52139,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersa71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6S3VersionKey4894796F",
+                          "Ref": "AssetParameters31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867daceS3VersionKey61669188",
                         },
                       ],
                     },

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -3944,7 +3944,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParametersa71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6S3BucketC44050A1
+          Ref: AssetParameters31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867daceS3Bucket4E159600
         S3Key:
           Fn::Join:
             - ""
@@ -3952,12 +3952,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersa71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6S3VersionKey4894796F
+                      - Ref: AssetParameters31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867daceS3VersionKey61669188
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParametersa71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6S3VersionKey4894796F
+                      - Ref: AssetParameters31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867daceS3VersionKey61669188
       Role:
         Fn::GetAtt:
           - ConstructHubOrchestrationRedriveServiceRoleB84EFF33
@@ -7961,18 +7961,18 @@ Parameters:
     Type: String
     Description: Artifact hash for asset
       "536462136e351119f12366ccd15cfd778200577a1ed1fc4422a7cb6e57fcfc57"
-  AssetParametersa71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6S3BucketC44050A1:
+  AssetParameters31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867daceS3Bucket4E159600:
     Type: String
     Description: S3 bucket for asset
-      "a71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6"
-  AssetParametersa71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6S3VersionKey4894796F:
+      "31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867dace"
+  AssetParameters31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867daceS3VersionKey61669188:
     Type: String
     Description: S3 key for asset version
-      "a71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6"
-  AssetParametersa71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6ArtifactHash02C9FC1F:
+      "31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867dace"
+  AssetParameters31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867daceArtifactHash4DF9DAC8:
     Type: String
     Description: Artifact hash for asset
-      "a71db9dd1627d88166a2fb3ff223ee5cfacba25017a4cdc1d859b1be1e8d39f6"
+      "31fadf0cd6c7acfedd6b2b7505b8660c93da8b459c65b8bc34cad5df4867dace"
   AssetParametersb32de5d6fb92c01b03e93e387691b3f444ac4e9800273abf834874c427c640f0S3Bucket0D334DA1:
     Type: String
     Description: S3 bucket for asset

--- a/src/backend/orchestration/redrive-state-machine.lambda.ts
+++ b/src/backend/orchestration/redrive-state-machine.lambda.ts
@@ -15,10 +15,13 @@ export async function handler(event: unknown, context: Context): Promise<void> {
     const input = JSON.parse(message.Body!);
     console.log(`Redriving message ${JSON.stringify(input, null, 2)}`);
 
+    // Strip the docgen field before redriving as this contains error messages that
+    // be too long for ECS inputs.
+    const { docGen, ...formatted } = input;
     const { executionArn } = await sfn.startExecution({
       stateMachineArn: stateMachineArn,
       input: JSON.stringify({
-        ...input,
+        ...formatted,
         // Remove the _error information
         _error: undefined,
         // Add the redrive information


### PR DESCRIPTION
Removes the docGen field from messages before redriving to the
orchestration SFN input. Previously, these could become too long and
would cause redriving to error with "Container Overrides length must be
at most..."

Notably, when starting to generate Go documentation, some packages
failed because the rosetta tablet had been generated before jsii-rosetta
supported Go. These failures were sent to the DLQ with the error
message "The following snippet was not found in any of the loaded
tablets: SNIPPET", where the snippet could be understandably quite long.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*