### PR TITLE
chore(npmjs): follower alarm should be low severity

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -4120,18 +4120,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":24,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"NpmJs/Follower Failures\\",\\"region\\":\\"",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
-              Object {
-                "Fn::GetAtt": Array [
-                  "ConstructHubSourcesNpmJsFollowerFailures86BCBA0D",
-                  "Arn",
-                ],
-              },
-              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":30,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"NpmJs/Follower Not Running\\",\\"region\\":\\"",
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":24,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"NpmJs/Follower Not Running\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -4142,7 +4131,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":36,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"New version visibility SLA breached\\",\\"region\\":\\"",
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":30,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"New version visibility SLA breached\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -9244,9 +9233,6 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
     },
     "ConstructHubSourcesNpmJsFollowerFailures86BCBA0D": Object {
       "Properties": Object {
-        "AlarmActions": Array [
-          "arn:aws:sns:us-east-1:123456789012:mystack-mytopic-NZJ5JSMVGFIE",
-        ],
         "AlarmDescription": Object {
           "Fn::Join": Array [
             "",
@@ -16405,18 +16391,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":24,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"NpmJs/Follower Failures\\",\\"region\\":\\"",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
-              Object {
-                "Fn::GetAtt": Array [
-                  "ConstructHubSourcesNpmJsFollowerFailures86BCBA0D",
-                  "Arn",
-                ],
-              },
-              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":30,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"NpmJs/Follower Not Running\\",\\"region\\":\\"",
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":24,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"NpmJs/Follower Not Running\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -16427,7 +16402,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":36,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"New version visibility SLA breached\\",\\"region\\":\\"",
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":30,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"New version visibility SLA breached\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -21602,9 +21577,6 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
     },
     "ConstructHubSourcesNpmJsFollowerFailures86BCBA0D": Object {
       "Properties": Object {
-        "AlarmActions": Array [
-          "arn:aws:sns:us-east-1:123456789012:mystack-mytopic-NZJ5JSMVGFIE",
-        ],
         "AlarmDescription": Object {
           "Fn::Join": Array [
             "",
@@ -28408,18 +28380,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":24,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"NpmJs/Follower Failures\\",\\"region\\":\\"",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
-              Object {
-                "Fn::GetAtt": Array [
-                  "ConstructHubSourcesNpmJsFollowerFailures86BCBA0D",
-                  "Arn",
-                ],
-              },
-              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":30,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"NpmJs/Follower Not Running\\",\\"region\\":\\"",
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":24,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"NpmJs/Follower Not Running\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -28430,7 +28391,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":36,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"New version visibility SLA breached\\",\\"region\\":\\"",
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":30,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"New version visibility SLA breached\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -33532,9 +33493,6 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
     },
     "ConstructHubSourcesNpmJsFollowerFailures86BCBA0D": Object {
       "Properties": Object {
-        "AlarmActions": Array [
-          "arn:aws:sns:us-east-1:123456789012:mystack-mytopic-NZJ5JSMVGFIE",
-        ],
         "AlarmDescription": Object {
           "Fn::Join": Array [
             "",
@@ -40472,18 +40430,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":36,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"NpmJs/Follower Failures\\",\\"region\\":\\"",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
-              Object {
-                "Fn::GetAtt": Array [
-                  "ConstructHubSourcesNpmJsFollowerFailures86BCBA0D",
-                  "Arn",
-                ],
-              },
-              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":42,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"NpmJs/Follower Not Running\\",\\"region\\":\\"",
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":36,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"NpmJs/Follower Not Running\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -40494,7 +40441,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":48,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"New version visibility SLA breached\\",\\"region\\":\\"",
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":42,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"New version visibility SLA breached\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -45583,9 +45530,6 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
     },
     "ConstructHubSourcesNpmJsFollowerFailures86BCBA0D": Object {
       "Properties": Object {
-        "AlarmActions": Array [
-          "arn:aws:sns:us-east-1:123456789012:mystack-mytopic-NZJ5JSMVGFIE",
-        ],
         "AlarmDescription": Object {
           "Fn::Join": Array [
             "",
@@ -52839,18 +52783,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":24,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"NpmJs/Follower Failures\\",\\"region\\":\\"",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
-              Object {
-                "Fn::GetAtt": Array [
-                  "ConstructHubSourcesNpmJsFollowerFailures86BCBA0D",
-                  "Arn",
-                ],
-              },
-              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":30,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"NpmJs/Follower Not Running\\",\\"region\\":\\"",
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":24,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"NpmJs/Follower Not Running\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -52861,7 +52794,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":36,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"New version visibility SLA breached\\",\\"region\\":\\"",
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":30,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"New version visibility SLA breached\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -57661,9 +57594,6 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
     },
     "ConstructHubSourcesNpmJsFollowerFailures86BCBA0D": Object {
       "Properties": Object {
-        "AlarmActions": Array [
-          "arn:aws:sns:us-east-1:123456789012:mystack-mytopic-NZJ5JSMVGFIE",
-        ],
         "AlarmDescription": Object {
           "Fn::Join": Array [
             "",

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -232,20 +232,13 @@ Resources:
                 - ConstructHubMonitoringWebCanaryHomePageErrorsE7BB4002
                 - Arn
             - '"]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":36,"properties":{"view":"timeSeries","title":"NpmJs/Follower
-              Failures","region":"'
-            - Ref: AWS::Region
-            - '","annotations":{"alarms":["'
-            - Fn::GetAtt:
-                - ConstructHubSourcesNpmJsFollowerFailures86BCBA0D
-                - Arn
-            - '"]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":42,"properties":{"view":"timeSeries","title":"NpmJs/Follower
               Not Running","region":"'
             - Ref: AWS::Region
             - '","annotations":{"alarms":["'
             - Fn::GetAtt:
                 - ConstructHubSourcesNpmJsFollowerNotRunningCEAF0E1E
                 - Arn
-            - '"]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":48,"properties":{"view":"timeSeries","title":"New
+            - '"]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":42,"properties":{"view":"timeSeries","title":"New
               version visibility SLA breached","region":"'
             - Ref: AWS::Region
             - '","annotations":{"alarms":["'

--- a/src/package-sources/npmjs.ts
+++ b/src/package-sources/npmjs.ts
@@ -461,7 +461,7 @@ export class NpmJs implements IPackageSource {
         threshold: 1,
         treatMissingData: TreatMissingData.MISSING,
       });
-    monitoring.addHighSeverityAlarm('NpmJs/Follower Failures', failureAlarm);
+    monitoring.addLowSeverityAlarm('NpmJs/Follower Failures', failureAlarm);
 
     const notRunningAlarm = follower
       .metricInvocations({ period: FOLLOWER_RUN_RATE })


### PR DESCRIPTION
The npmjs follower frequently fails due to issues with the npmjs
replica. In these instances there is no action item other than to wait
for the replica to recover. Lowering the severity of the alarm.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*