### PR TITLE
fix: canary fails on npm returning 503

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -9007,7 +9007,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5aa25f8ee75f1575885899085167294ac046d2e14690f2526e39aa87dfc6c90e.zip",
+          "S3Key": "de7daa4fec4acfe2004fd7acda09154aeb8f866aff95fbc337afa21db103bb7b.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {
@@ -21536,7 +21536,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5aa25f8ee75f1575885899085167294ac046d2e14690f2526e39aa87dfc6c90e.zip",
+          "S3Key": "de7daa4fec4acfe2004fd7acda09154aeb8f866aff95fbc337afa21db103bb7b.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {
@@ -33637,7 +33637,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5aa25f8ee75f1575885899085167294ac046d2e14690f2526e39aa87dfc6c90e.zip",
+          "S3Key": "de7daa4fec4acfe2004fd7acda09154aeb8f866aff95fbc337afa21db103bb7b.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {
@@ -45872,7 +45872,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5aa25f8ee75f1575885899085167294ac046d2e14690f2526e39aa87dfc6c90e.zip",
+          "S3Key": "de7daa4fec4acfe2004fd7acda09154aeb8f866aff95fbc337afa21db103bb7b.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {
@@ -58108,7 +58108,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5aa25f8ee75f1575885899085167294ac046d2e14690f2526e39aa87dfc6c90e.zip",
+          "S3Key": "de7daa4fec4acfe2004fd7acda09154aeb8f866aff95fbc337afa21db103bb7b.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -9007,7 +9007,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "de7daa4fec4acfe2004fd7acda09154aeb8f866aff95fbc337afa21db103bb7b.zip",
+          "S3Key": "abadd3df34746ccf346b2ab3ca3e279e05133bc59625722ec722a1e232e68150.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {
@@ -21536,7 +21536,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "de7daa4fec4acfe2004fd7acda09154aeb8f866aff95fbc337afa21db103bb7b.zip",
+          "S3Key": "abadd3df34746ccf346b2ab3ca3e279e05133bc59625722ec722a1e232e68150.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {
@@ -33637,7 +33637,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "de7daa4fec4acfe2004fd7acda09154aeb8f866aff95fbc337afa21db103bb7b.zip",
+          "S3Key": "abadd3df34746ccf346b2ab3ca3e279e05133bc59625722ec722a1e232e68150.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {
@@ -45872,7 +45872,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "de7daa4fec4acfe2004fd7acda09154aeb8f866aff95fbc337afa21db103bb7b.zip",
+          "S3Key": "abadd3df34746ccf346b2ab3ca3e279e05133bc59625722ec722a1e232e68150.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {
@@ -58108,7 +58108,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "de7daa4fec4acfe2004fd7acda09154aeb8f866aff95fbc337afa21db103bb7b.zip",
+          "S3Key": "abadd3df34746ccf346b2ab3ca3e279e05133bc59625722ec722a1e232e68150.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -9007,7 +9007,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "abadd3df34746ccf346b2ab3ca3e279e05133bc59625722ec722a1e232e68150.zip",
+          "S3Key": "e92693d8a42c98c58c18b79fd8fbc66b48440cfc0bb2595a4ccc0f2de20b4dd0.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {
@@ -21536,7 +21536,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "abadd3df34746ccf346b2ab3ca3e279e05133bc59625722ec722a1e232e68150.zip",
+          "S3Key": "e92693d8a42c98c58c18b79fd8fbc66b48440cfc0bb2595a4ccc0f2de20b4dd0.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {
@@ -33637,7 +33637,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "abadd3df34746ccf346b2ab3ca3e279e05133bc59625722ec722a1e232e68150.zip",
+          "S3Key": "e92693d8a42c98c58c18b79fd8fbc66b48440cfc0bb2595a4ccc0f2de20b4dd0.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {
@@ -45872,7 +45872,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "abadd3df34746ccf346b2ab3ca3e279e05133bc59625722ec722a1e232e68150.zip",
+          "S3Key": "e92693d8a42c98c58c18b79fd8fbc66b48440cfc0bb2595a4ccc0f2de20b4dd0.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {
@@ -58108,7 +58108,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "abadd3df34746ccf346b2ab3ca3e279e05133bc59625722ec722a1e232e68150.zip",
+          "S3Key": "e92693d8a42c98c58c18b79fd8fbc66b48440cfc0bb2595a4ccc0f2de20b4dd0.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": Object {

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -7631,7 +7631,7 @@ Resources:
       Code:
         S3Bucket:
           Fn::Sub: cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}
-        S3Key: 5aa25f8ee75f1575885899085167294ac046d2e14690f2526e39aa87dfc6c90e.zip
+        S3Key: de7daa4fec4acfe2004fd7acda09154aeb8f866aff95fbc337afa21db103bb7b.zip
       Role:
         Fn::GetAtt:
           - ConstructHubSourcesNpmJsCanaryServiceRoleC4CBCDA2

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -7631,7 +7631,7 @@ Resources:
       Code:
         S3Bucket:
           Fn::Sub: cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}
-        S3Key: de7daa4fec4acfe2004fd7acda09154aeb8f866aff95fbc337afa21db103bb7b.zip
+        S3Key: abadd3df34746ccf346b2ab3ca3e279e05133bc59625722ec722a1e232e68150.zip
       Role:
         Fn::GetAtt:
           - ConstructHubSourcesNpmJsCanaryServiceRoleC4CBCDA2

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -7631,7 +7631,7 @@ Resources:
       Code:
         S3Bucket:
           Fn::Sub: cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}
-        S3Key: abadd3df34746ccf346b2ab3ca3e279e05133bc59625722ec722a1e232e68150.zip
+        S3Key: e92693d8a42c98c58c18b79fd8fbc66b48440cfc0bb2595a4ccc0f2de20b4dd0.zip
       Role:
         Fn::GetAtt:
           - ConstructHubSourcesNpmJsCanaryServiceRoleC4CBCDA2

--- a/src/package-sources/npmjs/canary/npmjs-package-canary.lambda.ts
+++ b/src/package-sources/npmjs/canary/npmjs-package-canary.lambda.ts
@@ -177,7 +177,7 @@ export async function handler(event: unknown): Promise<void> {
   } catch (error) {
     if (
       error instanceof HTTPError &&
-      (error.httpStatusCode === 502 || error.httpStatusCode === 504)
+      (error.httpStatusCode === 502 || error.httpStatusCode === 503 || error.httpStatusCode === 504)
     ) {
       // This is an HTTP 5XX from a dependency, so we'll log this out, and pretend it did not fail...
       console.error(

--- a/src/package-sources/npmjs/canary/npmjs-package-canary.lambda.ts
+++ b/src/package-sources/npmjs/canary/npmjs-package-canary.lambda.ts
@@ -177,7 +177,9 @@ export async function handler(event: unknown): Promise<void> {
   } catch (error) {
     if (
       error instanceof HTTPError &&
-      (error.httpStatusCode === 502 || error.httpStatusCode === 503 || error.httpStatusCode === 504)
+      (error.httpStatusCode === 502 ||
+        error.httpStatusCode === 503 ||
+        error.httpStatusCode === 504)
     ) {
       // This is an HTTP 5XX from a dependency, so we'll log this out, and pretend it did not fail...
       console.error(

--- a/src/package-sources/npmjs/canary/npmjs-package-canary.lambda.ts
+++ b/src/package-sources/npmjs/canary/npmjs-package-canary.lambda.ts
@@ -177,9 +177,8 @@ export async function handler(event: unknown): Promise<void> {
   } catch (error) {
     if (
       error instanceof HTTPError &&
-      (error.httpStatusCode === 502 ||
-        error.httpStatusCode === 503 ||
-        error.httpStatusCode === 504)
+      error.httpStatusCode &&
+      error.httpStatusCode >= 500
     ) {
       // This is an HTTP 5XX from a dependency, so we'll log this out, and pretend it did not fail...
       console.error(


### PR DESCRIPTION
The canary currently fails when npm returns a status of `503 Service
Unavailable`, which should be handled the same as other known 500 cases.
This causes the metric to correctly be emitted and supress other alarms
due to service outage.

fixes: #916


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*