### PR TITLE
chore: reduce aggressiveness of NoChanges alarm

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -8810,7 +8810,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "Fn::Join": Array [
             "",
             Array [
-              "The NpmJs follower function is no discovering any changes from CouchDB!
+              "The NpmJs follower function is not discovering any changes from CouchDB!
 
 RunBook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md
 
@@ -8823,7 +8823,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
         },
         "AlarmName": "Test/ConstructHub/Sources/NpmJs/Follower/NoChanges",
         "ComparisonOperator": "LessThanThreshold",
-        "EvaluationPeriods": 2,
+        "EvaluationPeriods": 1,
         "MetricName": "ChangeCount",
         "Namespace": "ConstructHub/PackageSource/NpmJs/Follower",
         "Period": 300,
@@ -21258,7 +21258,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "Fn::Join": Array [
             "",
             Array [
-              "The NpmJs follower function is no discovering any changes from CouchDB!
+              "The NpmJs follower function is not discovering any changes from CouchDB!
 
 RunBook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md
 
@@ -21271,7 +21271,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
         },
         "AlarmName": "Test/ConstructHub/Sources/NpmJs/Follower/NoChanges",
         "ComparisonOperator": "LessThanThreshold",
-        "EvaluationPeriods": 2,
+        "EvaluationPeriods": 1,
         "MetricName": "ChangeCount",
         "Namespace": "ConstructHub/PackageSource/NpmJs/Follower",
         "Period": 300,
@@ -33234,7 +33234,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "Fn::Join": Array [
             "",
             Array [
-              "The NpmJs follower function is no discovering any changes from CouchDB!
+              "The NpmJs follower function is not discovering any changes from CouchDB!
 
 RunBook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md
 
@@ -33247,7 +33247,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
         },
         "AlarmName": "Test/ConstructHub/Sources/NpmJs/Follower/NoChanges",
         "ComparisonOperator": "LessThanThreshold",
-        "EvaluationPeriods": 2,
+        "EvaluationPeriods": 1,
         "MetricName": "ChangeCount",
         "Namespace": "ConstructHub/PackageSource/NpmJs/Follower",
         "Period": 300,
@@ -45400,7 +45400,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "Fn::Join": Array [
             "",
             Array [
-              "The NpmJs follower function is no discovering any changes from CouchDB!
+              "The NpmJs follower function is not discovering any changes from CouchDB!
 
 RunBook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md
 
@@ -45413,7 +45413,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
         },
         "AlarmName": "Test/ConstructHub/Sources/NpmJs/Follower/NoChanges",
         "ComparisonOperator": "LessThanThreshold",
-        "EvaluationPeriods": 2,
+        "EvaluationPeriods": 1,
         "MetricName": "ChangeCount",
         "Namespace": "ConstructHub/PackageSource/NpmJs/Follower",
         "Period": 300,
@@ -57593,7 +57593,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "Fn::Join": Array [
             "",
             Array [
-              "The NpmJs follower function is no discovering any changes from CouchDB!
+              "The NpmJs follower function is not discovering any changes from CouchDB!
 
 RunBook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md
 
@@ -57606,7 +57606,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
         },
         "AlarmName": "Test/ConstructHub/Sources/NpmJs/Follower/NoChanges",
         "ComparisonOperator": "LessThanThreshold",
-        "EvaluationPeriods": 2,
+        "EvaluationPeriods": 1,
         "MetricName": "ChangeCount",
         "Namespace": "ConstructHub/PackageSource/NpmJs/Follower",
         "Period": 300,

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -6496,12 +6496,12 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       ComparisonOperator: LessThanThreshold
-      EvaluationPeriods: 2
+      EvaluationPeriods: 1
       AlarmDescription:
         Fn::Join:
           - ""
           - - >-
-              The NpmJs follower function is no discovering any changes from
+              The NpmJs follower function is not discovering any changes from
               CouchDB!
 
 


### PR DESCRIPTION
Right now, the NPM/NoChanges alarm kicks in after 10 minutes.

However, NPM periodically has changes in which it's pretty unhappy,
will throttle us heavily until the Lambda finally times out (and
subsequently, saw no changes). This cuts us nonactionable tickets
(since we don't control NPM) and is generally just annoying.

Increase the alarm sensitivy to an hour without changes.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*