### PR TITLE
chore: increase timeout of NpmJs canary

### DIFF
--- a/src/package-sources/npmjs/canary/index.ts
+++ b/src/package-sources/npmjs/canary/index.ts
@@ -39,7 +39,12 @@ export class NpmJsPackageCanary extends Construct {
         [Environment.PACKAGE_NAME]: props.packageName,
       },
       memorySize: 10_024,
-      timeout: Duration.minutes(1),
+      // Runs every minute, but we don't want to timeout if/when the npm replica
+      // is overloaded & extremely slow. HTTP 504 take upstream of 30 seconds to
+      // be returned... There wouldn't normally be more than 5 (maybe 6)
+      // concurrent executions of this, which should be okay to avoid causing a
+      // load storm that contributes to the problem.
+      timeout: Duration.minutes(5),
     });
     const grant = props.bucket.grantReadWrite(
       this.handler,


### PR DESCRIPTION
When the npm replica is overloaded and we get HTTP 504 (Gateway Timeout),
these error responses can take upstream of 30 seconds to be returned, which
makes it likely that the function times out if it's operating on a 1 minute
timeout.

Reducing the request timeout is difficult as this would introduce a new
error class to handler (timeouts), and the handling of these would be
awkward (should be similar to gateway timeout, so why not wait for this?).


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*