### PR TITLE
fix: NpmJs source canary fails when npm servers are impaired

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -9007,7 +9007,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "52b2c3211afba07666b6cef7f079b82715be5fc763159d6fdf1da008f7be7ad0.zip",
+          "S3Key": "35f3d22c9454c12d060b9342c04257351c531c8c21cf4620d03fa94a266e52c3.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {
@@ -9125,6 +9125,30 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "Namespace": "AWS/Lambda",
         "Period": 60,
         "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ConstructHubSourcesNpmJsCanaryGatewayErrorsDAA2E45C": Object {
+      "DependsOn": Array [
+        "ConstructHubLicenseListAwsCliLayer59592811",
+        "ConstructHubLicenseListCustomResource323F0FD4",
+      ],
+      "Properties": Object {
+        "AlarmDescription": "The NpmJs package canary has been encountering consistent HTTP gateway errors when contacting npmjs servers
+for an hour or more. This means the canary has been unable to evaluate SLA compliance for that much time.
+It is probable that nothing can be done except for waiting for npm servers to come back online, but the
+situation should be checked to make sure there is not another problem.
+
+Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md",
+        "AlarmName": "Test/ConstructHub/Sources/NpmJs/Canary/GatewayErrors",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 60,
+        "MetricName": "HttpGatewayErrors",
+        "Namespace": "ConstructHub/PackageCanary",
+        "Period": 60,
+        "Statistic": "Minimum",
         "Threshold": 0,
         "TreatMissingData": "breaching",
       },
@@ -21455,7 +21479,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "52b2c3211afba07666b6cef7f079b82715be5fc763159d6fdf1da008f7be7ad0.zip",
+          "S3Key": "35f3d22c9454c12d060b9342c04257351c531c8c21cf4620d03fa94a266e52c3.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {
@@ -21573,6 +21597,30 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "Namespace": "AWS/Lambda",
         "Period": 60,
         "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ConstructHubSourcesNpmJsCanaryGatewayErrorsDAA2E45C": Object {
+      "DependsOn": Array [
+        "ConstructHubLicenseListAwsCliLayer59592811",
+        "ConstructHubLicenseListCustomResource323F0FD4",
+      ],
+      "Properties": Object {
+        "AlarmDescription": "The NpmJs package canary has been encountering consistent HTTP gateway errors when contacting npmjs servers
+for an hour or more. This means the canary has been unable to evaluate SLA compliance for that much time.
+It is probable that nothing can be done except for waiting for npm servers to come back online, but the
+situation should be checked to make sure there is not another problem.
+
+Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md",
+        "AlarmName": "Test/ConstructHub/Sources/NpmJs/Canary/GatewayErrors",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 60,
+        "MetricName": "HttpGatewayErrors",
+        "Namespace": "ConstructHub/PackageCanary",
+        "Period": 60,
+        "Statistic": "Minimum",
         "Threshold": 0,
         "TreatMissingData": "breaching",
       },
@@ -33475,7 +33523,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "52b2c3211afba07666b6cef7f079b82715be5fc763159d6fdf1da008f7be7ad0.zip",
+          "S3Key": "35f3d22c9454c12d060b9342c04257351c531c8c21cf4620d03fa94a266e52c3.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {
@@ -33593,6 +33641,30 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "Namespace": "AWS/Lambda",
         "Period": 60,
         "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ConstructHubSourcesNpmJsCanaryGatewayErrorsDAA2E45C": Object {
+      "DependsOn": Array [
+        "ConstructHubLicenseListAwsCliLayer59592811",
+        "ConstructHubLicenseListCustomResource323F0FD4",
+      ],
+      "Properties": Object {
+        "AlarmDescription": "The NpmJs package canary has been encountering consistent HTTP gateway errors when contacting npmjs servers
+for an hour or more. This means the canary has been unable to evaluate SLA compliance for that much time.
+It is probable that nothing can be done except for waiting for npm servers to come back online, but the
+situation should be checked to make sure there is not another problem.
+
+Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md",
+        "AlarmName": "Test/ConstructHub/Sources/NpmJs/Canary/GatewayErrors",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 60,
+        "MetricName": "HttpGatewayErrors",
+        "Namespace": "ConstructHub/PackageCanary",
+        "Period": 60,
+        "Statistic": "Minimum",
         "Threshold": 0,
         "TreatMissingData": "breaching",
       },
@@ -45629,7 +45701,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "52b2c3211afba07666b6cef7f079b82715be5fc763159d6fdf1da008f7be7ad0.zip",
+          "S3Key": "35f3d22c9454c12d060b9342c04257351c531c8c21cf4620d03fa94a266e52c3.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {
@@ -45734,6 +45806,30 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "Namespace": "AWS/Lambda",
         "Period": 60,
         "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ConstructHubSourcesNpmJsCanaryGatewayErrorsDAA2E45C": Object {
+      "DependsOn": Array [
+        "ConstructHubLicenseListAwsCliLayer59592811",
+        "ConstructHubLicenseListCustomResource323F0FD4",
+      ],
+      "Properties": Object {
+        "AlarmDescription": "The NpmJs package canary has been encountering consistent HTTP gateway errors when contacting npmjs servers
+for an hour or more. This means the canary has been unable to evaluate SLA compliance for that much time.
+It is probable that nothing can be done except for waiting for npm servers to come back online, but the
+situation should be checked to make sure there is not another problem.
+
+Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md",
+        "AlarmName": "Test/ConstructHub/Sources/NpmJs/Canary/GatewayErrors",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 60,
+        "MetricName": "HttpGatewayErrors",
+        "Namespace": "ConstructHub/PackageCanary",
+        "Period": 60,
+        "Statistic": "Minimum",
         "Threshold": 0,
         "TreatMissingData": "breaching",
       },
@@ -57784,7 +57880,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "52b2c3211afba07666b6cef7f079b82715be5fc763159d6fdf1da008f7be7ad0.zip",
+          "S3Key": "35f3d22c9454c12d060b9342c04257351c531c8c21cf4620d03fa94a266e52c3.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {
@@ -57902,6 +57998,30 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "Namespace": "AWS/Lambda",
         "Period": 60,
         "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ConstructHubSourcesNpmJsCanaryGatewayErrorsDAA2E45C": Object {
+      "DependsOn": Array [
+        "ConstructHubLicenseListAwsCliLayer59592811",
+        "ConstructHubLicenseListCustomResource323F0FD4",
+      ],
+      "Properties": Object {
+        "AlarmDescription": "The NpmJs package canary has been encountering consistent HTTP gateway errors when contacting npmjs servers
+for an hour or more. This means the canary has been unable to evaluate SLA compliance for that much time.
+It is probable that nothing can be done except for waiting for npm servers to come back online, but the
+situation should be checked to make sure there is not another problem.
+
+Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md",
+        "AlarmName": "Test/ConstructHub/Sources/NpmJs/Canary/GatewayErrors",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 60,
+        "MetricName": "HttpGatewayErrors",
+        "Namespace": "ConstructHub/PackageCanary",
+        "Period": 60,
+        "Statistic": "Minimum",
         "Threshold": 0,
         "TreatMissingData": "breaching",
       },

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -7579,7 +7579,7 @@ Resources:
       Code:
         S3Bucket:
           Fn::Sub: cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}
-        S3Key: 52b2c3211afba07666b6cef7f079b82715be5fc763159d6fdf1da008f7be7ad0.zip
+        S3Key: 35f3d22c9454c12d060b9342c04257351c531c8c21cf4620d03fa94a266e52c3.zip
       Role:
         Fn::GetAtt:
           - ConstructHubSourcesNpmJsCanaryServiceRoleC4CBCDA2
@@ -7746,6 +7746,33 @@ Resources:
 
 
         Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md
+    DependsOn:
+      - ConstructHubLicenseListAwsCliLayer59592811
+      - ConstructHubLicenseListCustomResource323F0FD4
+  ConstructHubSourcesNpmJsCanaryGatewayErrorsDAA2E45C:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ComparisonOperator: GreaterThanThreshold
+      EvaluationPeriods: 60
+      AlarmDescription: >-
+        The NpmJs package canary has been encountering consistent HTTP gateway
+        errors when contacting npmjs servers
+
+        for an hour or more. This means the canary has been unable to evaluate SLA compliance for that much time.
+
+        It is probable that nothing can be done except for waiting for npm servers to come back online, but the
+
+        situation should be checked to make sure there is not another problem.
+
+
+        Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md
+      AlarmName: dev/ConstructHub/Sources/NpmJs/Canary/GatewayErrors
+      MetricName: HttpGatewayErrors
+      Namespace: ConstructHub/PackageCanary
+      Period: 60
+      Statistic: Minimum
+      Threshold: 0
+      TreatMissingData: breaching
     DependsOn:
       - ConstructHubLicenseListAwsCliLayer59592811
       - ConstructHubLicenseListCustomResource323F0FD4

--- a/src/package-sources/npmjs.ts
+++ b/src/package-sources/npmjs.ts
@@ -648,7 +648,8 @@ export class NpmJs implements IPackageSource {
     );
 
     // Using MIN statistic, so if a run is successful (and hence emits a 0), this alarm will not trigger.
-    const gatewayErrorsAlarm = canary.metricHttpGatewayErrors({ period, statistic: Statistic.MINIMUM })
+    const gatewayErrorsAlarm = canary
+      .metricHttpGatewayErrors({ period, statistic: Statistic.MINIMUM })
       .createAlarm(canary, 'GatewayErrors', {
         alarmDescription: [
           'The NpmJs package canary has been encountering consistent HTTP gateway errors when contacting npmjs servers',
@@ -664,7 +665,10 @@ export class NpmJs implements IPackageSource {
         threshold: 0,
         treatMissingData: TreatMissingData.BREACHING,
       });
-    monitoring.addLowSeverityAlarm('NpmJs Follower Canary is experiencing HTTP Gateway errors', gatewayErrorsAlarm);
+    monitoring.addLowSeverityAlarm(
+      'NpmJs Follower Canary is experiencing HTTP Gateway errors',
+      gatewayErrorsAlarm
+    );
 
     return [
       new GraphWidget({

--- a/src/package-sources/npmjs/canary/constants.ts
+++ b/src/package-sources/npmjs/canary/constants.ts
@@ -43,6 +43,13 @@ export const enum MetricName {
    * when the replica is detected to be up.
    */
   NPM_REPLICA_DOWN = 'NpmReplicaIsDown',
+
+  /**
+   * A metric tracking HTTP 502 and HTTP 504 errors received while processing.
+   * Those are often encountered when the npm servers are overloaded, or
+   * otherwise impaired, and could cause alarms we cannot do anything about.
+   */
+  HTTP_GATEWAY_ERRORS = 'HttpGatewayErrors',
 }
 
 export const enum ObjectKey {

--- a/src/package-sources/npmjs/canary/index.ts
+++ b/src/package-sources/npmjs/canary/index.ts
@@ -120,6 +120,21 @@ export class NpmJsPackageCanary extends Construct {
     });
   }
 
+  /**
+   * A metric tracking HTTP Gateway errors experienced while the canary is
+   * running. Those are typically caused by the npm registry servers being
+   * overloaded or otherwise impaired, and would cause false alarms.
+   */
+  public metricHttpGatewayErrors(opts?: MetricOptions): Metric {
+    return new Metric({
+      period: Duration.minutes(1),
+      statistic: Statistic.SUM,
+      ...opts,
+      metricName: MetricName.HTTP_GATEWAY_ERRORS,
+      namespace: METRICS_NAMESPACE,
+    });
+  }
+
   public metricErrors(opts?: MetricOptions): Metric {
     return this.handler.metricErrors(opts);
   }


### PR DESCRIPTION
We are seeing semi-frequent occurrences of npm servers being impaired
and returning HTTP Gateway errors (HTTP 502, HTTP 504). There is nothing
we can do but wait for these to resolve, so we should not be failing and
alarming unless the situation persists for an extended amount of time.

This change catches HTTP errors and "ignores" HTTP 502 and HTTP 504
errors, while emitting a metric to reflect those errors being
encountered. A new low-severity alarm will fire if we continue to see
HTTP 502 and HTTP 504 errors on every single run for more than 60
minutes.

I chose not to apply a back-off & retry policy as those issues are
usually caused by servers being overloaded and the best strategy here
is to let these servers cool off, not pile up more load on them.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*