### PR TITLE
chore: mitigate alarm verbosity

### DIFF
--- a/API.md
+++ b/API.md
@@ -10711,7 +10711,7 @@ ConstructHub monitoring features exposed to extension points.
 ##### `addHighSeverityAlarm` <a name="addHighSeverityAlarm" id="construct-hub.IMonitoring.addHighSeverityAlarm"></a>
 
 ```typescript
-public addHighSeverityAlarm(title: string, alarm: Alarm): void
+public addHighSeverityAlarm(title: string, alarm: AlarmBase): void
 ```
 
 Adds a high-severity alarm.
@@ -10729,7 +10729,7 @@ a user-friendly title for the alarm (will be rendered on the high-severity Cloud
 
 ###### `alarm`<sup>Required</sup> <a name="alarm" id="construct-hub.IMonitoring.addHighSeverityAlarm.parameter.alarm"></a>
 
-- *Type:* aws-cdk-lib.aws_cloudwatch.Alarm
+- *Type:* aws-cdk-lib.aws_cloudwatch.AlarmBase
 
 the alarm to be added to the high-severity dashboard.
 
@@ -10738,7 +10738,7 @@ the alarm to be added to the high-severity dashboard.
 ##### `addLowSeverityAlarm` <a name="addLowSeverityAlarm" id="construct-hub.IMonitoring.addLowSeverityAlarm"></a>
 
 ```typescript
-public addLowSeverityAlarm(title: string, alarm: Alarm): void
+public addLowSeverityAlarm(title: string, alarm: AlarmBase): void
 ```
 
 Adds a low-severity alarm.
@@ -10756,7 +10756,7 @@ a user-friendly title for the alarm (not currently used).
 
 ###### `alarm`<sup>Required</sup> <a name="alarm" id="construct-hub.IMonitoring.addLowSeverityAlarm.parameter.alarm"></a>
 
-- *Type:* aws-cdk-lib.aws_cloudwatch.Alarm
+- *Type:* aws-cdk-lib.aws_cloudwatch.AlarmBase
 
 the alarm to be added.
 

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -666,6 +666,38 @@ If there is a reason why a tracked version cannot possibly be ingested, the S3
 object backing the canary state can be deleted, which will effectively
 re-initialize the canary to track only the latest available version.
 
+### `ConstructHub/Sources/NpmJs/Canary/NotRunningOrFailing`
+
+#### Description
+
+This alarm is only provisioned in case the [NpmJs package canary][package-canary]
+was configured. It triggers when the canary is not running as expected, or is
+reporting failures.
+
+When the [NpmJs package canary][package-canary] does not successfully run, the
+`ConstructHub/Sources/NpmJs/Canary/SLA-Breached` alarm cannot be triggered due
+to lack of data. This may hence hide customer-visible problems.
+
+#### Investigation
+
+In the AWS Console, verify whether the alarm triggered due to
+`ConstructHub/Sources/NpmJs/Canary/Failing` or
+`ConstructHub/Sources/NpmJs/Canary/NotRunning`.
+
+If the canary is not running, verify that the scheduled trigger for the [NpmJs
+package canary][package-canary] is correctly enabled. If it is, and the canary
+is not running, the account might have run out of available AWS Lambda
+concurrency, and a limit increase request might be necessary. When that is the
+case, the function will report this via the `Throttled` metric.
+
+Otherwise, [dive into the Lambda logs][#lambda-log-dive] of the Canary function
+to determine what is happening and resolve the problem.
+
+#### Resolution
+
+Once the canary starts unning normally again, the alarm will clear itself
+without requiring any further intervention.
+
 ## :information_source: General Recommendations
 
 ### Diving into Lambda Function logs in CloudWatch Logs

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -4135,6 +4135,17 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":30,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"NpmJs Follower Canary is not running or fails\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ConstructHubSourcesNpmJsCanaryNotRunningOrFailing62A8E2F6",
+                  "Arn",
+                ],
+              },
               "\\"]},\\"yAxis\\":{}}}]}",
             ],
           ],
@@ -9048,7 +9059,7 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "EvaluationPeriods": 2,
         "Metrics": Array [
           Object {
-            "Expression": "IF(FILL(mLag, 0) < 120, MAX([mDwell, mTTC]))",
+            "Expression": "IF(FILL(mLag, 0) < 180, MAX([mDwell, mTTC]))",
             "Id": "expr_1",
           },
           Object {
@@ -9092,6 +9103,97 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ConstructHubSourcesNpmJsCanaryFailingE338711F": Object {
+      "DependsOn": Array [
+        "ConstructHubLicenseListAwsCliLayer59592811",
+        "ConstructHubLicenseListCustomResource323F0FD4",
+      ],
+      "Properties": Object {
+        "AlarmName": "Test/ConstructHub/Sources/NpmJs/Canary/Failing",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": Object {
+              "Ref": "ConstructHubSourcesNpmJsCanary5558FC45",
+            },
+          },
+        ],
+        "EvaluationPeriods": 2,
+        "MetricName": "Errors",
+        "Namespace": "AWS/Lambda",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ConstructHubSourcesNpmJsCanaryNotRunningFCFBD0E6": Object {
+      "DependsOn": Array [
+        "ConstructHubLicenseListAwsCliLayer59592811",
+        "ConstructHubLicenseListCustomResource323F0FD4",
+      ],
+      "Properties": Object {
+        "AlarmName": "Test/ConstructHub/Sources/NpmJs/Canary/NotRunning",
+        "ComparisonOperator": "LessThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": Object {
+              "Ref": "ConstructHubSourcesNpmJsCanary5558FC45",
+            },
+          },
+        ],
+        "EvaluationPeriods": 2,
+        "MetricName": "Invocations",
+        "Namespace": "AWS/Lambda",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ConstructHubSourcesNpmJsCanaryNotRunningOrFailing62A8E2F6": Object {
+      "DependsOn": Array [
+        "ConstructHubLicenseListAwsCliLayer59592811",
+        "ConstructHubLicenseListCustomResource323F0FD4",
+      ],
+      "Properties": Object {
+        "AlarmActions": Array [
+          "arn:aws:sns:us-east-1:123456789012:mystack-mytopic-NZJ5JSMVGFIE",
+        ],
+        "AlarmDescription": "The NpmJs package canary is not running or is failing. This prevents alarming when this instance of
+ConstructHub falls out of SLA for new package ingestion!
+
+Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md",
+        "AlarmName": "Test/ConstructHub/Sources/NpmJs/Canary/NotRunningOrFailing",
+        "AlarmRule": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "(ALARM(\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ConstructHubSourcesNpmJsCanaryFailingE338711F",
+                  "Arn",
+                ],
+              },
+              "\\") OR ALARM(\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ConstructHubSourcesNpmJsCanaryNotRunningFCFBD0E6",
+                  "Arn",
+                ],
+              },
+              "\\"))",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::CompositeAlarm",
     },
     "ConstructHubSourcesNpmJsCanarySchedule4D94219F": Object {
       "DependsOn": Array [
@@ -16408,6 +16510,17 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":30,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"NpmJs Follower Canary is not running or fails\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ConstructHubSourcesNpmJsCanaryNotRunningOrFailing62A8E2F6",
+                  "Arn",
+                ],
+              },
               "\\"]},\\"yAxis\\":{}}}]}",
             ],
           ],
@@ -21394,7 +21507,7 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "EvaluationPeriods": 2,
         "Metrics": Array [
           Object {
-            "Expression": "IF(FILL(mLag, 0) < 120, MAX([mDwell, mTTC]))",
+            "Expression": "IF(FILL(mLag, 0) < 180, MAX([mDwell, mTTC]))",
             "Id": "expr_1",
           },
           Object {
@@ -21438,6 +21551,97 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ConstructHubSourcesNpmJsCanaryFailingE338711F": Object {
+      "DependsOn": Array [
+        "ConstructHubLicenseListAwsCliLayer59592811",
+        "ConstructHubLicenseListCustomResource323F0FD4",
+      ],
+      "Properties": Object {
+        "AlarmName": "Test/ConstructHub/Sources/NpmJs/Canary/Failing",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": Object {
+              "Ref": "ConstructHubSourcesNpmJsCanary5558FC45",
+            },
+          },
+        ],
+        "EvaluationPeriods": 2,
+        "MetricName": "Errors",
+        "Namespace": "AWS/Lambda",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ConstructHubSourcesNpmJsCanaryNotRunningFCFBD0E6": Object {
+      "DependsOn": Array [
+        "ConstructHubLicenseListAwsCliLayer59592811",
+        "ConstructHubLicenseListCustomResource323F0FD4",
+      ],
+      "Properties": Object {
+        "AlarmName": "Test/ConstructHub/Sources/NpmJs/Canary/NotRunning",
+        "ComparisonOperator": "LessThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": Object {
+              "Ref": "ConstructHubSourcesNpmJsCanary5558FC45",
+            },
+          },
+        ],
+        "EvaluationPeriods": 2,
+        "MetricName": "Invocations",
+        "Namespace": "AWS/Lambda",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ConstructHubSourcesNpmJsCanaryNotRunningOrFailing62A8E2F6": Object {
+      "DependsOn": Array [
+        "ConstructHubLicenseListAwsCliLayer59592811",
+        "ConstructHubLicenseListCustomResource323F0FD4",
+      ],
+      "Properties": Object {
+        "AlarmActions": Array [
+          "arn:aws:sns:us-east-1:123456789012:mystack-mytopic-NZJ5JSMVGFIE",
+        ],
+        "AlarmDescription": "The NpmJs package canary is not running or is failing. This prevents alarming when this instance of
+ConstructHub falls out of SLA for new package ingestion!
+
+Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md",
+        "AlarmName": "Test/ConstructHub/Sources/NpmJs/Canary/NotRunningOrFailing",
+        "AlarmRule": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "(ALARM(\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ConstructHubSourcesNpmJsCanaryFailingE338711F",
+                  "Arn",
+                ],
+              },
+              "\\") OR ALARM(\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ConstructHubSourcesNpmJsCanaryNotRunningFCFBD0E6",
+                  "Arn",
+                ],
+              },
+              "\\"))",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::CompositeAlarm",
     },
     "ConstructHubSourcesNpmJsCanarySchedule4D94219F": Object {
       "DependsOn": Array [
@@ -28399,6 +28603,17 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":30,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"NpmJs Follower Canary is not running or fails\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ConstructHubSourcesNpmJsCanaryNotRunningOrFailing62A8E2F6",
+                  "Arn",
+                ],
+              },
               "\\"]},\\"yAxis\\":{}}}]}",
             ],
           ],
@@ -33312,7 +33527,7 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "EvaluationPeriods": 2,
         "Metrics": Array [
           Object {
-            "Expression": "IF(FILL(mLag, 0) < 120, MAX([mDwell, mTTC]))",
+            "Expression": "IF(FILL(mLag, 0) < 180, MAX([mDwell, mTTC]))",
             "Id": "expr_1",
           },
           Object {
@@ -33356,6 +33571,97 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ConstructHubSourcesNpmJsCanaryFailingE338711F": Object {
+      "DependsOn": Array [
+        "ConstructHubLicenseListAwsCliLayer59592811",
+        "ConstructHubLicenseListCustomResource323F0FD4",
+      ],
+      "Properties": Object {
+        "AlarmName": "Test/ConstructHub/Sources/NpmJs/Canary/Failing",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": Object {
+              "Ref": "ConstructHubSourcesNpmJsCanary5558FC45",
+            },
+          },
+        ],
+        "EvaluationPeriods": 2,
+        "MetricName": "Errors",
+        "Namespace": "AWS/Lambda",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ConstructHubSourcesNpmJsCanaryNotRunningFCFBD0E6": Object {
+      "DependsOn": Array [
+        "ConstructHubLicenseListAwsCliLayer59592811",
+        "ConstructHubLicenseListCustomResource323F0FD4",
+      ],
+      "Properties": Object {
+        "AlarmName": "Test/ConstructHub/Sources/NpmJs/Canary/NotRunning",
+        "ComparisonOperator": "LessThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": Object {
+              "Ref": "ConstructHubSourcesNpmJsCanary5558FC45",
+            },
+          },
+        ],
+        "EvaluationPeriods": 2,
+        "MetricName": "Invocations",
+        "Namespace": "AWS/Lambda",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ConstructHubSourcesNpmJsCanaryNotRunningOrFailing62A8E2F6": Object {
+      "DependsOn": Array [
+        "ConstructHubLicenseListAwsCliLayer59592811",
+        "ConstructHubLicenseListCustomResource323F0FD4",
+      ],
+      "Properties": Object {
+        "AlarmActions": Array [
+          "arn:aws:sns:us-east-1:123456789012:mystack-mytopic-NZJ5JSMVGFIE",
+        ],
+        "AlarmDescription": "The NpmJs package canary is not running or is failing. This prevents alarming when this instance of
+ConstructHub falls out of SLA for new package ingestion!
+
+Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md",
+        "AlarmName": "Test/ConstructHub/Sources/NpmJs/Canary/NotRunningOrFailing",
+        "AlarmRule": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "(ALARM(\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ConstructHubSourcesNpmJsCanaryFailingE338711F",
+                  "Arn",
+                ],
+              },
+              "\\") OR ALARM(\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ConstructHubSourcesNpmJsCanaryNotRunningFCFBD0E6",
+                  "Arn",
+                ],
+              },
+              "\\"))",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::CompositeAlarm",
     },
     "ConstructHubSourcesNpmJsCanarySchedule4D94219F": Object {
       "DependsOn": Array [
@@ -40451,6 +40757,17 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":42,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"NpmJs Follower Canary is not running or fails\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ConstructHubSourcesNpmJsCanaryNotRunningOrFailing62A8E2F6",
+                  "Arn",
+                ],
+              },
               "\\"]},\\"yAxis\\":{}}}]}",
             ],
           ],
@@ -45351,7 +45668,7 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "EvaluationPeriods": 2,
         "Metrics": Array [
           Object {
-            "Expression": "IF(FILL(mLag, 0) < 120, MAX([mDwell, mTTC]))",
+            "Expression": "IF(FILL(mLag, 0) < 180, MAX([mDwell, mTTC]))",
             "Id": "expr_1",
           },
           Object {
@@ -45395,6 +45712,97 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ConstructHubSourcesNpmJsCanaryFailingE338711F": Object {
+      "DependsOn": Array [
+        "ConstructHubLicenseListAwsCliLayer59592811",
+        "ConstructHubLicenseListCustomResource323F0FD4",
+      ],
+      "Properties": Object {
+        "AlarmName": "Test/ConstructHub/Sources/NpmJs/Canary/Failing",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": Object {
+              "Ref": "ConstructHubSourcesNpmJsCanary5558FC45",
+            },
+          },
+        ],
+        "EvaluationPeriods": 2,
+        "MetricName": "Errors",
+        "Namespace": "AWS/Lambda",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ConstructHubSourcesNpmJsCanaryNotRunningFCFBD0E6": Object {
+      "DependsOn": Array [
+        "ConstructHubLicenseListAwsCliLayer59592811",
+        "ConstructHubLicenseListCustomResource323F0FD4",
+      ],
+      "Properties": Object {
+        "AlarmName": "Test/ConstructHub/Sources/NpmJs/Canary/NotRunning",
+        "ComparisonOperator": "LessThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": Object {
+              "Ref": "ConstructHubSourcesNpmJsCanary5558FC45",
+            },
+          },
+        ],
+        "EvaluationPeriods": 2,
+        "MetricName": "Invocations",
+        "Namespace": "AWS/Lambda",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ConstructHubSourcesNpmJsCanaryNotRunningOrFailing62A8E2F6": Object {
+      "DependsOn": Array [
+        "ConstructHubLicenseListAwsCliLayer59592811",
+        "ConstructHubLicenseListCustomResource323F0FD4",
+      ],
+      "Properties": Object {
+        "AlarmActions": Array [
+          "arn:aws:sns:us-east-1:123456789012:mystack-mytopic-NZJ5JSMVGFIE",
+        ],
+        "AlarmDescription": "The NpmJs package canary is not running or is failing. This prevents alarming when this instance of
+ConstructHub falls out of SLA for new package ingestion!
+
+Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md",
+        "AlarmName": "Test/ConstructHub/Sources/NpmJs/Canary/NotRunningOrFailing",
+        "AlarmRule": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "(ALARM(\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ConstructHubSourcesNpmJsCanaryFailingE338711F",
+                  "Arn",
+                ],
+              },
+              "\\") OR ALARM(\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ConstructHubSourcesNpmJsCanaryNotRunningFCFBD0E6",
+                  "Arn",
+                ],
+              },
+              "\\"))",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::CompositeAlarm",
     },
     "ConstructHubSourcesNpmJsCanarySchedule4D94219F": Object {
       "DependsOn": Array [
@@ -52806,6 +53214,17 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":30,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"NpmJs Follower Canary is not running or fails\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ConstructHubSourcesNpmJsCanaryNotRunningOrFailing62A8E2F6",
+                  "Arn",
+                ],
+              },
               "\\"]},\\"yAxis\\":{}}}]}",
             ],
           ],
@@ -57417,7 +57836,7 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "EvaluationPeriods": 2,
         "Metrics": Array [
           Object {
-            "Expression": "IF(FILL(mLag, 0) < 120, MAX([mDwell, mTTC]))",
+            "Expression": "IF(FILL(mLag, 0) < 180, MAX([mDwell, mTTC]))",
             "Id": "expr_1",
           },
           Object {
@@ -57461,6 +57880,97 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ConstructHubSourcesNpmJsCanaryFailingE338711F": Object {
+      "DependsOn": Array [
+        "ConstructHubLicenseListAwsCliLayer59592811",
+        "ConstructHubLicenseListCustomResource323F0FD4",
+      ],
+      "Properties": Object {
+        "AlarmName": "Test/ConstructHub/Sources/NpmJs/Canary/Failing",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": Object {
+              "Ref": "ConstructHubSourcesNpmJsCanary5558FC45",
+            },
+          },
+        ],
+        "EvaluationPeriods": 2,
+        "MetricName": "Errors",
+        "Namespace": "AWS/Lambda",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ConstructHubSourcesNpmJsCanaryNotRunningFCFBD0E6": Object {
+      "DependsOn": Array [
+        "ConstructHubLicenseListAwsCliLayer59592811",
+        "ConstructHubLicenseListCustomResource323F0FD4",
+      ],
+      "Properties": Object {
+        "AlarmName": "Test/ConstructHub/Sources/NpmJs/Canary/NotRunning",
+        "ComparisonOperator": "LessThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": Object {
+              "Ref": "ConstructHubSourcesNpmJsCanary5558FC45",
+            },
+          },
+        ],
+        "EvaluationPeriods": 2,
+        "MetricName": "Invocations",
+        "Namespace": "AWS/Lambda",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ConstructHubSourcesNpmJsCanaryNotRunningOrFailing62A8E2F6": Object {
+      "DependsOn": Array [
+        "ConstructHubLicenseListAwsCliLayer59592811",
+        "ConstructHubLicenseListCustomResource323F0FD4",
+      ],
+      "Properties": Object {
+        "AlarmActions": Array [
+          "arn:aws:sns:us-east-1:123456789012:mystack-mytopic-NZJ5JSMVGFIE",
+        ],
+        "AlarmDescription": "The NpmJs package canary is not running or is failing. This prevents alarming when this instance of
+ConstructHub falls out of SLA for new package ingestion!
+
+Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md",
+        "AlarmName": "Test/ConstructHub/Sources/NpmJs/Canary/NotRunningOrFailing",
+        "AlarmRule": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "(ALARM(\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ConstructHubSourcesNpmJsCanaryFailingE338711F",
+                  "Arn",
+                ],
+              },
+              "\\") OR ALARM(\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ConstructHubSourcesNpmJsCanaryNotRunningFCFBD0E6",
+                  "Arn",
+                ],
+              },
+              "\\"))",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::CompositeAlarm",
     },
     "ConstructHubSourcesNpmJsCanarySchedule4D94219F": Object {
       "DependsOn": Array [

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -672,7 +672,11 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[\\"ConstructHub/PackageCanary\\",\\"DwellTime\\",{\\"label\\":\\"Dwell Time\\",\\"period\\":60,\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/PackageCanary\\",\\"TimeToCatalog\\",{\\"label\\":\\"Time to Catalog\\",\\"period\\":60,\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/PackageCanary\\",\\"TrackedVersionCount\\",{\\"label\\":\\"Tracked Version Count\\",\\"period\\":60,\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ff0000\\",\\"label\\":\\"SLA (5 minutes)\\",\\"value\\":300,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}}}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":71,\\"properties\\":{\\"markdown\\":\\"# Ingestion Function\\\\n\\\\n[button:Ingestion Function](/lambda/home#/functions/",
+              "\\",\\"metrics\\":[[\\"ConstructHub/PackageCanary\\",\\"DwellTime\\",{\\"label\\":\\"Dwell Time\\",\\"period\\":60,\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/PackageCanary\\",\\"TimeToCatalog\\",{\\"label\\":\\"Time to Catalog\\",\\"period\\":60,\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/PackageCanary\\",\\"TrackedVersionCount\\",{\\"label\\":\\"Tracked Version Count\\",\\"period\\":60,\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ff0000\\",\\"label\\":\\"SLA (5 minutes)\\",\\"value\\":300,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":71,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Observed lag of replicate.npmjs.com\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"ConstructHub/PackageCanary\\",\\"EstimatedNpmReplicaLag\\",{\\"label\\":\\"Replica lag (construct-hub-probe)\\",\\"period\\":60,\\"stat\\":\\"Maximum\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ffa500\\",\\"label\\":\\"5 minutes\\",\\"value\\":300,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0}}}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":77,\\"properties\\":{\\"markdown\\":\\"# Ingestion Function\\\\n\\\\n[button:Ingestion Function](/lambda/home#/functions/",
               Object {
                 "Ref": "ConstructHubIngestion407909CE",
               },
@@ -695,7 +699,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              ")\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":73,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Function Health\\",\\"region\\":\\"",
+              ")\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":79,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Function Health\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -707,7 +711,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubIngestion407909CE",
               },
-              "\\",{\\"label\\":\\"Errors\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":73,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Input Queue\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Errors\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":79,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Input Queue\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -732,11 +736,11 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"period\\":60,\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ffa500\\",\\"label\\":\\"10 Minutes\\",\\"value\\":600,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":79,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Input Quality\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"period\\":60,\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ffa500\\",\\"label\\":\\"10 Minutes\\",\\"value\\":600,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":85,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Input Quality\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"stacked\\":true,\\"metrics\\":[[{\\"label\\":\\"Invalid Assemblies\\",\\"expression\\":\\"FILL(m0c5f10aa73687a21aa44b8985d19311246bca6c2cd1b2256b9f3e78c71e94fa3, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"InvalidAssembly\\",{\\"label\\":\\"Invalid Assemblies\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m0c5f10aa73687a21aa44b8985d19311246bca6c2cd1b2256b9f3e78c71e94fa3\\"}],[{\\"label\\":\\"Invalid Tarball\\",\\"expression\\":\\"FILL(m3a39d9b0bf974255f27dc95e44c8574bdfce2b97e49a7504346a77c5c9f6a3e1, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"InvalidTarball\\",{\\"label\\":\\"Invalid Tarball\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3a39d9b0bf974255f27dc95e44c8574bdfce2b97e49a7504346a77c5c9f6a3e1\\"}],[{\\"label\\":\\"Ineligible License\\",\\"expression\\":\\"FILL(me19ae9c3f20ae715e3462f9402684a3817282218f36e69494a60bc251e3435a6, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"IneligibleLicense\\",{\\"label\\":\\"Ineligible License\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"me19ae9c3f20ae715e3462f9402684a3817282218f36e69494a60bc251e3435a6\\"}],[{\\"label\\":\\"Mismatched Identity\\",\\"expression\\":\\"FILL(m7c1d407f17f8d2452a0bf87ac06fdd032de385a2758254f4192d6e17ed40d44b, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"MismatchedIdentityRejections\\",{\\"label\\":\\"Mismatched Identity\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m7c1d407f17f8d2452a0bf87ac06fdd032de385a2758254f4192d6e17ed40d44b\\"}],[{\\"label\\":\\"Found License file\\",\\"expression\\":\\"FILL(m7084dfec3c5bab86694d7ae438460f471c174a94bc67c9c9738e3ab60246b661, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"FoundLicenseFile\\",{\\"label\\":\\"Found License file\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m7084dfec3c5bab86694d7ae438460f471c174a94bc67c9c9738e3ab60246b661\\"}]],\\"yAxis\\":{\\"left\\":{\\"label\\":\\"Count\\",\\"min\\":0,\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":79,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Dead Letters\\",\\"region\\":\\"",
+              "\\",\\"stacked\\":true,\\"metrics\\":[[{\\"label\\":\\"Invalid Assemblies\\",\\"expression\\":\\"FILL(m0c5f10aa73687a21aa44b8985d19311246bca6c2cd1b2256b9f3e78c71e94fa3, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"InvalidAssembly\\",{\\"label\\":\\"Invalid Assemblies\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m0c5f10aa73687a21aa44b8985d19311246bca6c2cd1b2256b9f3e78c71e94fa3\\"}],[{\\"label\\":\\"Invalid Tarball\\",\\"expression\\":\\"FILL(m3a39d9b0bf974255f27dc95e44c8574bdfce2b97e49a7504346a77c5c9f6a3e1, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"InvalidTarball\\",{\\"label\\":\\"Invalid Tarball\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3a39d9b0bf974255f27dc95e44c8574bdfce2b97e49a7504346a77c5c9f6a3e1\\"}],[{\\"label\\":\\"Ineligible License\\",\\"expression\\":\\"FILL(me19ae9c3f20ae715e3462f9402684a3817282218f36e69494a60bc251e3435a6, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"IneligibleLicense\\",{\\"label\\":\\"Ineligible License\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"me19ae9c3f20ae715e3462f9402684a3817282218f36e69494a60bc251e3435a6\\"}],[{\\"label\\":\\"Mismatched Identity\\",\\"expression\\":\\"FILL(m7c1d407f17f8d2452a0bf87ac06fdd032de385a2758254f4192d6e17ed40d44b, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"MismatchedIdentityRejections\\",{\\"label\\":\\"Mismatched Identity\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m7c1d407f17f8d2452a0bf87ac06fdd032de385a2758254f4192d6e17ed40d44b\\"}],[{\\"label\\":\\"Found License file\\",\\"expression\\":\\"FILL(m7084dfec3c5bab86694d7ae438460f471c174a94bc67c9c9738e3ab60246b661, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"FoundLicenseFile\\",{\\"label\\":\\"Found License file\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m7084dfec3c5bab86694d7ae438460f471c174a94bc67c9c9738e3ab60246b661\\"}]],\\"yAxis\\":{\\"left\\":{\\"label\\":\\"Count\\",\\"min\\":0,\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":85,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Dead Letters\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -761,7 +765,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ff7f0e\\",\\"label\\":\\"10 days\\",\\"value\\":864000,\\"yAxis\\":\\"right\\"},{\\"color\\":\\"#ff0000\\",\\"label\\":\\"14 days (DLQ Retention)\\",\\"value\\":1209600,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":85,\\"properties\\":{\\"markdown\\":\\"# Orchestration\\\\n\\\\n[button:primary:State Machine](/states/home#/statemachines/view/",
+              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ff7f0e\\",\\"label\\":\\"10 days\\",\\"value\\":864000,\\"yAxis\\":\\"right\\"},{\\"color\\":\\"#ff0000\\",\\"label\\":\\"14 days (DLQ Retention)\\",\\"value\\":1209600,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":91,\\"properties\\":{\\"markdown\\":\\"# Orchestration\\\\n\\\\n[button:primary:State Machine](/states/home#/statemachines/view/",
               Object {
                 "Ref": "ConstructHubOrchestration39161A46",
               },
@@ -788,7 +792,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubOrchestrationRegenerateAllDocumentationE9FAB254",
               },
-              ")\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":87,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"State Machine Executions\\",\\"region\\":\\"",
+              ")\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":93,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"State Machine Executions\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -820,7 +824,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubOrchestration39161A46",
               },
-              "\\",{\\"label\\":\\"Duration\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":87,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Dead Letter Queue\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Duration\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":93,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Dead Letter Queue\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -845,7 +849,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ff7f0e\\",\\"label\\":\\"10 days\\",\\"value\\":864000,\\"yAxis\\":\\"right\\"},{\\"color\\":\\"#ff0000\\",\\"label\\":\\"14 days (DLQ Retention)\\",\\"value\\":1209600,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":93,\\"properties\\":{\\"markdown\\":\\"# Deny List\\\\n\\\\n[button:primary:Deny List Object](/s3/object/",
+              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ff7f0e\\",\\"label\\":\\"10 days\\",\\"value\\":864000,\\"yAxis\\":\\"right\\"},{\\"color\\":\\"#ff0000\\",\\"label\\":\\"14 days (DLQ Retention)\\",\\"value\\":1209600,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":99,\\"properties\\":{\\"markdown\\":\\"# Deny List\\\\n\\\\n[button:primary:Deny List Object](/s3/object/",
               Object {
                 "Ref": "ConstructHubDenyListBucket1B3C2C2E",
               },
@@ -876,7 +880,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubDenyListPrunePruneQueueHandlerF7EB599B",
               },
-              "/log-events)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":95,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Deny List\\",\\"region\\":\\"",
+              "/log-events)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":101,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Deny List\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -887,7 +891,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              "\\",{\\"label\\":\\"Deleted Files\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":300}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":95,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Prune Function Health\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Deleted Files\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":300}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":101,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Prune Function Health\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -899,7 +903,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubDenyListPrunePruneHandler30B33551",
               },
-              "\\",{\\"label\\":\\"Errors\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":300}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":101,\\"properties\\":{\\"markdown\\":\\"# Package Stats\\\\n\\\\n[button:primary:Package Stats Object](/s3/object/",
+              "\\",{\\"label\\":\\"Errors\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":300}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":107,\\"properties\\":{\\"markdown\\":\\"# Package Stats\\\\n\\\\n[button:primary:Package Stats Object](/s3/object/",
               Object {
                 "Ref": "ConstructHubPackageDataDC5EF35E",
               },
@@ -911,11 +915,11 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubStats61DB07B1",
               },
-              "/log-events)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":103,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Number of Package Stats Recorded\\",\\"region\\":\\"",
+              "/log-events)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":109,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Number of Package Stats Recorded\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[{\\"label\\":\\"Packages with stats\\",\\"expression\\":\\"FILL(m47411943a6e8f8e16a1dd905ff43cab11425b802c4d32615e081cab30c15f29f, REPEAT)\\"}],[\\"ConstructHub/PackageStats\\",\\"RegisteredPackagesWithStats\\",{\\"label\\":\\"Packages with stats\\",\\"stat\\":\\"Maximum\\",\\"visible\\":false,\\"id\\":\\"m47411943a6e8f8e16a1dd905ff43cab11425b802c4d32615e081cab30c15f29f\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":103,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Invocation Duration\\",\\"region\\":\\"",
+              "\\",\\"metrics\\":[[{\\"label\\":\\"Packages with stats\\",\\"expression\\":\\"FILL(m47411943a6e8f8e16a1dd905ff43cab11425b802c4d32615e081cab30c15f29f, REPEAT)\\"}],[\\"ConstructHub/PackageStats\\",\\"RegisteredPackagesWithStats\\",{\\"label\\":\\"Packages with stats\\",\\"stat\\":\\"Maximum\\",\\"visible\\":false,\\"id\\":\\"m47411943a6e8f8e16a1dd905ff43cab11425b802c4d32615e081cab30c15f29f\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":109,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Invocation Duration\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -923,7 +927,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubStats61DB07B1",
               },
-              "\\",{\\"label\\":\\"Duration\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ffa500\\",\\"label\\":\\"15 minutes (Lambda timeout)\\",\\"value\\":900,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0}}}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":109,\\"properties\\":{\\"markdown\\":\\"# Version Tracker\\\\n\\\\n[button:primary:Versions Object](/s3/object/",
+              "\\",{\\"label\\":\\"Duration\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ffa500\\",\\"label\\":\\"15 minutes (Lambda timeout)\\",\\"value\\":900,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0}}}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":115,\\"properties\\":{\\"markdown\\":\\"# Version Tracker\\\\n\\\\n[button:primary:Versions Object](/s3/object/",
               Object {
                 "Ref": "ConstructHubPackageDataDC5EF35E",
               },
@@ -935,11 +939,11 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubVersionTrackerD5E8AEAE",
               },
-              "/log-events)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":111,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Number of Package Versions Recorded\\",\\"region\\":\\"",
+              "/log-events)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":117,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Number of Package Versions Recorded\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[{\\"label\\":\\"Package versions recorded\\",\\"expression\\":\\"FILL(m343ebb2e5802fe223e549d8262d8d0c364846e0276426bc0a2d872e83bd8e63d, REPEAT)\\"}],[\\"ConstructHub/VersionTracker\\",\\"TrackedVersionsCount\\",{\\"label\\":\\"Package versions recorded\\",\\"stat\\":\\"Maximum\\",\\"visible\\":false,\\"id\\":\\"m343ebb2e5802fe223e549d8262d8d0c364846e0276426bc0a2d872e83bd8e63d\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":111,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Invocation Duration\\",\\"region\\":\\"",
+              "\\",\\"metrics\\":[[{\\"label\\":\\"Package versions recorded\\",\\"expression\\":\\"FILL(m343ebb2e5802fe223e549d8262d8d0c364846e0276426bc0a2d872e83bd8e63d, REPEAT)\\"}],[\\"ConstructHub/VersionTracker\\",\\"TrackedVersionsCount\\",{\\"label\\":\\"Package versions recorded\\",\\"stat\\":\\"Maximum\\",\\"visible\\":false,\\"id\\":\\"m343ebb2e5802fe223e549d8262d8d0c364846e0276426bc0a2d872e83bd8e63d\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":117,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Invocation Duration\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -4128,17 +4132,6 @@ Direct link to function: /lambda/home#/functions/",
               Object {
                 "Fn::GetAtt": Array [
                   "ConstructHubSourcesNpmJsFollowerNotRunningCEAF0E1E",
-                  "Arn",
-                ],
-              },
-              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":30,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"New version visibility SLA breached\\",\\"region\\":\\"",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
-              Object {
-                "Fn::GetAtt": Array [
-                  "ConstructHubSourcesNpmJsCanaryAlarmBE2B479E",
                   "Arn",
                 ],
               },
@@ -9003,7 +8996,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d7ae5d02316ef1da8c643a967d4e9ac3e3aa608617b4893f0023416129edb9ad.zip",
+          "S3Key": "34dff6f44de35b1c8efed081f774e0d2f7402826e3287041c4b095bf9e9f1933.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {
@@ -9048,9 +9041,6 @@ Direct link to Lambda function: /lambda/home#/functions/",
         "ConstructHubLicenseListCustomResource323F0FD4",
       ],
       "Properties": Object {
-        "AlarmActions": Array [
-          "arn:aws:sns:us-east-1:123456789012:mystack-mytopic-NZJ5JSMVGFIE",
-        ],
         "AlarmDescription": "New versions of construct-hub-probe have been published over 5 minutes ago and are still not visible in construct hub
 Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md",
         "AlarmName": "Test/ConstructHub/Sources/NpmJs/Canary/SLA-Breached",
@@ -9058,7 +9048,7 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "EvaluationPeriods": 2,
         "Metrics": Array [
           Object {
-            "Expression": "MAX([mDwell, mTTC])",
+            "Expression": "IF(FILL(mLag, 0) < 120, MAX([mDwell, mTTC]))",
             "Id": "expr_1",
           },
           Object {
@@ -9085,9 +9075,21 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
             },
             "ReturnData": false,
           },
+          Object {
+            "Id": "mLag",
+            "MetricStat": Object {
+              "Metric": Object {
+                "MetricName": "EstimatedNpmReplicaLag",
+                "Namespace": "ConstructHub/PackageCanary",
+              },
+              "Period": 60,
+              "Stat": "Maximum",
+            },
+            "ReturnData": false,
+          },
         ],
         "Threshold": 300,
-        "TreatMissingData": "breaching",
+        "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
@@ -12642,7 +12644,11 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[\\"ConstructHub/PackageCanary\\",\\"DwellTime\\",{\\"label\\":\\"Dwell Time\\",\\"period\\":60,\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/PackageCanary\\",\\"TimeToCatalog\\",{\\"label\\":\\"Time to Catalog\\",\\"period\\":60,\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/PackageCanary\\",\\"TrackedVersionCount\\",{\\"label\\":\\"Tracked Version Count\\",\\"period\\":60,\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ff0000\\",\\"label\\":\\"SLA (5 minutes)\\",\\"value\\":300,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}}}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":71,\\"properties\\":{\\"markdown\\":\\"# Ingestion Function\\\\n\\\\n[button:Ingestion Function](/lambda/home#/functions/",
+              "\\",\\"metrics\\":[[\\"ConstructHub/PackageCanary\\",\\"DwellTime\\",{\\"label\\":\\"Dwell Time\\",\\"period\\":60,\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/PackageCanary\\",\\"TimeToCatalog\\",{\\"label\\":\\"Time to Catalog\\",\\"period\\":60,\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/PackageCanary\\",\\"TrackedVersionCount\\",{\\"label\\":\\"Tracked Version Count\\",\\"period\\":60,\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ff0000\\",\\"label\\":\\"SLA (5 minutes)\\",\\"value\\":300,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":71,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Observed lag of replicate.npmjs.com\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"ConstructHub/PackageCanary\\",\\"EstimatedNpmReplicaLag\\",{\\"label\\":\\"Replica lag (construct-hub-probe)\\",\\"period\\":60,\\"stat\\":\\"Maximum\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ffa500\\",\\"label\\":\\"5 minutes\\",\\"value\\":300,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0}}}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":77,\\"properties\\":{\\"markdown\\":\\"# Ingestion Function\\\\n\\\\n[button:Ingestion Function](/lambda/home#/functions/",
               Object {
                 "Ref": "ConstructHubIngestion407909CE",
               },
@@ -12665,7 +12671,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              ")\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":73,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Function Health\\",\\"region\\":\\"",
+              ")\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":79,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Function Health\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -12677,7 +12683,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubIngestion407909CE",
               },
-              "\\",{\\"label\\":\\"Errors\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":73,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Input Queue\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Errors\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":79,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Input Queue\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -12702,11 +12708,11 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"period\\":60,\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ffa500\\",\\"label\\":\\"10 Minutes\\",\\"value\\":600,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":79,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Input Quality\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"period\\":60,\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ffa500\\",\\"label\\":\\"10 Minutes\\",\\"value\\":600,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":85,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Input Quality\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"stacked\\":true,\\"metrics\\":[[{\\"label\\":\\"Invalid Assemblies\\",\\"expression\\":\\"FILL(m0c5f10aa73687a21aa44b8985d19311246bca6c2cd1b2256b9f3e78c71e94fa3, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"InvalidAssembly\\",{\\"label\\":\\"Invalid Assemblies\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m0c5f10aa73687a21aa44b8985d19311246bca6c2cd1b2256b9f3e78c71e94fa3\\"}],[{\\"label\\":\\"Invalid Tarball\\",\\"expression\\":\\"FILL(m3a39d9b0bf974255f27dc95e44c8574bdfce2b97e49a7504346a77c5c9f6a3e1, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"InvalidTarball\\",{\\"label\\":\\"Invalid Tarball\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3a39d9b0bf974255f27dc95e44c8574bdfce2b97e49a7504346a77c5c9f6a3e1\\"}],[{\\"label\\":\\"Ineligible License\\",\\"expression\\":\\"FILL(me19ae9c3f20ae715e3462f9402684a3817282218f36e69494a60bc251e3435a6, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"IneligibleLicense\\",{\\"label\\":\\"Ineligible License\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"me19ae9c3f20ae715e3462f9402684a3817282218f36e69494a60bc251e3435a6\\"}],[{\\"label\\":\\"Mismatched Identity\\",\\"expression\\":\\"FILL(m7c1d407f17f8d2452a0bf87ac06fdd032de385a2758254f4192d6e17ed40d44b, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"MismatchedIdentityRejections\\",{\\"label\\":\\"Mismatched Identity\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m7c1d407f17f8d2452a0bf87ac06fdd032de385a2758254f4192d6e17ed40d44b\\"}],[{\\"label\\":\\"Found License file\\",\\"expression\\":\\"FILL(m7084dfec3c5bab86694d7ae438460f471c174a94bc67c9c9738e3ab60246b661, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"FoundLicenseFile\\",{\\"label\\":\\"Found License file\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m7084dfec3c5bab86694d7ae438460f471c174a94bc67c9c9738e3ab60246b661\\"}]],\\"yAxis\\":{\\"left\\":{\\"label\\":\\"Count\\",\\"min\\":0,\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":79,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Dead Letters\\",\\"region\\":\\"",
+              "\\",\\"stacked\\":true,\\"metrics\\":[[{\\"label\\":\\"Invalid Assemblies\\",\\"expression\\":\\"FILL(m0c5f10aa73687a21aa44b8985d19311246bca6c2cd1b2256b9f3e78c71e94fa3, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"InvalidAssembly\\",{\\"label\\":\\"Invalid Assemblies\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m0c5f10aa73687a21aa44b8985d19311246bca6c2cd1b2256b9f3e78c71e94fa3\\"}],[{\\"label\\":\\"Invalid Tarball\\",\\"expression\\":\\"FILL(m3a39d9b0bf974255f27dc95e44c8574bdfce2b97e49a7504346a77c5c9f6a3e1, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"InvalidTarball\\",{\\"label\\":\\"Invalid Tarball\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3a39d9b0bf974255f27dc95e44c8574bdfce2b97e49a7504346a77c5c9f6a3e1\\"}],[{\\"label\\":\\"Ineligible License\\",\\"expression\\":\\"FILL(me19ae9c3f20ae715e3462f9402684a3817282218f36e69494a60bc251e3435a6, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"IneligibleLicense\\",{\\"label\\":\\"Ineligible License\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"me19ae9c3f20ae715e3462f9402684a3817282218f36e69494a60bc251e3435a6\\"}],[{\\"label\\":\\"Mismatched Identity\\",\\"expression\\":\\"FILL(m7c1d407f17f8d2452a0bf87ac06fdd032de385a2758254f4192d6e17ed40d44b, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"MismatchedIdentityRejections\\",{\\"label\\":\\"Mismatched Identity\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m7c1d407f17f8d2452a0bf87ac06fdd032de385a2758254f4192d6e17ed40d44b\\"}],[{\\"label\\":\\"Found License file\\",\\"expression\\":\\"FILL(m7084dfec3c5bab86694d7ae438460f471c174a94bc67c9c9738e3ab60246b661, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"FoundLicenseFile\\",{\\"label\\":\\"Found License file\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m7084dfec3c5bab86694d7ae438460f471c174a94bc67c9c9738e3ab60246b661\\"}]],\\"yAxis\\":{\\"left\\":{\\"label\\":\\"Count\\",\\"min\\":0,\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":85,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Dead Letters\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -12731,7 +12737,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ff7f0e\\",\\"label\\":\\"10 days\\",\\"value\\":864000,\\"yAxis\\":\\"right\\"},{\\"color\\":\\"#ff0000\\",\\"label\\":\\"14 days (DLQ Retention)\\",\\"value\\":1209600,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":85,\\"properties\\":{\\"markdown\\":\\"# Orchestration\\\\n\\\\n[button:primary:State Machine](/states/home#/statemachines/view/",
+              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ff7f0e\\",\\"label\\":\\"10 days\\",\\"value\\":864000,\\"yAxis\\":\\"right\\"},{\\"color\\":\\"#ff0000\\",\\"label\\":\\"14 days (DLQ Retention)\\",\\"value\\":1209600,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":91,\\"properties\\":{\\"markdown\\":\\"# Orchestration\\\\n\\\\n[button:primary:State Machine](/states/home#/statemachines/view/",
               Object {
                 "Ref": "ConstructHubOrchestration39161A46",
               },
@@ -12758,7 +12764,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubOrchestrationRegenerateAllDocumentationE9FAB254",
               },
-              ")\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":87,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"State Machine Executions\\",\\"region\\":\\"",
+              ")\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":93,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"State Machine Executions\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -12790,7 +12796,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubOrchestration39161A46",
               },
-              "\\",{\\"label\\":\\"Duration\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":87,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Dead Letter Queue\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Duration\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":93,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Dead Letter Queue\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -12815,7 +12821,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ff7f0e\\",\\"label\\":\\"10 days\\",\\"value\\":864000,\\"yAxis\\":\\"right\\"},{\\"color\\":\\"#ff0000\\",\\"label\\":\\"14 days (DLQ Retention)\\",\\"value\\":1209600,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":93,\\"properties\\":{\\"markdown\\":\\"# Deny List\\\\n\\\\n[button:primary:Deny List Object](/s3/object/",
+              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ff7f0e\\",\\"label\\":\\"10 days\\",\\"value\\":864000,\\"yAxis\\":\\"right\\"},{\\"color\\":\\"#ff0000\\",\\"label\\":\\"14 days (DLQ Retention)\\",\\"value\\":1209600,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":99,\\"properties\\":{\\"markdown\\":\\"# Deny List\\\\n\\\\n[button:primary:Deny List Object](/s3/object/",
               Object {
                 "Ref": "ConstructHubDenyListBucket1B3C2C2E",
               },
@@ -12846,7 +12852,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubDenyListPrunePruneQueueHandlerF7EB599B",
               },
-              "/log-events)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":95,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Deny List\\",\\"region\\":\\"",
+              "/log-events)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":101,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Deny List\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -12857,7 +12863,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              "\\",{\\"label\\":\\"Deleted Files\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":300}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":95,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Prune Function Health\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Deleted Files\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":300}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":101,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Prune Function Health\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -12869,7 +12875,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubDenyListPrunePruneHandler30B33551",
               },
-              "\\",{\\"label\\":\\"Errors\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":300}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":101,\\"properties\\":{\\"markdown\\":\\"# Package Stats\\\\n\\\\n[button:primary:Package Stats Object](/s3/object/",
+              "\\",{\\"label\\":\\"Errors\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":300}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":107,\\"properties\\":{\\"markdown\\":\\"# Package Stats\\\\n\\\\n[button:primary:Package Stats Object](/s3/object/",
               Object {
                 "Ref": "ConstructHubPackageDataDC5EF35E",
               },
@@ -12881,11 +12887,11 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubStats61DB07B1",
               },
-              "/log-events)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":103,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Number of Package Stats Recorded\\",\\"region\\":\\"",
+              "/log-events)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":109,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Number of Package Stats Recorded\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[{\\"label\\":\\"Packages with stats\\",\\"expression\\":\\"FILL(m47411943a6e8f8e16a1dd905ff43cab11425b802c4d32615e081cab30c15f29f, REPEAT)\\"}],[\\"ConstructHub/PackageStats\\",\\"RegisteredPackagesWithStats\\",{\\"label\\":\\"Packages with stats\\",\\"stat\\":\\"Maximum\\",\\"visible\\":false,\\"id\\":\\"m47411943a6e8f8e16a1dd905ff43cab11425b802c4d32615e081cab30c15f29f\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":103,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Invocation Duration\\",\\"region\\":\\"",
+              "\\",\\"metrics\\":[[{\\"label\\":\\"Packages with stats\\",\\"expression\\":\\"FILL(m47411943a6e8f8e16a1dd905ff43cab11425b802c4d32615e081cab30c15f29f, REPEAT)\\"}],[\\"ConstructHub/PackageStats\\",\\"RegisteredPackagesWithStats\\",{\\"label\\":\\"Packages with stats\\",\\"stat\\":\\"Maximum\\",\\"visible\\":false,\\"id\\":\\"m47411943a6e8f8e16a1dd905ff43cab11425b802c4d32615e081cab30c15f29f\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":109,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Invocation Duration\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -12893,7 +12899,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubStats61DB07B1",
               },
-              "\\",{\\"label\\":\\"Duration\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ffa500\\",\\"label\\":\\"15 minutes (Lambda timeout)\\",\\"value\\":900,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0}}}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":109,\\"properties\\":{\\"markdown\\":\\"# Version Tracker\\\\n\\\\n[button:primary:Versions Object](/s3/object/",
+              "\\",{\\"label\\":\\"Duration\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ffa500\\",\\"label\\":\\"15 minutes (Lambda timeout)\\",\\"value\\":900,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0}}}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":115,\\"properties\\":{\\"markdown\\":\\"# Version Tracker\\\\n\\\\n[button:primary:Versions Object](/s3/object/",
               Object {
                 "Ref": "ConstructHubPackageDataDC5EF35E",
               },
@@ -12905,11 +12911,11 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubVersionTrackerD5E8AEAE",
               },
-              "/log-events)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":111,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Number of Package Versions Recorded\\",\\"region\\":\\"",
+              "/log-events)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":117,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Number of Package Versions Recorded\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[{\\"label\\":\\"Package versions recorded\\",\\"expression\\":\\"FILL(m343ebb2e5802fe223e549d8262d8d0c364846e0276426bc0a2d872e83bd8e63d, REPEAT)\\"}],[\\"ConstructHub/VersionTracker\\",\\"TrackedVersionsCount\\",{\\"label\\":\\"Package versions recorded\\",\\"stat\\":\\"Maximum\\",\\"visible\\":false,\\"id\\":\\"m343ebb2e5802fe223e549d8262d8d0c364846e0276426bc0a2d872e83bd8e63d\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":111,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Invocation Duration\\",\\"region\\":\\"",
+              "\\",\\"metrics\\":[[{\\"label\\":\\"Package versions recorded\\",\\"expression\\":\\"FILL(m343ebb2e5802fe223e549d8262d8d0c364846e0276426bc0a2d872e83bd8e63d, REPEAT)\\"}],[\\"ConstructHub/VersionTracker\\",\\"TrackedVersionsCount\\",{\\"label\\":\\"Package versions recorded\\",\\"stat\\":\\"Maximum\\",\\"visible\\":false,\\"id\\":\\"m343ebb2e5802fe223e549d8262d8d0c364846e0276426bc0a2d872e83bd8e63d\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":117,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Invocation Duration\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -16399,17 +16405,6 @@ Direct link to function: /lambda/home#/functions/",
               Object {
                 "Fn::GetAtt": Array [
                   "ConstructHubSourcesNpmJsFollowerNotRunningCEAF0E1E",
-                  "Arn",
-                ],
-              },
-              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":30,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"New version visibility SLA breached\\",\\"region\\":\\"",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
-              Object {
-                "Fn::GetAtt": Array [
-                  "ConstructHubSourcesNpmJsCanaryAlarmBE2B479E",
                   "Arn",
                 ],
               },
@@ -21347,7 +21342,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d7ae5d02316ef1da8c643a967d4e9ac3e3aa608617b4893f0023416129edb9ad.zip",
+          "S3Key": "34dff6f44de35b1c8efed081f774e0d2f7402826e3287041c4b095bf9e9f1933.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {
@@ -21392,9 +21387,6 @@ Direct link to Lambda function: /lambda/home#/functions/",
         "ConstructHubLicenseListCustomResource323F0FD4",
       ],
       "Properties": Object {
-        "AlarmActions": Array [
-          "arn:aws:sns:us-east-1:123456789012:mystack-mytopic-NZJ5JSMVGFIE",
-        ],
         "AlarmDescription": "New versions of construct-hub-probe have been published over 5 minutes ago and are still not visible in construct hub
 Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md",
         "AlarmName": "Test/ConstructHub/Sources/NpmJs/Canary/SLA-Breached",
@@ -21402,7 +21394,7 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "EvaluationPeriods": 2,
         "Metrics": Array [
           Object {
-            "Expression": "MAX([mDwell, mTTC])",
+            "Expression": "IF(FILL(mLag, 0) < 120, MAX([mDwell, mTTC]))",
             "Id": "expr_1",
           },
           Object {
@@ -21429,9 +21421,21 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
             },
             "ReturnData": false,
           },
+          Object {
+            "Id": "mLag",
+            "MetricStat": Object {
+              "Metric": Object {
+                "MetricName": "EstimatedNpmReplicaLag",
+                "Namespace": "ConstructHub/PackageCanary",
+              },
+              "Period": 60,
+              "Stat": "Maximum",
+            },
+            "ReturnData": false,
+          },
         ],
         "Threshold": 300,
-        "TreatMissingData": "breaching",
+        "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
@@ -24932,7 +24936,11 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[\\"ConstructHub/PackageCanary\\",\\"DwellTime\\",{\\"label\\":\\"Dwell Time\\",\\"period\\":60,\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/PackageCanary\\",\\"TimeToCatalog\\",{\\"label\\":\\"Time to Catalog\\",\\"period\\":60,\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/PackageCanary\\",\\"TrackedVersionCount\\",{\\"label\\":\\"Tracked Version Count\\",\\"period\\":60,\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ff0000\\",\\"label\\":\\"SLA (5 minutes)\\",\\"value\\":300,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}}}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":71,\\"properties\\":{\\"markdown\\":\\"# Ingestion Function\\\\n\\\\n[button:Ingestion Function](/lambda/home#/functions/",
+              "\\",\\"metrics\\":[[\\"ConstructHub/PackageCanary\\",\\"DwellTime\\",{\\"label\\":\\"Dwell Time\\",\\"period\\":60,\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/PackageCanary\\",\\"TimeToCatalog\\",{\\"label\\":\\"Time to Catalog\\",\\"period\\":60,\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/PackageCanary\\",\\"TrackedVersionCount\\",{\\"label\\":\\"Tracked Version Count\\",\\"period\\":60,\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ff0000\\",\\"label\\":\\"SLA (5 minutes)\\",\\"value\\":300,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":71,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Observed lag of replicate.npmjs.com\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"ConstructHub/PackageCanary\\",\\"EstimatedNpmReplicaLag\\",{\\"label\\":\\"Replica lag (construct-hub-probe)\\",\\"period\\":60,\\"stat\\":\\"Maximum\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ffa500\\",\\"label\\":\\"5 minutes\\",\\"value\\":300,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0}}}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":77,\\"properties\\":{\\"markdown\\":\\"# Ingestion Function\\\\n\\\\n[button:Ingestion Function](/lambda/home#/functions/",
               Object {
                 "Ref": "ConstructHubIngestion407909CE",
               },
@@ -24955,7 +24963,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              ")\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":73,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Function Health\\",\\"region\\":\\"",
+              ")\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":79,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Function Health\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -24967,7 +24975,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubIngestion407909CE",
               },
-              "\\",{\\"label\\":\\"Errors\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":73,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Input Queue\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Errors\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":79,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Input Queue\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -24992,11 +25000,11 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"period\\":60,\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ffa500\\",\\"label\\":\\"10 Minutes\\",\\"value\\":600,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":79,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Input Quality\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"period\\":60,\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ffa500\\",\\"label\\":\\"10 Minutes\\",\\"value\\":600,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":85,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Input Quality\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"stacked\\":true,\\"metrics\\":[[{\\"label\\":\\"Invalid Assemblies\\",\\"expression\\":\\"FILL(m0c5f10aa73687a21aa44b8985d19311246bca6c2cd1b2256b9f3e78c71e94fa3, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"InvalidAssembly\\",{\\"label\\":\\"Invalid Assemblies\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m0c5f10aa73687a21aa44b8985d19311246bca6c2cd1b2256b9f3e78c71e94fa3\\"}],[{\\"label\\":\\"Invalid Tarball\\",\\"expression\\":\\"FILL(m3a39d9b0bf974255f27dc95e44c8574bdfce2b97e49a7504346a77c5c9f6a3e1, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"InvalidTarball\\",{\\"label\\":\\"Invalid Tarball\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3a39d9b0bf974255f27dc95e44c8574bdfce2b97e49a7504346a77c5c9f6a3e1\\"}],[{\\"label\\":\\"Ineligible License\\",\\"expression\\":\\"FILL(me19ae9c3f20ae715e3462f9402684a3817282218f36e69494a60bc251e3435a6, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"IneligibleLicense\\",{\\"label\\":\\"Ineligible License\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"me19ae9c3f20ae715e3462f9402684a3817282218f36e69494a60bc251e3435a6\\"}],[{\\"label\\":\\"Mismatched Identity\\",\\"expression\\":\\"FILL(m7c1d407f17f8d2452a0bf87ac06fdd032de385a2758254f4192d6e17ed40d44b, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"MismatchedIdentityRejections\\",{\\"label\\":\\"Mismatched Identity\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m7c1d407f17f8d2452a0bf87ac06fdd032de385a2758254f4192d6e17ed40d44b\\"}],[{\\"label\\":\\"Found License file\\",\\"expression\\":\\"FILL(m7084dfec3c5bab86694d7ae438460f471c174a94bc67c9c9738e3ab60246b661, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"FoundLicenseFile\\",{\\"label\\":\\"Found License file\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m7084dfec3c5bab86694d7ae438460f471c174a94bc67c9c9738e3ab60246b661\\"}]],\\"yAxis\\":{\\"left\\":{\\"label\\":\\"Count\\",\\"min\\":0,\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":79,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Dead Letters\\",\\"region\\":\\"",
+              "\\",\\"stacked\\":true,\\"metrics\\":[[{\\"label\\":\\"Invalid Assemblies\\",\\"expression\\":\\"FILL(m0c5f10aa73687a21aa44b8985d19311246bca6c2cd1b2256b9f3e78c71e94fa3, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"InvalidAssembly\\",{\\"label\\":\\"Invalid Assemblies\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m0c5f10aa73687a21aa44b8985d19311246bca6c2cd1b2256b9f3e78c71e94fa3\\"}],[{\\"label\\":\\"Invalid Tarball\\",\\"expression\\":\\"FILL(m3a39d9b0bf974255f27dc95e44c8574bdfce2b97e49a7504346a77c5c9f6a3e1, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"InvalidTarball\\",{\\"label\\":\\"Invalid Tarball\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3a39d9b0bf974255f27dc95e44c8574bdfce2b97e49a7504346a77c5c9f6a3e1\\"}],[{\\"label\\":\\"Ineligible License\\",\\"expression\\":\\"FILL(me19ae9c3f20ae715e3462f9402684a3817282218f36e69494a60bc251e3435a6, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"IneligibleLicense\\",{\\"label\\":\\"Ineligible License\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"me19ae9c3f20ae715e3462f9402684a3817282218f36e69494a60bc251e3435a6\\"}],[{\\"label\\":\\"Mismatched Identity\\",\\"expression\\":\\"FILL(m7c1d407f17f8d2452a0bf87ac06fdd032de385a2758254f4192d6e17ed40d44b, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"MismatchedIdentityRejections\\",{\\"label\\":\\"Mismatched Identity\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m7c1d407f17f8d2452a0bf87ac06fdd032de385a2758254f4192d6e17ed40d44b\\"}],[{\\"label\\":\\"Found License file\\",\\"expression\\":\\"FILL(m7084dfec3c5bab86694d7ae438460f471c174a94bc67c9c9738e3ab60246b661, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"FoundLicenseFile\\",{\\"label\\":\\"Found License file\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m7084dfec3c5bab86694d7ae438460f471c174a94bc67c9c9738e3ab60246b661\\"}]],\\"yAxis\\":{\\"left\\":{\\"label\\":\\"Count\\",\\"min\\":0,\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":85,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Dead Letters\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -25021,7 +25029,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ff7f0e\\",\\"label\\":\\"10 days\\",\\"value\\":864000,\\"yAxis\\":\\"right\\"},{\\"color\\":\\"#ff0000\\",\\"label\\":\\"14 days (DLQ Retention)\\",\\"value\\":1209600,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":85,\\"properties\\":{\\"markdown\\":\\"# Orchestration\\\\n\\\\n[button:primary:State Machine](/states/home#/statemachines/view/",
+              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ff7f0e\\",\\"label\\":\\"10 days\\",\\"value\\":864000,\\"yAxis\\":\\"right\\"},{\\"color\\":\\"#ff0000\\",\\"label\\":\\"14 days (DLQ Retention)\\",\\"value\\":1209600,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":91,\\"properties\\":{\\"markdown\\":\\"# Orchestration\\\\n\\\\n[button:primary:State Machine](/states/home#/statemachines/view/",
               Object {
                 "Ref": "ConstructHubOrchestration39161A46",
               },
@@ -25048,7 +25056,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubOrchestrationRegenerateAllDocumentationE9FAB254",
               },
-              ")\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":87,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"State Machine Executions\\",\\"region\\":\\"",
+              ")\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":93,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"State Machine Executions\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -25080,7 +25088,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubOrchestration39161A46",
               },
-              "\\",{\\"label\\":\\"Duration\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":87,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Dead Letter Queue\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Duration\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":93,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Dead Letter Queue\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -25105,7 +25113,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ff7f0e\\",\\"label\\":\\"10 days\\",\\"value\\":864000,\\"yAxis\\":\\"right\\"},{\\"color\\":\\"#ff0000\\",\\"label\\":\\"14 days (DLQ Retention)\\",\\"value\\":1209600,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":93,\\"properties\\":{\\"markdown\\":\\"# Deny List\\\\n\\\\n[button:primary:Deny List Object](/s3/object/",
+              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ff7f0e\\",\\"label\\":\\"10 days\\",\\"value\\":864000,\\"yAxis\\":\\"right\\"},{\\"color\\":\\"#ff0000\\",\\"label\\":\\"14 days (DLQ Retention)\\",\\"value\\":1209600,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":99,\\"properties\\":{\\"markdown\\":\\"# Deny List\\\\n\\\\n[button:primary:Deny List Object](/s3/object/",
               Object {
                 "Ref": "ConstructHubDenyListBucket1B3C2C2E",
               },
@@ -25136,7 +25144,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubDenyListPrunePruneQueueHandlerF7EB599B",
               },
-              "/log-events)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":95,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Deny List\\",\\"region\\":\\"",
+              "/log-events)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":101,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Deny List\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -25147,7 +25155,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              "\\",{\\"label\\":\\"Deleted Files\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":300}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":95,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Prune Function Health\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Deleted Files\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":300}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":101,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Prune Function Health\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -25159,7 +25167,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubDenyListPrunePruneHandler30B33551",
               },
-              "\\",{\\"label\\":\\"Errors\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":300}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":101,\\"properties\\":{\\"markdown\\":\\"# Package Stats\\\\n\\\\n[button:primary:Package Stats Object](/s3/object/",
+              "\\",{\\"label\\":\\"Errors\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":300}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":107,\\"properties\\":{\\"markdown\\":\\"# Package Stats\\\\n\\\\n[button:primary:Package Stats Object](/s3/object/",
               Object {
                 "Ref": "ConstructHubPackageDataDC5EF35E",
               },
@@ -25171,11 +25179,11 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubStats61DB07B1",
               },
-              "/log-events)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":103,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Number of Package Stats Recorded\\",\\"region\\":\\"",
+              "/log-events)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":109,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Number of Package Stats Recorded\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[{\\"label\\":\\"Packages with stats\\",\\"expression\\":\\"FILL(m47411943a6e8f8e16a1dd905ff43cab11425b802c4d32615e081cab30c15f29f, REPEAT)\\"}],[\\"ConstructHub/PackageStats\\",\\"RegisteredPackagesWithStats\\",{\\"label\\":\\"Packages with stats\\",\\"stat\\":\\"Maximum\\",\\"visible\\":false,\\"id\\":\\"m47411943a6e8f8e16a1dd905ff43cab11425b802c4d32615e081cab30c15f29f\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":103,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Invocation Duration\\",\\"region\\":\\"",
+              "\\",\\"metrics\\":[[{\\"label\\":\\"Packages with stats\\",\\"expression\\":\\"FILL(m47411943a6e8f8e16a1dd905ff43cab11425b802c4d32615e081cab30c15f29f, REPEAT)\\"}],[\\"ConstructHub/PackageStats\\",\\"RegisteredPackagesWithStats\\",{\\"label\\":\\"Packages with stats\\",\\"stat\\":\\"Maximum\\",\\"visible\\":false,\\"id\\":\\"m47411943a6e8f8e16a1dd905ff43cab11425b802c4d32615e081cab30c15f29f\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":109,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Invocation Duration\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -25183,7 +25191,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubStats61DB07B1",
               },
-              "\\",{\\"label\\":\\"Duration\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ffa500\\",\\"label\\":\\"15 minutes (Lambda timeout)\\",\\"value\\":900,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0}}}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":109,\\"properties\\":{\\"markdown\\":\\"# Version Tracker\\\\n\\\\n[button:primary:Versions Object](/s3/object/",
+              "\\",{\\"label\\":\\"Duration\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ffa500\\",\\"label\\":\\"15 minutes (Lambda timeout)\\",\\"value\\":900,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0}}}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":115,\\"properties\\":{\\"markdown\\":\\"# Version Tracker\\\\n\\\\n[button:primary:Versions Object](/s3/object/",
               Object {
                 "Ref": "ConstructHubPackageDataDC5EF35E",
               },
@@ -25195,11 +25203,11 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubVersionTrackerD5E8AEAE",
               },
-              "/log-events)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":111,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Number of Package Versions Recorded\\",\\"region\\":\\"",
+              "/log-events)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":117,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Number of Package Versions Recorded\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[{\\"label\\":\\"Package versions recorded\\",\\"expression\\":\\"FILL(m343ebb2e5802fe223e549d8262d8d0c364846e0276426bc0a2d872e83bd8e63d, REPEAT)\\"}],[\\"ConstructHub/VersionTracker\\",\\"TrackedVersionsCount\\",{\\"label\\":\\"Package versions recorded\\",\\"stat\\":\\"Maximum\\",\\"visible\\":false,\\"id\\":\\"m343ebb2e5802fe223e549d8262d8d0c364846e0276426bc0a2d872e83bd8e63d\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":111,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Invocation Duration\\",\\"region\\":\\"",
+              "\\",\\"metrics\\":[[{\\"label\\":\\"Package versions recorded\\",\\"expression\\":\\"FILL(m343ebb2e5802fe223e549d8262d8d0c364846e0276426bc0a2d872e83bd8e63d, REPEAT)\\"}],[\\"ConstructHub/VersionTracker\\",\\"TrackedVersionsCount\\",{\\"label\\":\\"Package versions recorded\\",\\"stat\\":\\"Maximum\\",\\"visible\\":false,\\"id\\":\\"m343ebb2e5802fe223e549d8262d8d0c364846e0276426bc0a2d872e83bd8e63d\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":117,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Invocation Duration\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -28388,17 +28396,6 @@ Direct link to function: /lambda/home#/functions/",
               Object {
                 "Fn::GetAtt": Array [
                   "ConstructHubSourcesNpmJsFollowerNotRunningCEAF0E1E",
-                  "Arn",
-                ],
-              },
-              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":30,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"New version visibility SLA breached\\",\\"region\\":\\"",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
-              Object {
-                "Fn::GetAtt": Array [
-                  "ConstructHubSourcesNpmJsCanaryAlarmBE2B479E",
                   "Arn",
                 ],
               },
@@ -33263,7 +33260,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d7ae5d02316ef1da8c643a967d4e9ac3e3aa608617b4893f0023416129edb9ad.zip",
+          "S3Key": "34dff6f44de35b1c8efed081f774e0d2f7402826e3287041c4b095bf9e9f1933.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {
@@ -33308,9 +33305,6 @@ Direct link to Lambda function: /lambda/home#/functions/",
         "ConstructHubLicenseListCustomResource323F0FD4",
       ],
       "Properties": Object {
-        "AlarmActions": Array [
-          "arn:aws:sns:us-east-1:123456789012:mystack-mytopic-NZJ5JSMVGFIE",
-        ],
         "AlarmDescription": "New versions of construct-hub-probe have been published over 5 minutes ago and are still not visible in construct hub
 Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md",
         "AlarmName": "Test/ConstructHub/Sources/NpmJs/Canary/SLA-Breached",
@@ -33318,7 +33312,7 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "EvaluationPeriods": 2,
         "Metrics": Array [
           Object {
-            "Expression": "MAX([mDwell, mTTC])",
+            "Expression": "IF(FILL(mLag, 0) < 120, MAX([mDwell, mTTC]))",
             "Id": "expr_1",
           },
           Object {
@@ -33345,9 +33339,21 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
             },
             "ReturnData": false,
           },
+          Object {
+            "Id": "mLag",
+            "MetricStat": Object {
+              "Metric": Object {
+                "MetricName": "EstimatedNpmReplicaLag",
+                "Namespace": "ConstructHub/PackageCanary",
+              },
+              "Period": 60,
+              "Stat": "Maximum",
+            },
+            "ReturnData": false,
+          },
         ],
         "Threshold": 300,
-        "TreatMissingData": "breaching",
+        "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
@@ -36973,7 +36979,11 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[\\"ConstructHub/PackageCanary\\",\\"DwellTime\\",{\\"label\\":\\"Dwell Time\\",\\"period\\":60,\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/PackageCanary\\",\\"TimeToCatalog\\",{\\"label\\":\\"Time to Catalog\\",\\"period\\":60,\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/PackageCanary\\",\\"TrackedVersionCount\\",{\\"label\\":\\"Tracked Version Count\\",\\"period\\":60,\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ff0000\\",\\"label\\":\\"SLA (5 minutes)\\",\\"value\\":300,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}}}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":71,\\"properties\\":{\\"markdown\\":\\"# Ingestion Function\\\\n\\\\n[button:Ingestion Function](/lambda/home#/functions/",
+              "\\",\\"metrics\\":[[\\"ConstructHub/PackageCanary\\",\\"DwellTime\\",{\\"label\\":\\"Dwell Time\\",\\"period\\":60,\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/PackageCanary\\",\\"TimeToCatalog\\",{\\"label\\":\\"Time to Catalog\\",\\"period\\":60,\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/PackageCanary\\",\\"TrackedVersionCount\\",{\\"label\\":\\"Tracked Version Count\\",\\"period\\":60,\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ff0000\\",\\"label\\":\\"SLA (5 minutes)\\",\\"value\\":300,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":71,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Observed lag of replicate.npmjs.com\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"ConstructHub/PackageCanary\\",\\"EstimatedNpmReplicaLag\\",{\\"label\\":\\"Replica lag (construct-hub-probe)\\",\\"period\\":60,\\"stat\\":\\"Maximum\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ffa500\\",\\"label\\":\\"5 minutes\\",\\"value\\":300,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0}}}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":77,\\"properties\\":{\\"markdown\\":\\"# Ingestion Function\\\\n\\\\n[button:Ingestion Function](/lambda/home#/functions/",
               Object {
                 "Ref": "ConstructHubIngestion407909CE",
               },
@@ -36996,7 +37006,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              ")\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":73,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Function Health\\",\\"region\\":\\"",
+              ")\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":79,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Function Health\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -37008,7 +37018,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubIngestion407909CE",
               },
-              "\\",{\\"label\\":\\"Errors\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":73,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Input Queue\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Errors\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":79,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Input Queue\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -37033,11 +37043,11 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"period\\":60,\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ffa500\\",\\"label\\":\\"10 Minutes\\",\\"value\\":600,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":79,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Input Quality\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"period\\":60,\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ffa500\\",\\"label\\":\\"10 Minutes\\",\\"value\\":600,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":85,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Input Quality\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"stacked\\":true,\\"metrics\\":[[{\\"label\\":\\"Invalid Assemblies\\",\\"expression\\":\\"FILL(m0c5f10aa73687a21aa44b8985d19311246bca6c2cd1b2256b9f3e78c71e94fa3, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"InvalidAssembly\\",{\\"label\\":\\"Invalid Assemblies\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m0c5f10aa73687a21aa44b8985d19311246bca6c2cd1b2256b9f3e78c71e94fa3\\"}],[{\\"label\\":\\"Invalid Tarball\\",\\"expression\\":\\"FILL(m3a39d9b0bf974255f27dc95e44c8574bdfce2b97e49a7504346a77c5c9f6a3e1, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"InvalidTarball\\",{\\"label\\":\\"Invalid Tarball\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3a39d9b0bf974255f27dc95e44c8574bdfce2b97e49a7504346a77c5c9f6a3e1\\"}],[{\\"label\\":\\"Ineligible License\\",\\"expression\\":\\"FILL(me19ae9c3f20ae715e3462f9402684a3817282218f36e69494a60bc251e3435a6, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"IneligibleLicense\\",{\\"label\\":\\"Ineligible License\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"me19ae9c3f20ae715e3462f9402684a3817282218f36e69494a60bc251e3435a6\\"}],[{\\"label\\":\\"Mismatched Identity\\",\\"expression\\":\\"FILL(m7c1d407f17f8d2452a0bf87ac06fdd032de385a2758254f4192d6e17ed40d44b, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"MismatchedIdentityRejections\\",{\\"label\\":\\"Mismatched Identity\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m7c1d407f17f8d2452a0bf87ac06fdd032de385a2758254f4192d6e17ed40d44b\\"}],[{\\"label\\":\\"Found License file\\",\\"expression\\":\\"FILL(m7084dfec3c5bab86694d7ae438460f471c174a94bc67c9c9738e3ab60246b661, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"FoundLicenseFile\\",{\\"label\\":\\"Found License file\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m7084dfec3c5bab86694d7ae438460f471c174a94bc67c9c9738e3ab60246b661\\"}]],\\"yAxis\\":{\\"left\\":{\\"label\\":\\"Count\\",\\"min\\":0,\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":79,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Dead Letters\\",\\"region\\":\\"",
+              "\\",\\"stacked\\":true,\\"metrics\\":[[{\\"label\\":\\"Invalid Assemblies\\",\\"expression\\":\\"FILL(m0c5f10aa73687a21aa44b8985d19311246bca6c2cd1b2256b9f3e78c71e94fa3, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"InvalidAssembly\\",{\\"label\\":\\"Invalid Assemblies\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m0c5f10aa73687a21aa44b8985d19311246bca6c2cd1b2256b9f3e78c71e94fa3\\"}],[{\\"label\\":\\"Invalid Tarball\\",\\"expression\\":\\"FILL(m3a39d9b0bf974255f27dc95e44c8574bdfce2b97e49a7504346a77c5c9f6a3e1, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"InvalidTarball\\",{\\"label\\":\\"Invalid Tarball\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3a39d9b0bf974255f27dc95e44c8574bdfce2b97e49a7504346a77c5c9f6a3e1\\"}],[{\\"label\\":\\"Ineligible License\\",\\"expression\\":\\"FILL(me19ae9c3f20ae715e3462f9402684a3817282218f36e69494a60bc251e3435a6, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"IneligibleLicense\\",{\\"label\\":\\"Ineligible License\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"me19ae9c3f20ae715e3462f9402684a3817282218f36e69494a60bc251e3435a6\\"}],[{\\"label\\":\\"Mismatched Identity\\",\\"expression\\":\\"FILL(m7c1d407f17f8d2452a0bf87ac06fdd032de385a2758254f4192d6e17ed40d44b, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"MismatchedIdentityRejections\\",{\\"label\\":\\"Mismatched Identity\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m7c1d407f17f8d2452a0bf87ac06fdd032de385a2758254f4192d6e17ed40d44b\\"}],[{\\"label\\":\\"Found License file\\",\\"expression\\":\\"FILL(m7084dfec3c5bab86694d7ae438460f471c174a94bc67c9c9738e3ab60246b661, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"FoundLicenseFile\\",{\\"label\\":\\"Found License file\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m7084dfec3c5bab86694d7ae438460f471c174a94bc67c9c9738e3ab60246b661\\"}]],\\"yAxis\\":{\\"left\\":{\\"label\\":\\"Count\\",\\"min\\":0,\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":85,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Dead Letters\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -37062,7 +37072,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ff7f0e\\",\\"label\\":\\"10 days\\",\\"value\\":864000,\\"yAxis\\":\\"right\\"},{\\"color\\":\\"#ff0000\\",\\"label\\":\\"14 days (DLQ Retention)\\",\\"value\\":1209600,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":85,\\"properties\\":{\\"markdown\\":\\"# Orchestration\\\\n\\\\n[button:primary:State Machine](/states/home#/statemachines/view/",
+              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ff7f0e\\",\\"label\\":\\"10 days\\",\\"value\\":864000,\\"yAxis\\":\\"right\\"},{\\"color\\":\\"#ff0000\\",\\"label\\":\\"14 days (DLQ Retention)\\",\\"value\\":1209600,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":91,\\"properties\\":{\\"markdown\\":\\"# Orchestration\\\\n\\\\n[button:primary:State Machine](/states/home#/statemachines/view/",
               Object {
                 "Ref": "ConstructHubOrchestration39161A46",
               },
@@ -37089,7 +37099,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubOrchestrationRegenerateAllDocumentationE9FAB254",
               },
-              ")\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":87,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"State Machine Executions\\",\\"region\\":\\"",
+              ")\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":93,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"State Machine Executions\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -37121,7 +37131,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubOrchestration39161A46",
               },
-              "\\",{\\"label\\":\\"Duration\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":87,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Dead Letter Queue\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Duration\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":93,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Dead Letter Queue\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -37146,7 +37156,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ff7f0e\\",\\"label\\":\\"10 days\\",\\"value\\":864000,\\"yAxis\\":\\"right\\"},{\\"color\\":\\"#ff0000\\",\\"label\\":\\"14 days (DLQ Retention)\\",\\"value\\":1209600,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":93,\\"properties\\":{\\"markdown\\":\\"# Deny List\\\\n\\\\n[button:primary:Deny List Object](/s3/object/",
+              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ff7f0e\\",\\"label\\":\\"10 days\\",\\"value\\":864000,\\"yAxis\\":\\"right\\"},{\\"color\\":\\"#ff0000\\",\\"label\\":\\"14 days (DLQ Retention)\\",\\"value\\":1209600,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":99,\\"properties\\":{\\"markdown\\":\\"# Deny List\\\\n\\\\n[button:primary:Deny List Object](/s3/object/",
               Object {
                 "Ref": "ConstructHubDenyListBucket1B3C2C2E",
               },
@@ -37177,7 +37187,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubDenyListPrunePruneQueueHandlerF7EB599B",
               },
-              "/log-events)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":95,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Deny List\\",\\"region\\":\\"",
+              "/log-events)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":101,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Deny List\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -37188,7 +37198,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              "\\",{\\"label\\":\\"Deleted Files\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":300}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":95,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Prune Function Health\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Deleted Files\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":300}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":101,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Prune Function Health\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -37200,7 +37210,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubDenyListPrunePruneHandler30B33551",
               },
-              "\\",{\\"label\\":\\"Errors\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":300}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":101,\\"properties\\":{\\"markdown\\":\\"# Package Stats\\\\n\\\\n[button:primary:Package Stats Object](/s3/object/",
+              "\\",{\\"label\\":\\"Errors\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":300}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":107,\\"properties\\":{\\"markdown\\":\\"# Package Stats\\\\n\\\\n[button:primary:Package Stats Object](/s3/object/",
               Object {
                 "Ref": "ConstructHubPackageDataDC5EF35E",
               },
@@ -37212,11 +37222,11 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubStats61DB07B1",
               },
-              "/log-events)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":103,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Number of Package Stats Recorded\\",\\"region\\":\\"",
+              "/log-events)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":109,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Number of Package Stats Recorded\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[{\\"label\\":\\"Packages with stats\\",\\"expression\\":\\"FILL(m47411943a6e8f8e16a1dd905ff43cab11425b802c4d32615e081cab30c15f29f, REPEAT)\\"}],[\\"ConstructHub/PackageStats\\",\\"RegisteredPackagesWithStats\\",{\\"label\\":\\"Packages with stats\\",\\"stat\\":\\"Maximum\\",\\"visible\\":false,\\"id\\":\\"m47411943a6e8f8e16a1dd905ff43cab11425b802c4d32615e081cab30c15f29f\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":103,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Invocation Duration\\",\\"region\\":\\"",
+              "\\",\\"metrics\\":[[{\\"label\\":\\"Packages with stats\\",\\"expression\\":\\"FILL(m47411943a6e8f8e16a1dd905ff43cab11425b802c4d32615e081cab30c15f29f, REPEAT)\\"}],[\\"ConstructHub/PackageStats\\",\\"RegisteredPackagesWithStats\\",{\\"label\\":\\"Packages with stats\\",\\"stat\\":\\"Maximum\\",\\"visible\\":false,\\"id\\":\\"m47411943a6e8f8e16a1dd905ff43cab11425b802c4d32615e081cab30c15f29f\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":109,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Invocation Duration\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -37224,7 +37234,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubStats61DB07B1",
               },
-              "\\",{\\"label\\":\\"Duration\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ffa500\\",\\"label\\":\\"15 minutes (Lambda timeout)\\",\\"value\\":900,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0}}}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":109,\\"properties\\":{\\"markdown\\":\\"# Version Tracker\\\\n\\\\n[button:primary:Versions Object](/s3/object/",
+              "\\",{\\"label\\":\\"Duration\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ffa500\\",\\"label\\":\\"15 minutes (Lambda timeout)\\",\\"value\\":900,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0}}}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":115,\\"properties\\":{\\"markdown\\":\\"# Version Tracker\\\\n\\\\n[button:primary:Versions Object](/s3/object/",
               Object {
                 "Ref": "ConstructHubPackageDataDC5EF35E",
               },
@@ -37236,11 +37246,11 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubVersionTrackerD5E8AEAE",
               },
-              "/log-events)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":111,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Number of Package Versions Recorded\\",\\"region\\":\\"",
+              "/log-events)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":117,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Number of Package Versions Recorded\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[{\\"label\\":\\"Package versions recorded\\",\\"expression\\":\\"FILL(m343ebb2e5802fe223e549d8262d8d0c364846e0276426bc0a2d872e83bd8e63d, REPEAT)\\"}],[\\"ConstructHub/VersionTracker\\",\\"TrackedVersionsCount\\",{\\"label\\":\\"Package versions recorded\\",\\"stat\\":\\"Maximum\\",\\"visible\\":false,\\"id\\":\\"m343ebb2e5802fe223e549d8262d8d0c364846e0276426bc0a2d872e83bd8e63d\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":111,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Invocation Duration\\",\\"region\\":\\"",
+              "\\",\\"metrics\\":[[{\\"label\\":\\"Package versions recorded\\",\\"expression\\":\\"FILL(m343ebb2e5802fe223e549d8262d8d0c364846e0276426bc0a2d872e83bd8e63d, REPEAT)\\"}],[\\"ConstructHub/VersionTracker\\",\\"TrackedVersionsCount\\",{\\"label\\":\\"Package versions recorded\\",\\"stat\\":\\"Maximum\\",\\"visible\\":false,\\"id\\":\\"m343ebb2e5802fe223e549d8262d8d0c364846e0276426bc0a2d872e83bd8e63d\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":117,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Invocation Duration\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -40438,17 +40448,6 @@ Direct link to function: /lambda/home#/functions/",
               Object {
                 "Fn::GetAtt": Array [
                   "ConstructHubSourcesNpmJsFollowerNotRunningCEAF0E1E",
-                  "Arn",
-                ],
-              },
-              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":42,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"New version visibility SLA breached\\",\\"region\\":\\"",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
-              Object {
-                "Fn::GetAtt": Array [
-                  "ConstructHubSourcesNpmJsCanaryAlarmBE2B479E",
                   "Arn",
                 ],
               },
@@ -45313,7 +45312,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d7ae5d02316ef1da8c643a967d4e9ac3e3aa608617b4893f0023416129edb9ad.zip",
+          "S3Key": "34dff6f44de35b1c8efed081f774e0d2f7402826e3287041c4b095bf9e9f1933.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {
@@ -45345,9 +45344,6 @@ Direct link to Lambda function: /lambda/home#/functions/",
         "ConstructHubLicenseListCustomResource323F0FD4",
       ],
       "Properties": Object {
-        "AlarmActions": Array [
-          "arn:aws:sns:us-east-1:123456789012:mystack-mytopic-NZJ5JSMVGFIE",
-        ],
         "AlarmDescription": "New versions of construct-hub-probe have been published over 5 minutes ago and are still not visible in construct hub
 Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md",
         "AlarmName": "Test/ConstructHub/Sources/NpmJs/Canary/SLA-Breached",
@@ -45355,7 +45351,7 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "EvaluationPeriods": 2,
         "Metrics": Array [
           Object {
-            "Expression": "MAX([mDwell, mTTC])",
+            "Expression": "IF(FILL(mLag, 0) < 120, MAX([mDwell, mTTC]))",
             "Id": "expr_1",
           },
           Object {
@@ -45382,9 +45378,21 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
             },
             "ReturnData": false,
           },
+          Object {
+            "Id": "mLag",
+            "MetricStat": Object {
+              "Metric": Object {
+                "MetricName": "EstimatedNpmReplicaLag",
+                "Namespace": "ConstructHub/PackageCanary",
+              },
+              "Period": 60,
+              "Stat": "Maximum",
+            },
+            "ReturnData": false,
+          },
         ],
         "Threshold": 300,
-        "TreatMissingData": "breaching",
+        "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
@@ -49209,7 +49217,11 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[\\"ConstructHub/PackageCanary\\",\\"DwellTime\\",{\\"label\\":\\"Dwell Time\\",\\"period\\":60,\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/PackageCanary\\",\\"TimeToCatalog\\",{\\"label\\":\\"Time to Catalog\\",\\"period\\":60,\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/PackageCanary\\",\\"TrackedVersionCount\\",{\\"label\\":\\"Tracked Version Count\\",\\"period\\":60,\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ff0000\\",\\"label\\":\\"SLA (5 minutes)\\",\\"value\\":300,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}}}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":71,\\"properties\\":{\\"markdown\\":\\"# Ingestion Function\\\\n\\\\n[button:Ingestion Function](/lambda/home#/functions/",
+              "\\",\\"metrics\\":[[\\"ConstructHub/PackageCanary\\",\\"DwellTime\\",{\\"label\\":\\"Dwell Time\\",\\"period\\":60,\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/PackageCanary\\",\\"TimeToCatalog\\",{\\"label\\":\\"Time to Catalog\\",\\"period\\":60,\\"stat\\":\\"Maximum\\"}],[\\"ConstructHub/PackageCanary\\",\\"TrackedVersionCount\\",{\\"label\\":\\"Tracked Version Count\\",\\"period\\":60,\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ff0000\\",\\"label\\":\\"SLA (5 minutes)\\",\\"value\\":300,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":71,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Observed lag of replicate.npmjs.com\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"ConstructHub/PackageCanary\\",\\"EstimatedNpmReplicaLag\\",{\\"label\\":\\"Replica lag (construct-hub-probe)\\",\\"period\\":60,\\"stat\\":\\"Maximum\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ffa500\\",\\"label\\":\\"5 minutes\\",\\"value\\":300,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0}}}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":77,\\"properties\\":{\\"markdown\\":\\"# Ingestion Function\\\\n\\\\n[button:Ingestion Function](/lambda/home#/functions/",
               Object {
                 "Ref": "ConstructHubIngestion407909CE",
               },
@@ -49232,7 +49244,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              ")\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":73,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Function Health\\",\\"region\\":\\"",
+              ")\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":79,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Function Health\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -49244,7 +49256,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubIngestion407909CE",
               },
-              "\\",{\\"label\\":\\"Errors\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":73,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Input Queue\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Errors\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":79,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Input Queue\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -49269,11 +49281,11 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"period\\":60,\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ffa500\\",\\"label\\":\\"10 Minutes\\",\\"value\\":600,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":79,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Input Quality\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"period\\":60,\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ffa500\\",\\"label\\":\\"10 Minutes\\",\\"value\\":600,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":85,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Input Quality\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"stacked\\":true,\\"metrics\\":[[{\\"label\\":\\"Invalid Assemblies\\",\\"expression\\":\\"FILL(m0c5f10aa73687a21aa44b8985d19311246bca6c2cd1b2256b9f3e78c71e94fa3, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"InvalidAssembly\\",{\\"label\\":\\"Invalid Assemblies\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m0c5f10aa73687a21aa44b8985d19311246bca6c2cd1b2256b9f3e78c71e94fa3\\"}],[{\\"label\\":\\"Invalid Tarball\\",\\"expression\\":\\"FILL(m3a39d9b0bf974255f27dc95e44c8574bdfce2b97e49a7504346a77c5c9f6a3e1, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"InvalidTarball\\",{\\"label\\":\\"Invalid Tarball\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3a39d9b0bf974255f27dc95e44c8574bdfce2b97e49a7504346a77c5c9f6a3e1\\"}],[{\\"label\\":\\"Ineligible License\\",\\"expression\\":\\"FILL(me19ae9c3f20ae715e3462f9402684a3817282218f36e69494a60bc251e3435a6, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"IneligibleLicense\\",{\\"label\\":\\"Ineligible License\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"me19ae9c3f20ae715e3462f9402684a3817282218f36e69494a60bc251e3435a6\\"}],[{\\"label\\":\\"Mismatched Identity\\",\\"expression\\":\\"FILL(m7c1d407f17f8d2452a0bf87ac06fdd032de385a2758254f4192d6e17ed40d44b, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"MismatchedIdentityRejections\\",{\\"label\\":\\"Mismatched Identity\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m7c1d407f17f8d2452a0bf87ac06fdd032de385a2758254f4192d6e17ed40d44b\\"}],[{\\"label\\":\\"Found License file\\",\\"expression\\":\\"FILL(m7084dfec3c5bab86694d7ae438460f471c174a94bc67c9c9738e3ab60246b661, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"FoundLicenseFile\\",{\\"label\\":\\"Found License file\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m7084dfec3c5bab86694d7ae438460f471c174a94bc67c9c9738e3ab60246b661\\"}]],\\"yAxis\\":{\\"left\\":{\\"label\\":\\"Count\\",\\"min\\":0,\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":79,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Dead Letters\\",\\"region\\":\\"",
+              "\\",\\"stacked\\":true,\\"metrics\\":[[{\\"label\\":\\"Invalid Assemblies\\",\\"expression\\":\\"FILL(m0c5f10aa73687a21aa44b8985d19311246bca6c2cd1b2256b9f3e78c71e94fa3, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"InvalidAssembly\\",{\\"label\\":\\"Invalid Assemblies\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m0c5f10aa73687a21aa44b8985d19311246bca6c2cd1b2256b9f3e78c71e94fa3\\"}],[{\\"label\\":\\"Invalid Tarball\\",\\"expression\\":\\"FILL(m3a39d9b0bf974255f27dc95e44c8574bdfce2b97e49a7504346a77c5c9f6a3e1, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"InvalidTarball\\",{\\"label\\":\\"Invalid Tarball\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3a39d9b0bf974255f27dc95e44c8574bdfce2b97e49a7504346a77c5c9f6a3e1\\"}],[{\\"label\\":\\"Ineligible License\\",\\"expression\\":\\"FILL(me19ae9c3f20ae715e3462f9402684a3817282218f36e69494a60bc251e3435a6, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"IneligibleLicense\\",{\\"label\\":\\"Ineligible License\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"me19ae9c3f20ae715e3462f9402684a3817282218f36e69494a60bc251e3435a6\\"}],[{\\"label\\":\\"Mismatched Identity\\",\\"expression\\":\\"FILL(m7c1d407f17f8d2452a0bf87ac06fdd032de385a2758254f4192d6e17ed40d44b, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"MismatchedIdentityRejections\\",{\\"label\\":\\"Mismatched Identity\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m7c1d407f17f8d2452a0bf87ac06fdd032de385a2758254f4192d6e17ed40d44b\\"}],[{\\"label\\":\\"Found License file\\",\\"expression\\":\\"FILL(m7084dfec3c5bab86694d7ae438460f471c174a94bc67c9c9738e3ab60246b661, 0)\\"}],[\\"ConstructHub/Ingestion\\",\\"FoundLicenseFile\\",{\\"label\\":\\"Found License file\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m7084dfec3c5bab86694d7ae438460f471c174a94bc67c9c9738e3ab60246b661\\"}]],\\"yAxis\\":{\\"left\\":{\\"label\\":\\"Count\\",\\"min\\":0,\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":85,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Dead Letters\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -49298,7 +49310,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ff7f0e\\",\\"label\\":\\"10 days\\",\\"value\\":864000,\\"yAxis\\":\\"right\\"},{\\"color\\":\\"#ff0000\\",\\"label\\":\\"14 days (DLQ Retention)\\",\\"value\\":1209600,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":85,\\"properties\\":{\\"markdown\\":\\"# Orchestration\\\\n\\\\n[button:primary:State Machine](/states/home#/statemachines/view/",
+              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ff7f0e\\",\\"label\\":\\"10 days\\",\\"value\\":864000,\\"yAxis\\":\\"right\\"},{\\"color\\":\\"#ff0000\\",\\"label\\":\\"14 days (DLQ Retention)\\",\\"value\\":1209600,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":91,\\"properties\\":{\\"markdown\\":\\"# Orchestration\\\\n\\\\n[button:primary:State Machine](/states/home#/statemachines/view/",
               Object {
                 "Ref": "ConstructHubOrchestration39161A46",
               },
@@ -49325,7 +49337,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubOrchestrationRegenerateAllDocumentationE9FAB254",
               },
-              ")\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":87,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"State Machine Executions\\",\\"region\\":\\"",
+              ")\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":93,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"State Machine Executions\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -49357,7 +49369,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubOrchestration39161A46",
               },
-              "\\",{\\"label\\":\\"Duration\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":87,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Dead Letter Queue\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Duration\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":93,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Dead Letter Queue\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -49382,7 +49394,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ff7f0e\\",\\"label\\":\\"10 days\\",\\"value\\":864000,\\"yAxis\\":\\"right\\"},{\\"color\\":\\"#ff0000\\",\\"label\\":\\"14 days (DLQ Retention)\\",\\"value\\":1209600,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":93,\\"properties\\":{\\"markdown\\":\\"# Deny List\\\\n\\\\n[button:primary:Deny List Object](/s3/object/",
+              "\\",{\\"label\\":\\"Oldest Message Age\\",\\"stat\\":\\"Maximum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ff7f0e\\",\\"label\\":\\"10 days\\",\\"value\\":864000,\\"yAxis\\":\\"right\\"},{\\"color\\":\\"#ff0000\\",\\"label\\":\\"14 days (DLQ Retention)\\",\\"value\\":1209600,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0},\\"right\\":{\\"min\\":0}},\\"period\\":60}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":99,\\"properties\\":{\\"markdown\\":\\"# Deny List\\\\n\\\\n[button:primary:Deny List Object](/s3/object/",
               Object {
                 "Ref": "ConstructHubDenyListBucket1B3C2C2E",
               },
@@ -49413,7 +49425,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubDenyListPrunePruneQueueHandlerF7EB599B",
               },
-              "/log-events)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":95,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Deny List\\",\\"region\\":\\"",
+              "/log-events)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":101,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Deny List\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -49424,7 +49436,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                   "QueueName",
                 ],
               },
-              "\\",{\\"label\\":\\"Deleted Files\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":300}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":95,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Prune Function Health\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Deleted Files\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":300}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":101,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Prune Function Health\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -49436,7 +49448,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubDenyListPrunePruneHandler30B33551",
               },
-              "\\",{\\"label\\":\\"Errors\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":300}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":101,\\"properties\\":{\\"markdown\\":\\"# Package Stats\\\\n\\\\n[button:primary:Package Stats Object](/s3/object/",
+              "\\",{\\"label\\":\\"Errors\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}},\\"period\\":300}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":107,\\"properties\\":{\\"markdown\\":\\"# Package Stats\\\\n\\\\n[button:primary:Package Stats Object](/s3/object/",
               Object {
                 "Ref": "ConstructHubPackageDataDC5EF35E",
               },
@@ -49448,11 +49460,11 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubStats61DB07B1",
               },
-              "/log-events)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":103,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Number of Package Stats Recorded\\",\\"region\\":\\"",
+              "/log-events)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":109,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Number of Package Stats Recorded\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[{\\"label\\":\\"Packages with stats\\",\\"expression\\":\\"FILL(m47411943a6e8f8e16a1dd905ff43cab11425b802c4d32615e081cab30c15f29f, REPEAT)\\"}],[\\"ConstructHub/PackageStats\\",\\"RegisteredPackagesWithStats\\",{\\"label\\":\\"Packages with stats\\",\\"stat\\":\\"Maximum\\",\\"visible\\":false,\\"id\\":\\"m47411943a6e8f8e16a1dd905ff43cab11425b802c4d32615e081cab30c15f29f\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":103,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Invocation Duration\\",\\"region\\":\\"",
+              "\\",\\"metrics\\":[[{\\"label\\":\\"Packages with stats\\",\\"expression\\":\\"FILL(m47411943a6e8f8e16a1dd905ff43cab11425b802c4d32615e081cab30c15f29f, REPEAT)\\"}],[\\"ConstructHub/PackageStats\\",\\"RegisteredPackagesWithStats\\",{\\"label\\":\\"Packages with stats\\",\\"stat\\":\\"Maximum\\",\\"visible\\":false,\\"id\\":\\"m47411943a6e8f8e16a1dd905ff43cab11425b802c4d32615e081cab30c15f29f\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":109,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Invocation Duration\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -49460,7 +49472,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubStats61DB07B1",
               },
-              "\\",{\\"label\\":\\"Duration\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ffa500\\",\\"label\\":\\"15 minutes (Lambda timeout)\\",\\"value\\":900,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0}}}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":109,\\"properties\\":{\\"markdown\\":\\"# Version Tracker\\\\n\\\\n[button:primary:Versions Object](/s3/object/",
+              "\\",{\\"label\\":\\"Duration\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#ffa500\\",\\"label\\":\\"15 minutes (Lambda timeout)\\",\\"value\\":900,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0}}}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":115,\\"properties\\":{\\"markdown\\":\\"# Version Tracker\\\\n\\\\n[button:primary:Versions Object](/s3/object/",
               Object {
                 "Ref": "ConstructHubPackageDataDC5EF35E",
               },
@@ -49472,11 +49484,11 @@ def submit_response(event: dict, context, response_status: str, error_message: s
               Object {
                 "Ref": "ConstructHubVersionTrackerD5E8AEAE",
               },
-              "/log-events)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":111,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Number of Package Versions Recorded\\",\\"region\\":\\"",
+              "/log-events)\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":117,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Number of Package Versions Recorded\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[{\\"label\\":\\"Package versions recorded\\",\\"expression\\":\\"FILL(m343ebb2e5802fe223e549d8262d8d0c364846e0276426bc0a2d872e83bd8e63d, REPEAT)\\"}],[\\"ConstructHub/VersionTracker\\",\\"TrackedVersionsCount\\",{\\"label\\":\\"Package versions recorded\\",\\"stat\\":\\"Maximum\\",\\"visible\\":false,\\"id\\":\\"m343ebb2e5802fe223e549d8262d8d0c364846e0276426bc0a2d872e83bd8e63d\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":111,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Invocation Duration\\",\\"region\\":\\"",
+              "\\",\\"metrics\\":[[{\\"label\\":\\"Package versions recorded\\",\\"expression\\":\\"FILL(m343ebb2e5802fe223e549d8262d8d0c364846e0276426bc0a2d872e83bd8e63d, REPEAT)\\"}],[\\"ConstructHub/VersionTracker\\",\\"TrackedVersionsCount\\",{\\"label\\":\\"Package versions recorded\\",\\"stat\\":\\"Maximum\\",\\"visible\\":false,\\"id\\":\\"m343ebb2e5802fe223e549d8262d8d0c364846e0276426bc0a2d872e83bd8e63d\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":117,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Invocation Duration\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -52791,17 +52803,6 @@ Direct link to function: /lambda/home#/functions/",
               Object {
                 "Fn::GetAtt": Array [
                   "ConstructHubSourcesNpmJsFollowerNotRunningCEAF0E1E",
-                  "Arn",
-                ],
-              },
-              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":30,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"New version visibility SLA breached\\",\\"region\\":\\"",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
-              Object {
-                "Fn::GetAtt": Array [
-                  "ConstructHubSourcesNpmJsCanaryAlarmBE2B479E",
                   "Arn",
                 ],
               },
@@ -57364,7 +57365,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d7ae5d02316ef1da8c643a967d4e9ac3e3aa608617b4893f0023416129edb9ad.zip",
+          "S3Key": "34dff6f44de35b1c8efed081f774e0d2f7402826e3287041c4b095bf9e9f1933.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {
@@ -57409,9 +57410,6 @@ Direct link to Lambda function: /lambda/home#/functions/",
         "ConstructHubLicenseListCustomResource323F0FD4",
       ],
       "Properties": Object {
-        "AlarmActions": Array [
-          "arn:aws:sns:us-east-1:123456789012:mystack-mytopic-NZJ5JSMVGFIE",
-        ],
         "AlarmDescription": "New versions of construct-hub-probe have been published over 5 minutes ago and are still not visible in construct hub
 Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md",
         "AlarmName": "Test/ConstructHub/Sources/NpmJs/Canary/SLA-Breached",
@@ -57419,7 +57417,7 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "EvaluationPeriods": 2,
         "Metrics": Array [
           Object {
-            "Expression": "MAX([mDwell, mTTC])",
+            "Expression": "IF(FILL(mLag, 0) < 120, MAX([mDwell, mTTC]))",
             "Id": "expr_1",
           },
           Object {
@@ -57446,9 +57444,21 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
             },
             "ReturnData": false,
           },
+          Object {
+            "Id": "mLag",
+            "MetricStat": Object {
+              "Metric": Object {
+                "MetricName": "EstimatedNpmReplicaLag",
+                "Namespace": "ConstructHub/PackageCanary",
+              },
+              "Period": 60,
+              "Stat": "Maximum",
+            },
+            "ReturnData": false,
+          },
         ],
         "Threshold": 300,
-        "TreatMissingData": "breaching",
+        "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -238,6 +238,13 @@ Resources:
             - Fn::GetAtt:
                 - ConstructHubSourcesNpmJsFollowerNotRunningCEAF0E1E
                 - Arn
+            - '"]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":42,"properties":{"view":"timeSeries","title":"NpmJs
+              Follower Canary is not running or fails","region":"'
+            - Ref: AWS::Region
+            - '","annotations":{"alarms":["'
+            - Fn::GetAtt:
+                - ConstructHubSourcesNpmJsCanaryNotRunningOrFailing62A8E2F6
+                - Arn
             - '"]},"yAxis":{}}}]}'
   ConstructHubMonitoringWebCanaryHomePageHttpGetFunctionServiceRole9AAAD93C:
     Type: AWS::IAM::Role
@@ -7646,7 +7653,7 @@ Resources:
         Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md
       AlarmName: dev/ConstructHub/Sources/NpmJs/Canary/SLA-Breached
       Metrics:
-        - Expression: IF(FILL(mLag, 0) < 120, MAX([mDwell, mTTC]))
+        - Expression: IF(FILL(mLag, 0) < 180, MAX([mDwell, mTTC]))
           Id: expr_1
         - Id: mDwell
           MetricStat:
@@ -7674,6 +7681,71 @@ Resources:
           ReturnData: false
       Threshold: 300
       TreatMissingData: notBreaching
+    DependsOn:
+      - ConstructHubLicenseListAwsCliLayer59592811
+      - ConstructHubLicenseListCustomResource323F0FD4
+  ConstructHubSourcesNpmJsCanaryFailingE338711F:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ComparisonOperator: GreaterThanThreshold
+      EvaluationPeriods: 2
+      AlarmName: dev/ConstructHub/Sources/NpmJs/Canary/Failing
+      Dimensions:
+        - Name: FunctionName
+          Value:
+            Ref: ConstructHubSourcesNpmJsCanary5558FC45
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Period: 60
+      Statistic: Sum
+      Threshold: 0
+      TreatMissingData: breaching
+    DependsOn:
+      - ConstructHubLicenseListAwsCliLayer59592811
+      - ConstructHubLicenseListCustomResource323F0FD4
+  ConstructHubSourcesNpmJsCanaryNotRunningFCFBD0E6:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ComparisonOperator: LessThanThreshold
+      EvaluationPeriods: 2
+      AlarmName: dev/ConstructHub/Sources/NpmJs/Canary/NotRunning
+      Dimensions:
+        - Name: FunctionName
+          Value:
+            Ref: ConstructHubSourcesNpmJsCanary5558FC45
+      MetricName: Invocations
+      Namespace: AWS/Lambda
+      Period: 60
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: breaching
+    DependsOn:
+      - ConstructHubLicenseListAwsCliLayer59592811
+      - ConstructHubLicenseListCustomResource323F0FD4
+  ConstructHubSourcesNpmJsCanaryNotRunningOrFailing62A8E2F6:
+    Type: AWS::CloudWatch::CompositeAlarm
+    Properties:
+      AlarmName: dev/ConstructHub/Sources/NpmJs/Canary/NotRunningOrFailing
+      AlarmRule:
+        Fn::Join:
+          - ""
+          - - (ALARM("
+            - Fn::GetAtt:
+                - ConstructHubSourcesNpmJsCanaryFailingE338711F
+                - Arn
+            - '") OR ALARM("'
+            - Fn::GetAtt:
+                - ConstructHubSourcesNpmJsCanaryNotRunningFCFBD0E6
+                - Arn
+            - '"))'
+      AlarmDescription: >-
+        The NpmJs package canary is not running or is failing. This prevents
+        alarming when this instance of
+
+        ConstructHub falls out of SLA for new package ingestion!
+
+
+        Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md
     DependsOn:
       - ConstructHubLicenseListAwsCliLayer59592811
       - ConstructHubLicenseListCustomResource323F0FD4

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -238,13 +238,6 @@ Resources:
             - Fn::GetAtt:
                 - ConstructHubSourcesNpmJsFollowerNotRunningCEAF0E1E
                 - Arn
-            - '"]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":42,"properties":{"view":"timeSeries","title":"New
-              version visibility SLA breached","region":"'
-            - Ref: AWS::Region
-            - '","annotations":{"alarms":["'
-            - Fn::GetAtt:
-                - ConstructHubSourcesNpmJsCanaryAlarmBE2B479E
-                - Arn
             - '"]},"yAxis":{}}}]}'
   ConstructHubMonitoringWebCanaryHomePageHttpGetFunctionServiceRole9AAAD93C:
     Type: AWS::IAM::Role
@@ -7579,7 +7572,7 @@ Resources:
       Code:
         S3Bucket:
           Fn::Sub: cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}
-        S3Key: d7ae5d02316ef1da8c643a967d4e9ac3e3aa608617b4893f0023416129edb9ad.zip
+        S3Key: 34dff6f44de35b1c8efed081f774e0d2f7402826e3287041c4b095bf9e9f1933.zip
       Role:
         Fn::GetAtt:
           - ConstructHubSourcesNpmJsCanaryServiceRoleC4CBCDA2
@@ -7653,7 +7646,7 @@ Resources:
         Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md
       AlarmName: dev/ConstructHub/Sources/NpmJs/Canary/SLA-Breached
       Metrics:
-        - Expression: MAX([mDwell, mTTC])
+        - Expression: IF(FILL(mLag, 0) < 120, MAX([mDwell, mTTC]))
           Id: expr_1
         - Id: mDwell
           MetricStat:
@@ -7671,8 +7664,16 @@ Resources:
             Period: 60
             Stat: Maximum
           ReturnData: false
+        - Id: mLag
+          MetricStat:
+            Metric:
+              MetricName: EstimatedNpmReplicaLag
+              Namespace: ConstructHub/PackageCanary
+            Period: 60
+            Stat: Maximum
+          ReturnData: false
       Threshold: 300
-      TreatMissingData: breaching
+      TreatMissingData: notBreaching
     DependsOn:
       - ConstructHubLicenseListAwsCliLayer59592811
       - ConstructHubLicenseListCustomResource323F0FD4
@@ -8605,7 +8606,13 @@ Resources:
               Version
               Count","period":60,"stat":"Maximum","yAxis":"right"}]],"annotations":{"horizontal":[{"color":"#ff0000","label":"SLA
               (5
-              minutes)","value":300,"yAxis":"left"}]},"yAxis":{"left":{"min":0},"right":{"min":0}}}},{"type":"text","width":24,"height":2,"x":0,"y":71,"properties":{"markdown":"#
+              minutes)","value":300,"yAxis":"left"}]},"yAxis":{"left":{"min":0},"right":{"min":0}}}},{"type":"metric","width":12,"height":6,"x":0,"y":71,"properties":{"view":"timeSeries","title":"Observed
+              lag of replicate.npmjs.com","region":"'
+            - Ref: AWS::Region
+            - '","metrics":[["ConstructHub/PackageCanary","EstimatedNpmReplicaLag",{"label":"Replica
+              lag
+              (construct-hub-probe)","period":60,"stat":"Maximum"}]],"annotations":{"horizontal":[{"color":"#ffa500","label":"5
+              minutes","value":300,"yAxis":"left"}]},"yAxis":{"left":{"min":0}}}},{"type":"text","width":24,"height":2,"x":0,"y":77,"properties":{"markdown":"#
               Ingestion Function\\n\\n[button:Ingestion
               Function](/lambda/home#/functions/'
             - Ref: ConstructHubIngestion407909CE
@@ -8620,7 +8627,7 @@ Resources:
             - Fn::GetAtt:
                 - ConstructHubIngestionDLQ3E96A5F2
                 - QueueName
-            - )"}},{"type":"metric","width":12,"height":6,"x":0,"y":73,"properties":{"view":"timeSeries","title":"Function
+            - )"}},{"type":"metric","width":12,"height":6,"x":0,"y":79,"properties":{"view":"timeSeries","title":"Function
               Health","region":"
             - Ref: AWS::Region
             - '","metrics":[[{"label":"Invocations","expression":"FILL(m9ff955bd33652ecefb4dd9402064988aa5e418fcf59360156ff8c9e38dbde5e2,
@@ -8629,7 +8636,7 @@ Resources:
             - '",{"label":"Invocations","stat":"Sum","visible":false,"id":"m9ff955bd33652ecefb4dd9402064988aa5e418fcf59360156ff8c9e38dbde5e2"}],[{"label":"Errors","expression":"FILL(m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55,
               0)"}],["AWS/Lambda","Errors","FunctionName","'
             - Ref: ConstructHubIngestion407909CE
-            - '",{"label":"Errors","stat":"Sum","visible":false,"id":"m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55"}]],"yAxis":{"left":{"min":0}},"period":60}},{"type":"metric","width":12,"height":6,"x":12,"y":73,"properties":{"view":"timeSeries","title":"Input
+            - '",{"label":"Errors","stat":"Sum","visible":false,"id":"m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55"}]],"yAxis":{"left":{"min":0}},"period":60}},{"type":"metric","width":12,"height":6,"x":12,"y":79,"properties":{"view":"timeSeries","title":"Input
               Queue","region":"'
             - Ref: AWS::Region
             - '","metrics":[["AWS/SQS","ApproximateNumberOfMessagesVisible","QueueName","'
@@ -8648,7 +8655,7 @@ Resources:
                 - QueueName
             - '",{"label":"Oldest Message
               Age","period":60,"stat":"Maximum","yAxis":"right"}]],"annotations":{"horizontal":[{"color":"#ffa500","label":"10
-              Minutes","value":600,"yAxis":"right"}]},"yAxis":{"left":{"min":0},"right":{"min":0}},"period":60}},{"type":"metric","width":12,"height":6,"x":0,"y":79,"properties":{"view":"timeSeries","title":"Input
+              Minutes","value":600,"yAxis":"right"}]},"yAxis":{"left":{"min":0},"right":{"min":0}},"period":60}},{"type":"metric","width":12,"height":6,"x":0,"y":85,"properties":{"view":"timeSeries","title":"Input
               Quality","region":"'
             - Ref: AWS::Region
             - '","stacked":true,"metrics":[[{"label":"Invalid
@@ -8668,7 +8675,7 @@ Resources:
               file","expression":"FILL(m7084dfec3c5bab86694d7ae438460f471c174a94bc67c9c9738e3ab60246b661,
               0)"}],["ConstructHub/Ingestion","FoundLicenseFile",{"label":"Found
               License
-              file","stat":"Sum","visible":false,"id":"m7084dfec3c5bab86694d7ae438460f471c174a94bc67c9c9738e3ab60246b661"}]],"yAxis":{"left":{"label":"Count","min":0,"showUnits":false}}}},{"type":"metric","width":12,"height":6,"x":12,"y":79,"properties":{"view":"timeSeries","title":"Dead
+              file","stat":"Sum","visible":false,"id":"m7084dfec3c5bab86694d7ae438460f471c174a94bc67c9c9738e3ab60246b661"}]],"yAxis":{"left":{"label":"Count","min":0,"showUnits":false}}}},{"type":"metric","width":12,"height":6,"x":12,"y":85,"properties":{"view":"timeSeries","title":"Dead
               Letters","region":"'
             - Ref: AWS::Region
             - '","metrics":[["AWS/SQS","ApproximateNumberOfMessagesVisible","QueueName","'
@@ -8689,7 +8696,7 @@ Resources:
               Age","stat":"Maximum","yAxis":"right"}]],"annotations":{"horizontal":[{"color":"#ff7f0e","label":"10
               days","value":864000,"yAxis":"right"},{"color":"#ff0000","label":"14
               days (DLQ
-              Retention)","value":1209600,"yAxis":"right"}]},"yAxis":{"left":{"min":0},"right":{"min":0}},"period":60}},{"type":"text","width":24,"height":2,"x":0,"y":85,"properties":{"markdown":"#
+              Retention)","value":1209600,"yAxis":"right"}]},"yAxis":{"left":{"min":0},"right":{"min":0}},"period":60}},{"type":"text","width":24,"height":2,"x":0,"y":91,"properties":{"markdown":"#
               Orchestration\\n\\n[button:primary:State
               Machine](/states/home#/statemachines/view/'
             - Ref: ConstructHubOrchestration39161A46
@@ -8706,7 +8713,7 @@ Resources:
             - )\\n[button:Regenerate All
               Documentation](/states/home#/statemachines/view/
             - Ref: ConstructHubOrchestrationRegenerateAllDocumentationE9FAB254
-            - )"}},{"type":"metric","width":12,"height":6,"x":0,"y":87,"properties":{"view":"timeSeries","title":"State
+            - )"}},{"type":"metric","width":12,"height":6,"x":0,"y":93,"properties":{"view":"timeSeries","title":"State
               Machine Executions","region":"
             - Ref: AWS::Region
             - '","metrics":[[{"label":"Started","expression":"FILL(m392141ff4cfa3bbe1889b2db42bcf20599513e199a0b9fb8dc736cde893c1d7c,
@@ -8731,7 +8738,7 @@ Resources:
             - '",{"label":"Timed
               Out","stat":"Sum","visible":false,"id":"m106d91118c893ec9037d16448722184f1ebdcca08a617e1f13758151a8c85a21"}],["AWS/States","ExecutionTime","StateMachineArn","'
             - Ref: ConstructHubOrchestration39161A46
-            - '",{"label":"Duration","yAxis":"right"}]],"yAxis":{"left":{"min":0},"right":{"min":0}}}},{"type":"metric","width":12,"height":6,"x":12,"y":87,"properties":{"view":"timeSeries","title":"Dead
+            - '",{"label":"Duration","yAxis":"right"}]],"yAxis":{"left":{"min":0},"right":{"min":0}}}},{"type":"metric","width":12,"height":6,"x":12,"y":93,"properties":{"view":"timeSeries","title":"Dead
               Letter Queue","region":"'
             - Ref: AWS::Region
             - '","metrics":[["AWS/SQS","ApproximateNumberOfMessagesVisible","QueueName","'
@@ -8752,7 +8759,7 @@ Resources:
               Age","stat":"Maximum","yAxis":"right"}]],"annotations":{"horizontal":[{"color":"#ff7f0e","label":"10
               days","value":864000,"yAxis":"right"},{"color":"#ff0000","label":"14
               days (DLQ
-              Retention)","value":1209600,"yAxis":"right"}]},"yAxis":{"left":{"min":0},"right":{"min":0}},"period":60}},{"type":"text","width":24,"height":2,"x":0,"y":93,"properties":{"markdown":"#
+              Retention)","value":1209600,"yAxis":"right"}]},"yAxis":{"left":{"min":0},"right":{"min":0}},"period":60}},{"type":"text","width":24,"height":2,"x":0,"y":99,"properties":{"markdown":"#
               Deny List\\n\\n[button:primary:Deny List Object](/s3/object/'
             - Ref: ConstructHubDenyListBucket1B3C2C2E
             - ?prefix=deny-list.json)\\n[button:Prune
@@ -8773,7 +8780,7 @@ Resources:
             - )\\n[button:Delete
               Logs](/cloudwatch/home#logsV2:log-groups/log-group/$252Faws$252flambda$252f
             - Ref: ConstructHubDenyListPrunePruneQueueHandlerF7EB599B
-            - /log-events)"}},{"type":"metric","width":12,"height":6,"x":0,"y":95,"properties":{"view":"timeSeries","title":"Deny
+            - /log-events)"}},{"type":"metric","width":12,"height":6,"x":0,"y":101,"properties":{"view":"timeSeries","title":"Deny
               List","region":"
             - Ref: AWS::Region
             - '","metrics":[[{"label":"Rules","expression":"FILL(m41327b0edbbef1ca627d9503d1b9b9fab401700118519537b58e0557adee7e4f,
@@ -8782,7 +8789,7 @@ Resources:
                 - ConstructHubDenyListPruneDeleteQueueBBF60185
                 - QueueName
             - '",{"label":"Deleted
-              Files","stat":"Sum"}]],"yAxis":{"left":{"min":0}},"period":300}},{"type":"metric","width":12,"height":6,"x":12,"y":95,"properties":{"view":"timeSeries","title":"Prune
+              Files","stat":"Sum"}]],"yAxis":{"left":{"min":0}},"period":300}},{"type":"metric","width":12,"height":6,"x":12,"y":101,"properties":{"view":"timeSeries","title":"Prune
               Function Health","region":"'
             - Ref: AWS::Region
             - '","metrics":[[{"label":"Invocations","expression":"FILL(m9ff955bd33652ecefb4dd9402064988aa5e418fcf59360156ff8c9e38dbde5e2,
@@ -8791,7 +8798,7 @@ Resources:
             - '",{"label":"Invocations","stat":"Sum","visible":false,"id":"m9ff955bd33652ecefb4dd9402064988aa5e418fcf59360156ff8c9e38dbde5e2"}],[{"label":"Errors","expression":"FILL(m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55,
               0)"}],["AWS/Lambda","Errors","FunctionName","'
             - Ref: ConstructHubDenyListPrunePruneHandler30B33551
-            - '",{"label":"Errors","stat":"Sum","visible":false,"id":"m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55"}]],"yAxis":{"left":{"min":0}},"period":300}},{"type":"text","width":24,"height":2,"x":0,"y":101,"properties":{"markdown":"#
+            - '",{"label":"Errors","stat":"Sum","visible":false,"id":"m3aa18789f406dc22d5fd69d6a8b1ae08cbc04aabfde21bee51e16796b37a2e55"}]],"yAxis":{"left":{"min":0}},"period":300}},{"type":"text","width":24,"height":2,"x":0,"y":107,"properties":{"markdown":"#
               Package Stats\\n\\n[button:primary:Package Stats
               Object](/s3/object/'
             - Ref: ConstructHubPackageDataDC5EF35E
@@ -8801,21 +8808,21 @@ Resources:
             - )\\n[button:Package Stats
               Logs](/cloudwatch/home#logsV2:log-groups/log-group/$252Faws$252flambda$252f
             - Ref: ConstructHubStats61DB07B1
-            - /log-events)"}},{"type":"metric","width":12,"height":6,"x":0,"y":103,"properties":{"view":"timeSeries","title":"Number
+            - /log-events)"}},{"type":"metric","width":12,"height":6,"x":0,"y":109,"properties":{"view":"timeSeries","title":"Number
               of Package Stats Recorded","region":"
             - Ref: AWS::Region
             - '","metrics":[[{"label":"Packages with
               stats","expression":"FILL(m47411943a6e8f8e16a1dd905ff43cab11425b802c4d32615e081cab30c15f29f,
               REPEAT)"}],["ConstructHub/PackageStats","RegisteredPackagesWithStats",{"label":"Packages
               with
-              stats","stat":"Maximum","visible":false,"id":"m47411943a6e8f8e16a1dd905ff43cab11425b802c4d32615e081cab30c15f29f"}]],"yAxis":{"left":{"min":0}}}},{"type":"metric","width":12,"height":6,"x":12,"y":103,"properties":{"view":"timeSeries","title":"Invocation
+              stats","stat":"Maximum","visible":false,"id":"m47411943a6e8f8e16a1dd905ff43cab11425b802c4d32615e081cab30c15f29f"}]],"yAxis":{"left":{"min":0}}}},{"type":"metric","width":12,"height":6,"x":12,"y":109,"properties":{"view":"timeSeries","title":"Invocation
               Duration","region":"'
             - Ref: AWS::Region
             - '","metrics":[["AWS/Lambda","Duration","FunctionName","'
             - Ref: ConstructHubStats61DB07B1
             - '",{"label":"Duration"}]],"annotations":{"horizontal":[{"color":"#ffa500","label":"15
               minutes (Lambda
-              timeout)","value":900,"yAxis":"right"}]},"yAxis":{"left":{"min":0}}}},{"type":"text","width":24,"height":2,"x":0,"y":109,"properties":{"markdown":"#
+              timeout)","value":900,"yAxis":"right"}]},"yAxis":{"left":{"min":0}}}},{"type":"text","width":24,"height":2,"x":0,"y":115,"properties":{"markdown":"#
               Version Tracker\\n\\n[button:primary:Versions Object](/s3/object/'
             - Ref: ConstructHubPackageDataDC5EF35E
             - ?prefix=all-versions.json)\\n[button:Version Tracker
@@ -8824,21 +8831,21 @@ Resources:
             - )\\n[button:Version Tracker
               Logs](/cloudwatch/home#logsV2:log-groups/log-group/$252Faws$252flambda$252f
             - Ref: ConstructHubVersionTrackerD5E8AEAE
-            - /log-events)"}},{"type":"metric","width":12,"height":6,"x":0,"y":111,"properties":{"view":"timeSeries","title":"Number
+            - /log-events)"}},{"type":"metric","width":12,"height":6,"x":0,"y":117,"properties":{"view":"timeSeries","title":"Number
               of Package Versions Recorded","region":"
             - Ref: AWS::Region
             - '","metrics":[[{"label":"Package versions
               recorded","expression":"FILL(m343ebb2e5802fe223e549d8262d8d0c364846e0276426bc0a2d872e83bd8e63d,
               REPEAT)"}],["ConstructHub/VersionTracker","TrackedVersionsCount",{"label":"Package
               versions
-              recorded","stat":"Maximum","visible":false,"id":"m343ebb2e5802fe223e549d8262d8d0c364846e0276426bc0a2d872e83bd8e63d"}]],"yAxis":{"left":{"min":0}}}},{"type":"metric","width":12,"height":6,"x":12,"y":111,"properties":{"view":"timeSeries","title":"Invocation
+              recorded","stat":"Maximum","visible":false,"id":"m343ebb2e5802fe223e549d8262d8d0c364846e0276426bc0a2d872e83bd8e63d"}]],"yAxis":{"left":{"min":0}}}},{"type":"metric","width":12,"height":6,"x":12,"y":117,"properties":{"view":"timeSeries","title":"Invocation
               Duration","region":"'
             - Ref: AWS::Region
             - '","metrics":[["AWS/Lambda","Duration","FunctionName","'
             - Ref: ConstructHubVersionTrackerD5E8AEAE
             - '",{"label":"Duration"}]],"annotations":{"horizontal":[{"color":"#ffa500","label":"1
               minutes (Lambda
-              timeout)","value":60,"yAxis":"right"}]},"yAxis":{"left":{"min":0}}}},{"type":"text","width":24,"height":2,"x":0,"y":117,"properties":{"markdown":"#
+              timeout)","value":60,"yAxis":"right"}]},"yAxis":{"left":{"min":0}}}},{"type":"text","width":24,"height":2,"x":0,"y":123,"properties":{"markdown":"#
               Release
               Notes\\n\\n[button:primary:StateMachine](/states/home#/statemachines/view/'
             - Ref: ConstructHubReleaseNotesStateMachine8C711CC7
@@ -8872,14 +8879,14 @@ Resources:
             - Fn::GetAtt:
                 - ConstructHubReleaseNotesReleaseNotesFetchWorkerQueueDLQ56BF53F1
                 - QueueName
-            - )"}},{"type":"metric","width":12,"height":6,"x":0,"y":119,"properties":{"view":"timeSeries","title":"Number
+            - )"}},{"type":"metric","width":12,"height":6,"x":0,"y":125,"properties":{"view":"timeSeries","title":"Number
               of release Notes","region":"
             - Ref: AWS::Region
             - '","metrics":[[{"label":"Packages with release
               notes","expression":"FILL(m7a7a3037972a088d52187e29766f681a9cb9642d00a12e818823d134184ff48d,
               REPEAT)"}],["ConstructHub/ReleaseNotes","PackageWithChangeLog",{"label":"Packages
               with release
-              notes","stat":"Sum","visible":false,"id":"m7a7a3037972a088d52187e29766f681a9cb9642d00a12e818823d134184ff48d"}]],"yAxis":{"left":{"min":0}}}},{"type":"metric","width":12,"height":6,"x":12,"y":119,"properties":{"view":"timeSeries","title":"Release
+              notes","stat":"Sum","visible":false,"id":"m7a7a3037972a088d52187e29766f681a9cb9642d00a12e818823d134184ff48d"}]],"yAxis":{"left":{"min":0}}}},{"type":"metric","width":12,"height":6,"x":12,"y":125,"properties":{"view":"timeSeries","title":"Release
               notes generation Errors","region":"'
             - Ref: AWS::Region
             - '","metrics":[["ConstructHub/ReleaseNotes","AllErrors",{"label":"All

--- a/src/backend/catalog-builder/index.ts
+++ b/src/backend/catalog-builder/index.ts
@@ -153,6 +153,10 @@ export class CatalogBuilder extends Construct {
         threshold: -5,
       }
     );
+    // This is a high-severity alarm because it is indicative of a possible mass-extinction event
+    // in the catalog. This should definitely prompt immediate investigation, although it can also
+    // be caused by the recent addition of enough packages in the deny-list to cause the alarm to
+    // trigger.
     props.monitoring.addHighSeverityAlarm(
       'Catalog Size Shrunk',
       alarmShrinkingCatalog

--- a/src/monitoring/api.ts
+++ b/src/monitoring/api.ts
@@ -1,4 +1,4 @@
-import type { Alarm } from 'aws-cdk-lib/aws-cloudwatch';
+import type { AlarmBase } from 'aws-cdk-lib/aws-cloudwatch';
 
 /**
  * ConstructHub monitoring features exposed to extension points.
@@ -12,7 +12,7 @@ export interface IMonitoring {
    *              high-severity CloudWatch dashboard)
    * @param alarm the alarm to be added to the high-severity dashboard.
    */
-  addHighSeverityAlarm(title: string, alarm: Alarm): void;
+  addHighSeverityAlarm(title: string, alarm: AlarmBase): void;
 
   /**
    * Adds a low-severity alarm. If this alarm goes off, the action specified in
@@ -21,5 +21,5 @@ export interface IMonitoring {
    * @param title a user-friendly title for the alarm (not currently used).
    * @param alarm the alarm to be added.
    */
-  addLowSeverityAlarm(title: string, alarm: Alarm): void;
+  addLowSeverityAlarm(title: string, alarm: AlarmBase): void;
 }

--- a/src/monitoring/index.ts
+++ b/src/monitoring/index.ts
@@ -26,8 +26,8 @@ export interface MonitoringProps {
  */
 export class Monitoring extends Construct implements IMonitoring {
   private alarmActions?: AlarmActions;
-  private _highSeverityAlarms: cw.Alarm[];
-  private _lowSeverityAlarms: cw.Alarm[];
+  private _highSeverityAlarms: cw.AlarmBase[];
+  private _lowSeverityAlarms: cw.AlarmBase[];
 
   /**
    * Allows adding automatic monitoring to standard resources. Note that
@@ -66,7 +66,7 @@ export class Monitoring extends Construct implements IMonitoring {
    * Adds a high-severity alarm. If this alarm goes off, the action specified in `highSeverityAlarmActionArn`
    * @param alarm
    */
-  public addHighSeverityAlarm(title: string, alarm: cw.Alarm) {
+  public addHighSeverityAlarm(title: string, alarm: cw.AlarmBase) {
     const highSeverityActionArn = this.alarmActions?.highSeverity;
     if (highSeverityActionArn) {
       alarm.addAlarmAction({
@@ -86,10 +86,10 @@ export class Monitoring extends Construct implements IMonitoring {
       })
     );
 
-    this._highSeverityAlarms?.push(alarm);
+    this._highSeverityAlarms.push(alarm);
   }
 
-  public addLowSeverityAlarm(_title: string, alarm: cw.Alarm) {
+  public addLowSeverityAlarm(_title: string, alarm: cw.AlarmBase) {
     const normalSeverityActionArn = this.alarmActions?.normalSeverity;
     if (normalSeverityActionArn) {
       alarm.addAlarmAction({
@@ -100,7 +100,7 @@ export class Monitoring extends Construct implements IMonitoring {
     if (normalSeverityAction) {
       alarm.addAlarmAction(normalSeverityAction);
     }
-    this._lowSeverityAlarms?.push(alarm);
+    this._lowSeverityAlarms.push(alarm);
   }
 
   public get highSeverityAlarms() {

--- a/src/package-sources/npmjs.ts
+++ b/src/package-sources/npmjs.ts
@@ -610,20 +610,24 @@ export class NpmJs implements IPackageSource {
       'NotRunningOrFailing',
       {
         alarmRule: AlarmRule.anyOf(
-          canary.metricErrors({ period, statistic: Statistic.SUM }).createAlarm(canary, 'Failing', {
-            alarmName: `${canary.node.path}/Failing`,
-            comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
-            evaluationPeriods: 2,
-            threshold: 0,
-            treatMissingData: TreatMissingData.BREACHING,
-          }),
-          canary.metricInvocations({ period, statistic: Statistic.SUM }).createAlarm(canary, 'NotRunning', {
-            alarmName: `${canary.node.path}/NotRunning`,
-            comparisonOperator: ComparisonOperator.LESS_THAN_THRESHOLD,
-            evaluationPeriods: 2,
-            threshold: 1,
-            treatMissingData: TreatMissingData.BREACHING,
-          }),
+          canary
+            .metricErrors({ period, statistic: Statistic.SUM })
+            .createAlarm(canary, 'Failing', {
+              alarmName: `${canary.node.path}/Failing`,
+              comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+              evaluationPeriods: 2,
+              threshold: 0,
+              treatMissingData: TreatMissingData.BREACHING,
+            }),
+          canary
+            .metricInvocations({ period, statistic: Statistic.SUM })
+            .createAlarm(canary, 'NotRunning', {
+              alarmName: `${canary.node.path}/NotRunning`,
+              comparisonOperator: ComparisonOperator.LESS_THAN_THRESHOLD,
+              evaluationPeriods: 2,
+              threshold: 1,
+              treatMissingData: TreatMissingData.BREACHING,
+            })
         ),
         alarmDescription: [
           'The NpmJs package canary is not running or is failing. This prevents alarming when this instance of',

--- a/src/package-sources/npmjs/canary/constants.ts
+++ b/src/package-sources/npmjs/canary/constants.ts
@@ -28,6 +28,14 @@ export const enum MetricName {
    * package canary execution that produced the data point.
    */
   TRACKED_VERSION_COUNT = 'TrackedVersionCount',
+
+  /**
+   * The estimated lag between the npm registry replica (replicate.npmjs.com)
+   * and the primary registry (registry.npmjs.com). This cannot be measured
+   * directly because the primary does not expose the relevant CouchDB endpoints,
+   * so we use the probe package to get a low-resolution view of this.
+   */
+  NPM_REPLICA_LAG = 'EstimatedNpmReplicaLag',
 }
 
 export const enum ObjectKey {


### PR DESCRIPTION
In the last few weeks we have regularly observed a large gap between the
npmjs replica database (replicate.npmjs.com/registry) and the registry's
primary endpoint (registry.npmjs.org). When this happens, the SLA breach
alarm triggers despite ConstructHub cannot possible have indexed new
packages (as these are not visible on the replica just yet).

To reduce inactionnable alarms, this adds a process to measure the lag
that is observed between the primary and replica, and suppresses the
SLA alarm in case the delta is found to be too large to allow the SLA to
be met.

Additionally, the SLA alarm triggering is not necessarily indicative of
an operational issue with ConstructHub, and will not be immediately
customer-affecting. As a consequence, it was downgraded from high- to
low-severity.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*