### PR TITLE
fix: remove unsupported feature flags from dev app

### DIFF
--- a/.projenrc.js
+++ b/.projenrc.js
@@ -252,13 +252,10 @@ function addDevApp() {
       context: {
         '@aws-cdk/core:newStyleStackSynthesis': true,
         '@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId': true,
-        '@aws-cdk/core:enableStackNameDuplicates': 'true',
         'aws-cdk:enableDiffNoFail': 'true',
         '@aws-cdk/core:stackRelativeExports': 'true',
-        '@aws-cdk/aws-ecr-assets:dockerIgnoreSupport': true,
         '@aws-cdk/aws-secretsmanager:parseOwnedSecretName': true,
         '@aws-cdk/aws-kms:defaultKeyPolicies': true,
-        '@aws-cdk/aws-s3:grantWriteWithoutAcl': true,
         '@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount': true,
         '@aws-cdk/aws-rds:lowercaseDbIdentifier': true,
         '@aws-cdk/aws-efs:defaultEncryptionAtRest': true,


### PR DESCRIPTION
CDK V2 has default support for some of the features and the  feature flags have been removed. Removing the unsupported featur flags


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*