### PR TITLE
fix(npmjs): canary alarms when replicate.npmjs.com is down

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -9007,7 +9007,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "daf32d98a032c2147ae867c48e85227488c2f85561758fbedfcea2d4a2462305.zip",
+          "S3Key": "52b2c3211afba07666b6cef7f079b82715be5fc763159d6fdf1da008f7be7ad0.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {
@@ -21455,7 +21455,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "daf32d98a032c2147ae867c48e85227488c2f85561758fbedfcea2d4a2462305.zip",
+          "S3Key": "52b2c3211afba07666b6cef7f079b82715be5fc763159d6fdf1da008f7be7ad0.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {
@@ -33475,7 +33475,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "daf32d98a032c2147ae867c48e85227488c2f85561758fbedfcea2d4a2462305.zip",
+          "S3Key": "52b2c3211afba07666b6cef7f079b82715be5fc763159d6fdf1da008f7be7ad0.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {
@@ -45629,7 +45629,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "daf32d98a032c2147ae867c48e85227488c2f85561758fbedfcea2d4a2462305.zip",
+          "S3Key": "52b2c3211afba07666b6cef7f079b82715be5fc763159d6fdf1da008f7be7ad0.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {
@@ -57784,7 +57784,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "daf32d98a032c2147ae867c48e85227488c2f85561758fbedfcea2d4a2462305.zip",
+          "S3Key": "52b2c3211afba07666b6cef7f079b82715be5fc763159d6fdf1da008f7be7ad0.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -9007,7 +9007,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "690a69f41b4de2e39da000f8425ac7e6140ede848bd6c1d1451c59e9a6a54d08.zip",
+          "S3Key": "daf32d98a032c2147ae867c48e85227488c2f85561758fbedfcea2d4a2462305.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {
@@ -9059,7 +9059,7 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "EvaluationPeriods": 2,
         "Metrics": Array [
           Object {
-            "Expression": "IF((FILL(mLag, 0) < 180 AND mIsReplicaDown == 0), MAX([mDwell, mTTC]))",
+            "Expression": "IF(FILL(mLag, 0) < 180, MAX([mDwell, mTTC]))",
             "Id": "expr_1",
           },
           Object {
@@ -9091,18 +9091,6 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
             "MetricStat": Object {
               "Metric": Object {
                 "MetricName": "EstimatedNpmReplicaLag",
-                "Namespace": "ConstructHub/PackageCanary",
-              },
-              "Period": 60,
-              "Stat": "Maximum",
-            },
-            "ReturnData": false,
-          },
-          Object {
-            "Id": "mIsReplicaDown",
-            "MetricStat": Object {
-              "Metric": Object {
-                "MetricName": "NpmReplicaIsDown",
                 "Namespace": "ConstructHub/PackageCanary",
               },
               "Period": 60,
@@ -21467,7 +21455,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "690a69f41b4de2e39da000f8425ac7e6140ede848bd6c1d1451c59e9a6a54d08.zip",
+          "S3Key": "daf32d98a032c2147ae867c48e85227488c2f85561758fbedfcea2d4a2462305.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {
@@ -21519,7 +21507,7 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "EvaluationPeriods": 2,
         "Metrics": Array [
           Object {
-            "Expression": "IF((FILL(mLag, 0) < 180 AND mIsReplicaDown == 0), MAX([mDwell, mTTC]))",
+            "Expression": "IF(FILL(mLag, 0) < 180, MAX([mDwell, mTTC]))",
             "Id": "expr_1",
           },
           Object {
@@ -21551,18 +21539,6 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
             "MetricStat": Object {
               "Metric": Object {
                 "MetricName": "EstimatedNpmReplicaLag",
-                "Namespace": "ConstructHub/PackageCanary",
-              },
-              "Period": 60,
-              "Stat": "Maximum",
-            },
-            "ReturnData": false,
-          },
-          Object {
-            "Id": "mIsReplicaDown",
-            "MetricStat": Object {
-              "Metric": Object {
-                "MetricName": "NpmReplicaIsDown",
                 "Namespace": "ConstructHub/PackageCanary",
               },
               "Period": 60,
@@ -33499,7 +33475,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "690a69f41b4de2e39da000f8425ac7e6140ede848bd6c1d1451c59e9a6a54d08.zip",
+          "S3Key": "daf32d98a032c2147ae867c48e85227488c2f85561758fbedfcea2d4a2462305.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {
@@ -33551,7 +33527,7 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "EvaluationPeriods": 2,
         "Metrics": Array [
           Object {
-            "Expression": "IF((FILL(mLag, 0) < 180 AND mIsReplicaDown == 0), MAX([mDwell, mTTC]))",
+            "Expression": "IF(FILL(mLag, 0) < 180, MAX([mDwell, mTTC]))",
             "Id": "expr_1",
           },
           Object {
@@ -33583,18 +33559,6 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
             "MetricStat": Object {
               "Metric": Object {
                 "MetricName": "EstimatedNpmReplicaLag",
-                "Namespace": "ConstructHub/PackageCanary",
-              },
-              "Period": 60,
-              "Stat": "Maximum",
-            },
-            "ReturnData": false,
-          },
-          Object {
-            "Id": "mIsReplicaDown",
-            "MetricStat": Object {
-              "Metric": Object {
-                "MetricName": "NpmReplicaIsDown",
                 "Namespace": "ConstructHub/PackageCanary",
               },
               "Period": 60,
@@ -45665,7 +45629,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "690a69f41b4de2e39da000f8425ac7e6140ede848bd6c1d1451c59e9a6a54d08.zip",
+          "S3Key": "daf32d98a032c2147ae867c48e85227488c2f85561758fbedfcea2d4a2462305.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {
@@ -45704,7 +45668,7 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "EvaluationPeriods": 2,
         "Metrics": Array [
           Object {
-            "Expression": "IF((FILL(mLag, 0) < 180 AND mIsReplicaDown == 0), MAX([mDwell, mTTC]))",
+            "Expression": "IF(FILL(mLag, 0) < 180, MAX([mDwell, mTTC]))",
             "Id": "expr_1",
           },
           Object {
@@ -45736,18 +45700,6 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
             "MetricStat": Object {
               "Metric": Object {
                 "MetricName": "EstimatedNpmReplicaLag",
-                "Namespace": "ConstructHub/PackageCanary",
-              },
-              "Period": 60,
-              "Stat": "Maximum",
-            },
-            "ReturnData": false,
-          },
-          Object {
-            "Id": "mIsReplicaDown",
-            "MetricStat": Object {
-              "Metric": Object {
-                "MetricName": "NpmReplicaIsDown",
                 "Namespace": "ConstructHub/PackageCanary",
               },
               "Period": 60,
@@ -57832,7 +57784,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "690a69f41b4de2e39da000f8425ac7e6140ede848bd6c1d1451c59e9a6a54d08.zip",
+          "S3Key": "daf32d98a032c2147ae867c48e85227488c2f85561758fbedfcea2d4a2462305.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {
@@ -57884,7 +57836,7 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "EvaluationPeriods": 2,
         "Metrics": Array [
           Object {
-            "Expression": "IF((FILL(mLag, 0) < 180 AND mIsReplicaDown == 0), MAX([mDwell, mTTC]))",
+            "Expression": "IF(FILL(mLag, 0) < 180, MAX([mDwell, mTTC]))",
             "Id": "expr_1",
           },
           Object {
@@ -57916,18 +57868,6 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
             "MetricStat": Object {
               "Metric": Object {
                 "MetricName": "EstimatedNpmReplicaLag",
-                "Namespace": "ConstructHub/PackageCanary",
-              },
-              "Period": 60,
-              "Stat": "Maximum",
-            },
-            "ReturnData": false,
-          },
-          Object {
-            "Id": "mIsReplicaDown",
-            "MetricStat": Object {
-              "Metric": Object {
-                "MetricName": "NpmReplicaIsDown",
                 "Namespace": "ConstructHub/PackageCanary",
               },
               "Period": 60,

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -9007,7 +9007,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "34dff6f44de35b1c8efed081f774e0d2f7402826e3287041c4b095bf9e9f1933.zip",
+          "S3Key": "690a69f41b4de2e39da000f8425ac7e6140ede848bd6c1d1451c59e9a6a54d08.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {
@@ -9059,7 +9059,7 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "EvaluationPeriods": 2,
         "Metrics": Array [
           Object {
-            "Expression": "IF(FILL(mLag, 0) < 180, MAX([mDwell, mTTC]))",
+            "Expression": "IF((FILL(mLag, 0) < 180 AND mIsReplicaDown == 0), MAX([mDwell, mTTC]))",
             "Id": "expr_1",
           },
           Object {
@@ -9091,6 +9091,18 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
             "MetricStat": Object {
               "Metric": Object {
                 "MetricName": "EstimatedNpmReplicaLag",
+                "Namespace": "ConstructHub/PackageCanary",
+              },
+              "Period": 60,
+              "Stat": "Maximum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "mIsReplicaDown",
+            "MetricStat": Object {
+              "Metric": Object {
+                "MetricName": "NpmReplicaIsDown",
                 "Namespace": "ConstructHub/PackageCanary",
               },
               "Period": 60,
@@ -21455,7 +21467,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "34dff6f44de35b1c8efed081f774e0d2f7402826e3287041c4b095bf9e9f1933.zip",
+          "S3Key": "690a69f41b4de2e39da000f8425ac7e6140ede848bd6c1d1451c59e9a6a54d08.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {
@@ -21507,7 +21519,7 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "EvaluationPeriods": 2,
         "Metrics": Array [
           Object {
-            "Expression": "IF(FILL(mLag, 0) < 180, MAX([mDwell, mTTC]))",
+            "Expression": "IF((FILL(mLag, 0) < 180 AND mIsReplicaDown == 0), MAX([mDwell, mTTC]))",
             "Id": "expr_1",
           },
           Object {
@@ -21539,6 +21551,18 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
             "MetricStat": Object {
               "Metric": Object {
                 "MetricName": "EstimatedNpmReplicaLag",
+                "Namespace": "ConstructHub/PackageCanary",
+              },
+              "Period": 60,
+              "Stat": "Maximum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "mIsReplicaDown",
+            "MetricStat": Object {
+              "Metric": Object {
+                "MetricName": "NpmReplicaIsDown",
                 "Namespace": "ConstructHub/PackageCanary",
               },
               "Period": 60,
@@ -33475,7 +33499,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "34dff6f44de35b1c8efed081f774e0d2f7402826e3287041c4b095bf9e9f1933.zip",
+          "S3Key": "690a69f41b4de2e39da000f8425ac7e6140ede848bd6c1d1451c59e9a6a54d08.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {
@@ -33527,7 +33551,7 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "EvaluationPeriods": 2,
         "Metrics": Array [
           Object {
-            "Expression": "IF(FILL(mLag, 0) < 180, MAX([mDwell, mTTC]))",
+            "Expression": "IF((FILL(mLag, 0) < 180 AND mIsReplicaDown == 0), MAX([mDwell, mTTC]))",
             "Id": "expr_1",
           },
           Object {
@@ -33559,6 +33583,18 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
             "MetricStat": Object {
               "Metric": Object {
                 "MetricName": "EstimatedNpmReplicaLag",
+                "Namespace": "ConstructHub/PackageCanary",
+              },
+              "Period": 60,
+              "Stat": "Maximum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "mIsReplicaDown",
+            "MetricStat": Object {
+              "Metric": Object {
+                "MetricName": "NpmReplicaIsDown",
                 "Namespace": "ConstructHub/PackageCanary",
               },
               "Period": 60,
@@ -45629,7 +45665,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "34dff6f44de35b1c8efed081f774e0d2f7402826e3287041c4b095bf9e9f1933.zip",
+          "S3Key": "690a69f41b4de2e39da000f8425ac7e6140ede848bd6c1d1451c59e9a6a54d08.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {
@@ -45668,7 +45704,7 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "EvaluationPeriods": 2,
         "Metrics": Array [
           Object {
-            "Expression": "IF(FILL(mLag, 0) < 180, MAX([mDwell, mTTC]))",
+            "Expression": "IF((FILL(mLag, 0) < 180 AND mIsReplicaDown == 0), MAX([mDwell, mTTC]))",
             "Id": "expr_1",
           },
           Object {
@@ -45700,6 +45736,18 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
             "MetricStat": Object {
               "Metric": Object {
                 "MetricName": "EstimatedNpmReplicaLag",
+                "Namespace": "ConstructHub/PackageCanary",
+              },
+              "Period": 60,
+              "Stat": "Maximum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "mIsReplicaDown",
+            "MetricStat": Object {
+              "Metric": Object {
+                "MetricName": "NpmReplicaIsDown",
                 "Namespace": "ConstructHub/PackageCanary",
               },
               "Period": 60,
@@ -57784,7 +57832,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "34dff6f44de35b1c8efed081f774e0d2f7402826e3287041c4b095bf9e9f1933.zip",
+          "S3Key": "690a69f41b4de2e39da000f8425ac7e6140ede848bd6c1d1451c59e9a6a54d08.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {
@@ -57836,7 +57884,7 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "EvaluationPeriods": 2,
         "Metrics": Array [
           Object {
-            "Expression": "IF(FILL(mLag, 0) < 180, MAX([mDwell, mTTC]))",
+            "Expression": "IF((FILL(mLag, 0) < 180 AND mIsReplicaDown == 0), MAX([mDwell, mTTC]))",
             "Id": "expr_1",
           },
           Object {
@@ -57868,6 +57916,18 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
             "MetricStat": Object {
               "Metric": Object {
                 "MetricName": "EstimatedNpmReplicaLag",
+                "Namespace": "ConstructHub/PackageCanary",
+              },
+              "Period": 60,
+              "Stat": "Maximum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "mIsReplicaDown",
+            "MetricStat": Object {
+              "Metric": Object {
+                "MetricName": "NpmReplicaIsDown",
                 "Namespace": "ConstructHub/PackageCanary",
               },
               "Period": 60,

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -9059,7 +9059,7 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "EvaluationPeriods": 2,
         "Metrics": Array [
           Object {
-            "Expression": "IF(FILL(mLag, 0) < 180, MAX([mDwell, mTTC]))",
+            "Expression": "IF(FILL(mLag, REPEAT) < 180, MAX([mDwell, mTTC]))",
             "Id": "expr_1",
           },
           Object {
@@ -21507,7 +21507,7 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "EvaluationPeriods": 2,
         "Metrics": Array [
           Object {
-            "Expression": "IF(FILL(mLag, 0) < 180, MAX([mDwell, mTTC]))",
+            "Expression": "IF(FILL(mLag, REPEAT) < 180, MAX([mDwell, mTTC]))",
             "Id": "expr_1",
           },
           Object {
@@ -33527,7 +33527,7 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "EvaluationPeriods": 2,
         "Metrics": Array [
           Object {
-            "Expression": "IF(FILL(mLag, 0) < 180, MAX([mDwell, mTTC]))",
+            "Expression": "IF(FILL(mLag, REPEAT) < 180, MAX([mDwell, mTTC]))",
             "Id": "expr_1",
           },
           Object {
@@ -45668,7 +45668,7 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "EvaluationPeriods": 2,
         "Metrics": Array [
           Object {
-            "Expression": "IF(FILL(mLag, 0) < 180, MAX([mDwell, mTTC]))",
+            "Expression": "IF(FILL(mLag, REPEAT) < 180, MAX([mDwell, mTTC]))",
             "Id": "expr_1",
           },
           Object {
@@ -57836,7 +57836,7 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "EvaluationPeriods": 2,
         "Metrics": Array [
           Object {
-            "Expression": "IF(FILL(mLag, 0) < 180, MAX([mDwell, mTTC]))",
+            "Expression": "IF(FILL(mLag, REPEAT) < 180, MAX([mDwell, mTTC]))",
             "Id": "expr_1",
           },
           Object {

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -7653,7 +7653,7 @@ Resources:
         Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md
       AlarmName: dev/ConstructHub/Sources/NpmJs/Canary/SLA-Breached
       Metrics:
-        - Expression: IF(FILL(mLag, 0) < 180, MAX([mDwell, mTTC]))
+        - Expression: IF(FILL(mLag, REPEAT) < 180, MAX([mDwell, mTTC]))
           Id: expr_1
         - Id: mDwell
           MetricStat:

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -7579,7 +7579,7 @@ Resources:
       Code:
         S3Bucket:
           Fn::Sub: cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}
-        S3Key: 34dff6f44de35b1c8efed081f774e0d2f7402826e3287041c4b095bf9e9f1933.zip
+        S3Key: 690a69f41b4de2e39da000f8425ac7e6140ede848bd6c1d1451c59e9a6a54d08.zip
       Role:
         Fn::GetAtt:
           - ConstructHubSourcesNpmJsCanaryServiceRoleC4CBCDA2
@@ -7653,7 +7653,8 @@ Resources:
         Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md
       AlarmName: dev/ConstructHub/Sources/NpmJs/Canary/SLA-Breached
       Metrics:
-        - Expression: IF(FILL(mLag, 0) < 180, MAX([mDwell, mTTC]))
+        - Expression: IF((FILL(mLag, 0) < 180 AND mIsReplicaDown == 0), MAX([mDwell,
+            mTTC]))
           Id: expr_1
         - Id: mDwell
           MetricStat:
@@ -7675,6 +7676,14 @@ Resources:
           MetricStat:
             Metric:
               MetricName: EstimatedNpmReplicaLag
+              Namespace: ConstructHub/PackageCanary
+            Period: 60
+            Stat: Maximum
+          ReturnData: false
+        - Id: mIsReplicaDown
+          MetricStat:
+            Metric:
+              MetricName: NpmReplicaIsDown
               Namespace: ConstructHub/PackageCanary
             Period: 60
             Stat: Maximum

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -7579,7 +7579,7 @@ Resources:
       Code:
         S3Bucket:
           Fn::Sub: cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}
-        S3Key: 690a69f41b4de2e39da000f8425ac7e6140ede848bd6c1d1451c59e9a6a54d08.zip
+        S3Key: daf32d98a032c2147ae867c48e85227488c2f85561758fbedfcea2d4a2462305.zip
       Role:
         Fn::GetAtt:
           - ConstructHubSourcesNpmJsCanaryServiceRoleC4CBCDA2
@@ -7653,8 +7653,7 @@ Resources:
         Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md
       AlarmName: dev/ConstructHub/Sources/NpmJs/Canary/SLA-Breached
       Metrics:
-        - Expression: IF((FILL(mLag, 0) < 180 AND mIsReplicaDown == 0), MAX([mDwell,
-            mTTC]))
+        - Expression: IF(FILL(mLag, 0) < 180, MAX([mDwell, mTTC]))
           Id: expr_1
         - Id: mDwell
           MetricStat:
@@ -7676,14 +7675,6 @@ Resources:
           MetricStat:
             Metric:
               MetricName: EstimatedNpmReplicaLag
-              Namespace: ConstructHub/PackageCanary
-            Period: 60
-            Stat: Maximum
-          ReturnData: false
-        - Id: mIsReplicaDown
-          MetricStat:
-            Metric:
-              MetricName: NpmReplicaIsDown
               Namespace: ConstructHub/PackageCanary
             Period: 60
             Stat: Maximum

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -7579,7 +7579,7 @@ Resources:
       Code:
         S3Bucket:
           Fn::Sub: cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}
-        S3Key: daf32d98a032c2147ae867c48e85227488c2f85561758fbedfcea2d4a2462305.zip
+        S3Key: 52b2c3211afba07666b6cef7f079b82715be5fc763159d6fdf1da008f7be7ad0.zip
       Role:
         Fn::GetAtt:
           - ConstructHubSourcesNpmJsCanaryServiceRoleC4CBCDA2

--- a/src/package-sources/npmjs.ts
+++ b/src/package-sources/npmjs.ts
@@ -578,7 +578,7 @@ export class NpmJs implements IPackageSource {
       // nothing that can be done except for waiting until the replica has finally caught up. We
       // hence suppress the alarm if the replica lag is getting within 3 evaluation periods of the
       // visbility SLA.
-      expression: `IF(FILL(mLag, 0) < ${Math.max(
+      expression: `IF(FILL(mLag, REPEAT) < ${Math.max(
         visibilitySla.toSeconds() - 3 * period.toSeconds(),
         3 * period.toSeconds()
       )}, MAX([mDwell, mTTC]))`,

--- a/src/package-sources/npmjs/canary/constants.ts
+++ b/src/package-sources/npmjs/canary/constants.ts
@@ -36,6 +36,13 @@ export const enum MetricName {
    * so we use the probe package to get a low-resolution view of this.
    */
   NPM_REPLICA_LAG = 'EstimatedNpmReplicaLag',
+
+  /**
+   * A metric tracking whether the npm registry replica (replicate.npmjs.com)
+   * is down. The value is 1 when the replica is detected to be down, and 0
+   * when the replica is detected to be up.
+   */
+  NPM_REPLICA_DOWN = 'NpmReplicaIsDown',
 }
 
 export const enum ObjectKey {

--- a/src/package-sources/npmjs/canary/index.ts
+++ b/src/package-sources/npmjs/canary/index.ts
@@ -105,6 +105,21 @@ export class NpmJsPackageCanary extends Construct {
     });
   }
 
+  /**
+   * A metric tracking whether the npm registry replica (replicate.npmjs.com)
+   * is down. The value is 1 when the replica is detected to be down, and 0
+   * when the replica is detected to be up.
+   */
+  public metricNpmReplicaIsDown(opts?: MetricOptions): Metric {
+    return new Metric({
+      period: Duration.minutes(1),
+      statistic: Statistic.MAXIMUM,
+      ...opts,
+      metricName: MetricName.NPM_REPLICA_DOWN,
+      namespace: METRICS_NAMESPACE,
+    });
+  }
+
   public metricErrors(opts?: MetricOptions): Metric {
     return this.handler.metricErrors(opts);
   }

--- a/src/package-sources/npmjs/canary/npmjs-package-canary.lambda.ts
+++ b/src/package-sources/npmjs/canary/npmjs-package-canary.lambda.ts
@@ -63,9 +63,9 @@ export async function handler(event: unknown): Promise<void> {
   // If the current "latest" isn't the one from state, it needs updating.
   updateLatestIfNeeded(state, latest);
 
-  const replicaLag = await stateService.npmReplicaLagSeconds(packageName);
-
   try {
+    const replicaLag = await stateService.npmReplicaLagSeconds(packageName);
+
     await metricScope((metrics) => async () => {
       // Clear out default dimensions as we don't need those. See https://github.com/awslabs/aws-embedded-metrics-node/issues/73.
       metrics.setDimensions();

--- a/src/package-sources/npmjs/canary/npmjs-package-canary.lambda.ts
+++ b/src/package-sources/npmjs/canary/npmjs-package-canary.lambda.ts
@@ -77,6 +77,11 @@ export async function handler(event: unknown): Promise<void> {
         await stateService.npmReplicaLagSeconds(packageName),
         Unit.Seconds
       );
+      metrics.putMetric(
+        MetricName.NPM_REPLICA_DOWN,
+        (await stateService.isNpmReplicaDown()) ? 1 : 0,
+        Unit.None
+      );
     })();
 
     for (const versionState of [
@@ -302,6 +307,15 @@ export class CanaryStateService {
     );
 
     return { version, publishedAt: new Date(publishedAt) };
+  }
+
+  public async isNpmReplicaDown(): Promise<boolean> {
+    try {
+      await getJSON('https://replicate.npmjs.com/');
+      return false;
+    } catch (e) {
+      return true;
+    }
   }
 
   public async npmReplicaLagSeconds(packageName: string): Promise<number> {


### PR DESCRIPTION
Sometimes, the NpmJS canary errors because replicate.npmjs.com is down, causing an alarm to be triggered. There's no use failing and alarming since there's nothing that that can be done by the operator. So this PR catches the error, and opts to simply not report the NPM replica lag metric when it's unavailable.

The Npmjs/Canary/SLA-Breached alarm, which depends on this metric to determine if replicate.npmjs.com is down (and disable the alarm accordingly), will now fill in values based on what the last reported lag-time metric was, instead of filling in empty values with 0.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*