### PR TITLE
chore: upgrade major version of jsii-docgen

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "jest-junit": "^13",
     "jsii": "^1.63.2",
     "jsii-diff": "^1.63.2",
-    "jsii-docgen": "^6.3.27",
+    "jsii-docgen": "^7.0.56",
     "jsii-pacmak": "^1.63.2",
     "json-schema": "^0.4.0",
     "JSONStream": "^1.3.5",

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -1920,7 +1920,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "7ef5e11a8c4ae831ada41b1f7fd7191d236e267a0bc8c4a787f06b2faaf5eba4.zip",
+          "S3Key": "0145275b3b965add1bc57d0bc932372228c7e6f6342c579945ab10c53d676cd5.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": Object {
@@ -2144,7 +2144,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "61f21ac0cd9ff8688d263582cec405e6682833924caee6d9d5eda14388a68dee.zip",
+          "S3Key": "9b7fda00c17df0c47e27052089a5e46eeba2bd87974084ee4bad975412180a63.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": Object {
@@ -4692,7 +4692,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1592e560b3c4802dd557ad3c64116a94904ac65cfcf806fb0599abd287d91293.zip",
+          "S3Key": "c96826c1d068c5795f20a5424b8dfbad26862a56968d67a5e4eaba99c162f0a2.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -6433,7 +6433,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:e4192559d3fc9b857ca48f539758b8ed446932cec826ad69f476ccf51bf83608",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:51d8648f10d76daa58bbec167b98d9b41ece67c11bb49f46e0b9c27fbfdbf296",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -10117,7 +10117,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "43f498d8aa4afbe171809f5f8e9554a2247a55116fa0a18e6c3ed1b31c3ea5e8.zip",
+          "S3Key": "cd86fe109a6131d92af62de9d0a2df1d1bb3c28c3a93ac37855ade090beb73b7.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -10321,7 +10321,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "c1c579bd9934dca3a507d18a75bbada5e55248de83a509a0ad35a3c4a7c06eab.zip",
+          "S3Key": "eff6d29049503f68b2a61f077c12e9cfe5778eb36a065284a0c2bf8c9706bbb2.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -14278,7 +14278,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "7ef5e11a8c4ae831ada41b1f7fd7191d236e267a0bc8c4a787f06b2faaf5eba4.zip",
+          "S3Key": "0145275b3b965add1bc57d0bc932372228c7e6f6342c579945ab10c53d676cd5.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": Object {
@@ -14502,7 +14502,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "61f21ac0cd9ff8688d263582cec405e6682833924caee6d9d5eda14388a68dee.zip",
+          "S3Key": "9b7fda00c17df0c47e27052089a5e46eeba2bd87974084ee4bad975412180a63.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": Object {
@@ -17148,7 +17148,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1592e560b3c4802dd557ad3c64116a94904ac65cfcf806fb0599abd287d91293.zip",
+          "S3Key": "c96826c1d068c5795f20a5424b8dfbad26862a56968d67a5e4eaba99c162f0a2.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -18916,7 +18916,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:e4192559d3fc9b857ca48f539758b8ed446932cec826ad69f476ccf51bf83608",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:51d8648f10d76daa58bbec167b98d9b41ece67c11bb49f46e0b9c27fbfdbf296",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -22646,7 +22646,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "43f498d8aa4afbe171809f5f8e9554a2247a55116fa0a18e6c3ed1b31c3ea5e8.zip",
+          "S3Key": "cd86fe109a6131d92af62de9d0a2df1d1bb3c28c3a93ac37855ade090beb73b7.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -22850,7 +22850,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "c1c579bd9934dca3a507d18a75bbada5e55248de83a509a0ad35a3c4a7c06eab.zip",
+          "S3Key": "eff6d29049503f68b2a61f077c12e9cfe5778eb36a065284a0c2bf8c9706bbb2.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -26550,7 +26550,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "7ef5e11a8c4ae831ada41b1f7fd7191d236e267a0bc8c4a787f06b2faaf5eba4.zip",
+          "S3Key": "0145275b3b965add1bc57d0bc932372228c7e6f6342c579945ab10c53d676cd5.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": Object {
@@ -26774,7 +26774,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "61f21ac0cd9ff8688d263582cec405e6682833924caee6d9d5eda14388a68dee.zip",
+          "S3Key": "9b7fda00c17df0c47e27052089a5e46eeba2bd87974084ee4bad975412180a63.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": Object {
@@ -29322,7 +29322,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1592e560b3c4802dd557ad3c64116a94904ac65cfcf806fb0599abd287d91293.zip",
+          "S3Key": "c96826c1d068c5795f20a5424b8dfbad26862a56968d67a5e4eaba99c162f0a2.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -31063,7 +31063,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:e4192559d3fc9b857ca48f539758b8ed446932cec826ad69f476ccf51bf83608",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:51d8648f10d76daa58bbec167b98d9b41ece67c11bb49f46e0b9c27fbfdbf296",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -34747,7 +34747,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "43f498d8aa4afbe171809f5f8e9554a2247a55116fa0a18e6c3ed1b31c3ea5e8.zip",
+          "S3Key": "cd86fe109a6131d92af62de9d0a2df1d1bb3c28c3a93ac37855ade090beb73b7.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -34951,7 +34951,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "c1c579bd9934dca3a507d18a75bbada5e55248de83a509a0ad35a3c4a7c06eab.zip",
+          "S3Key": "eff6d29049503f68b2a61f077c12e9cfe5778eb36a065284a0c2bf8c9706bbb2.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -38776,7 +38776,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "7ef5e11a8c4ae831ada41b1f7fd7191d236e267a0bc8c4a787f06b2faaf5eba4.zip",
+          "S3Key": "0145275b3b965add1bc57d0bc932372228c7e6f6342c579945ab10c53d676cd5.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": Object {
@@ -38987,7 +38987,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "61f21ac0cd9ff8688d263582cec405e6682833924caee6d9d5eda14388a68dee.zip",
+          "S3Key": "9b7fda00c17df0c47e27052089a5e46eeba2bd87974084ee4bad975412180a63.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": Object {
@@ -41557,7 +41557,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1592e560b3c4802dd557ad3c64116a94904ac65cfcf806fb0599abd287d91293.zip",
+          "S3Key": "c96826c1d068c5795f20a5424b8dfbad26862a56968d67a5e4eaba99c162f0a2.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -43298,7 +43298,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:e4192559d3fc9b857ca48f539758b8ed446932cec826ad69f476ccf51bf83608",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:51d8648f10d76daa58bbec167b98d9b41ece67c11bb49f46e0b9c27fbfdbf296",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -46969,7 +46969,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "43f498d8aa4afbe171809f5f8e9554a2247a55116fa0a18e6c3ed1b31c3ea5e8.zip",
+          "S3Key": "cd86fe109a6131d92af62de9d0a2df1d1bb3c28c3a93ac37855ade090beb73b7.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -47173,7 +47173,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "c1c579bd9934dca3a507d18a75bbada5e55248de83a509a0ad35a3c4a7c06eab.zip",
+          "S3Key": "eff6d29049503f68b2a61f077c12e9cfe5778eb36a065284a0c2bf8c9706bbb2.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -51197,7 +51197,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "7ef5e11a8c4ae831ada41b1f7fd7191d236e267a0bc8c4a787f06b2faaf5eba4.zip",
+          "S3Key": "0145275b3b965add1bc57d0bc932372228c7e6f6342c579945ab10c53d676cd5.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": Object {
@@ -51421,7 +51421,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "61f21ac0cd9ff8688d263582cec405e6682833924caee6d9d5eda14388a68dee.zip",
+          "S3Key": "9b7fda00c17df0c47e27052089a5e46eeba2bd87974084ee4bad975412180a63.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": Object {
@@ -54124,7 +54124,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1592e560b3c4802dd557ad3c64116a94904ac65cfcf806fb0599abd287d91293.zip",
+          "S3Key": "c96826c1d068c5795f20a5424b8dfbad26862a56968d67a5e4eaba99c162f0a2.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -55472,7 +55472,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:e4192559d3fc9b857ca48f539758b8ed446932cec826ad69f476ccf51bf83608",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:51d8648f10d76daa58bbec167b98d9b41ece67c11bb49f46e0b9c27fbfdbf296",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -59218,7 +59218,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "43f498d8aa4afbe171809f5f8e9554a2247a55116fa0a18e6c3ed1b31c3ea5e8.zip",
+          "S3Key": "cd86fe109a6131d92af62de9d0a2df1d1bb3c28c3a93ac37855ade090beb73b7.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -62274,7 +62274,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "c1c579bd9934dca3a507d18a75bbada5e55248de83a509a0ad35a3c4a7c06eab.zip",
+          "S3Key": "eff6d29049503f68b2a61f077c12e9cfe5778eb36a065284a0c2bf8c9706bbb2.zip",
         },
         "Description": Object {
           "Fn::Join": Array [

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -1920,7 +1920,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "0145275b3b965add1bc57d0bc932372228c7e6f6342c579945ab10c53d676cd5.zip",
+          "S3Key": "7ef5e11a8c4ae831ada41b1f7fd7191d236e267a0bc8c4a787f06b2faaf5eba4.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": Object {
@@ -2144,7 +2144,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "9b7fda00c17df0c47e27052089a5e46eeba2bd87974084ee4bad975412180a63.zip",
+          "S3Key": "61f21ac0cd9ff8688d263582cec405e6682833924caee6d9d5eda14388a68dee.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": Object {
@@ -4692,7 +4692,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "c96826c1d068c5795f20a5424b8dfbad26862a56968d67a5e4eaba99c162f0a2.zip",
+          "S3Key": "1592e560b3c4802dd557ad3c64116a94904ac65cfcf806fb0599abd287d91293.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -6433,7 +6433,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:01a0d1dd4f783f872c259befa49d8181e8a5962c8f80f19e6f4e4b8d564bf439",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:e4192559d3fc9b857ca48f539758b8ed446932cec826ad69f476ccf51bf83608",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -10117,7 +10117,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "cd86fe109a6131d92af62de9d0a2df1d1bb3c28c3a93ac37855ade090beb73b7.zip",
+          "S3Key": "43f498d8aa4afbe171809f5f8e9554a2247a55116fa0a18e6c3ed1b31c3ea5e8.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -10321,7 +10321,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "eff6d29049503f68b2a61f077c12e9cfe5778eb36a065284a0c2bf8c9706bbb2.zip",
+          "S3Key": "c1c579bd9934dca3a507d18a75bbada5e55248de83a509a0ad35a3c4a7c06eab.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -14278,7 +14278,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "0145275b3b965add1bc57d0bc932372228c7e6f6342c579945ab10c53d676cd5.zip",
+          "S3Key": "7ef5e11a8c4ae831ada41b1f7fd7191d236e267a0bc8c4a787f06b2faaf5eba4.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": Object {
@@ -14502,7 +14502,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "9b7fda00c17df0c47e27052089a5e46eeba2bd87974084ee4bad975412180a63.zip",
+          "S3Key": "61f21ac0cd9ff8688d263582cec405e6682833924caee6d9d5eda14388a68dee.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": Object {
@@ -17148,7 +17148,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "c96826c1d068c5795f20a5424b8dfbad26862a56968d67a5e4eaba99c162f0a2.zip",
+          "S3Key": "1592e560b3c4802dd557ad3c64116a94904ac65cfcf806fb0599abd287d91293.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -18916,7 +18916,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:01a0d1dd4f783f872c259befa49d8181e8a5962c8f80f19e6f4e4b8d564bf439",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:e4192559d3fc9b857ca48f539758b8ed446932cec826ad69f476ccf51bf83608",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -22646,7 +22646,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "cd86fe109a6131d92af62de9d0a2df1d1bb3c28c3a93ac37855ade090beb73b7.zip",
+          "S3Key": "43f498d8aa4afbe171809f5f8e9554a2247a55116fa0a18e6c3ed1b31c3ea5e8.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -22850,7 +22850,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "eff6d29049503f68b2a61f077c12e9cfe5778eb36a065284a0c2bf8c9706bbb2.zip",
+          "S3Key": "c1c579bd9934dca3a507d18a75bbada5e55248de83a509a0ad35a3c4a7c06eab.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -26550,7 +26550,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "0145275b3b965add1bc57d0bc932372228c7e6f6342c579945ab10c53d676cd5.zip",
+          "S3Key": "7ef5e11a8c4ae831ada41b1f7fd7191d236e267a0bc8c4a787f06b2faaf5eba4.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": Object {
@@ -26774,7 +26774,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "9b7fda00c17df0c47e27052089a5e46eeba2bd87974084ee4bad975412180a63.zip",
+          "S3Key": "61f21ac0cd9ff8688d263582cec405e6682833924caee6d9d5eda14388a68dee.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": Object {
@@ -29322,7 +29322,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "c96826c1d068c5795f20a5424b8dfbad26862a56968d67a5e4eaba99c162f0a2.zip",
+          "S3Key": "1592e560b3c4802dd557ad3c64116a94904ac65cfcf806fb0599abd287d91293.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -31063,7 +31063,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:01a0d1dd4f783f872c259befa49d8181e8a5962c8f80f19e6f4e4b8d564bf439",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:e4192559d3fc9b857ca48f539758b8ed446932cec826ad69f476ccf51bf83608",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -34747,7 +34747,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "cd86fe109a6131d92af62de9d0a2df1d1bb3c28c3a93ac37855ade090beb73b7.zip",
+          "S3Key": "43f498d8aa4afbe171809f5f8e9554a2247a55116fa0a18e6c3ed1b31c3ea5e8.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -34951,7 +34951,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "eff6d29049503f68b2a61f077c12e9cfe5778eb36a065284a0c2bf8c9706bbb2.zip",
+          "S3Key": "c1c579bd9934dca3a507d18a75bbada5e55248de83a509a0ad35a3c4a7c06eab.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -38776,7 +38776,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "0145275b3b965add1bc57d0bc932372228c7e6f6342c579945ab10c53d676cd5.zip",
+          "S3Key": "7ef5e11a8c4ae831ada41b1f7fd7191d236e267a0bc8c4a787f06b2faaf5eba4.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": Object {
@@ -38987,7 +38987,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "9b7fda00c17df0c47e27052089a5e46eeba2bd87974084ee4bad975412180a63.zip",
+          "S3Key": "61f21ac0cd9ff8688d263582cec405e6682833924caee6d9d5eda14388a68dee.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": Object {
@@ -41557,7 +41557,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "c96826c1d068c5795f20a5424b8dfbad26862a56968d67a5e4eaba99c162f0a2.zip",
+          "S3Key": "1592e560b3c4802dd557ad3c64116a94904ac65cfcf806fb0599abd287d91293.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -43298,7 +43298,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:01a0d1dd4f783f872c259befa49d8181e8a5962c8f80f19e6f4e4b8d564bf439",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:e4192559d3fc9b857ca48f539758b8ed446932cec826ad69f476ccf51bf83608",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -46969,7 +46969,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "cd86fe109a6131d92af62de9d0a2df1d1bb3c28c3a93ac37855ade090beb73b7.zip",
+          "S3Key": "43f498d8aa4afbe171809f5f8e9554a2247a55116fa0a18e6c3ed1b31c3ea5e8.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -47173,7 +47173,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "eff6d29049503f68b2a61f077c12e9cfe5778eb36a065284a0c2bf8c9706bbb2.zip",
+          "S3Key": "c1c579bd9934dca3a507d18a75bbada5e55248de83a509a0ad35a3c4a7c06eab.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -51197,7 +51197,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "0145275b3b965add1bc57d0bc932372228c7e6f6342c579945ab10c53d676cd5.zip",
+          "S3Key": "7ef5e11a8c4ae831ada41b1f7fd7191d236e267a0bc8c4a787f06b2faaf5eba4.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": Object {
@@ -51421,7 +51421,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "9b7fda00c17df0c47e27052089a5e46eeba2bd87974084ee4bad975412180a63.zip",
+          "S3Key": "61f21ac0cd9ff8688d263582cec405e6682833924caee6d9d5eda14388a68dee.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": Object {
@@ -54124,7 +54124,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "c96826c1d068c5795f20a5424b8dfbad26862a56968d67a5e4eaba99c162f0a2.zip",
+          "S3Key": "1592e560b3c4802dd557ad3c64116a94904ac65cfcf806fb0599abd287d91293.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -55472,7 +55472,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:01a0d1dd4f783f872c259befa49d8181e8a5962c8f80f19e6f4e4b8d564bf439",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:e4192559d3fc9b857ca48f539758b8ed446932cec826ad69f476ccf51bf83608",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -59218,7 +59218,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "cd86fe109a6131d92af62de9d0a2df1d1bb3c28c3a93ac37855ade090beb73b7.zip",
+          "S3Key": "43f498d8aa4afbe171809f5f8e9554a2247a55116fa0a18e6c3ed1b31c3ea5e8.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -62274,7 +62274,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "eff6d29049503f68b2a61f077c12e9cfe5778eb36a065284a0c2bf8c9706bbb2.zip",
+          "S3Key": "c1c579bd9934dca3a507d18a75bbada5e55248de83a509a0ad35a3c4a7c06eab.zip",
         },
         "Description": Object {
           "Fn::Join": Array [

--- a/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
+++ b/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
@@ -118,7 +118,7 @@ Object {
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:e4192559d3fc9b857ca48f539758b8ed446932cec826ad69f476ccf51bf83608",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:51d8648f10d76daa58bbec167b98d9b41ece67c11bb49f46e0b9c27fbfdbf296",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -2354,7 +2354,7 @@ Object {
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:e4192559d3fc9b857ca48f539758b8ed446932cec826ad69f476ccf51bf83608",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:51d8648f10d76daa58bbec167b98d9b41ece67c11bb49f46e0b9c27fbfdbf296",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -4658,7 +4658,7 @@ Object {
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:e4192559d3fc9b857ca48f539758b8ed446932cec826ad69f476ccf51bf83608",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:51d8648f10d76daa58bbec167b98d9b41ece67c11bb49f46e0b9c27fbfdbf296",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -6890,7 +6890,7 @@ Object {
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:e4192559d3fc9b857ca48f539758b8ed446932cec826ad69f476ccf51bf83608",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:51d8648f10d76daa58bbec167b98d9b41ece67c11bb49f46e0b9c27fbfdbf296",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",

--- a/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
+++ b/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
@@ -118,7 +118,7 @@ Object {
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:01a0d1dd4f783f872c259befa49d8181e8a5962c8f80f19e6f4e4b8d564bf439",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:e4192559d3fc9b857ca48f539758b8ed446932cec826ad69f476ccf51bf83608",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -2354,7 +2354,7 @@ Object {
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:01a0d1dd4f783f872c259befa49d8181e8a5962c8f80f19e6f4e4b8d564bf439",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:e4192559d3fc9b857ca48f539758b8ed446932cec826ad69f476ccf51bf83608",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -4658,7 +4658,7 @@ Object {
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:01a0d1dd4f783f872c259befa49d8181e8a5962c8f80f19e6f4e4b8d564bf439",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:e4192559d3fc9b857ca48f539758b8ed446932cec826ad69f476ccf51bf83608",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -6890,7 +6890,7 @@ Object {
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:01a0d1dd4f783f872c259befa49d8181e8a5962c8f80f19e6f4e4b8d564bf439",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:e4192559d3fc9b857ca48f539758b8ed446932cec826ad69f476ccf51bf83608",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -2917,7 +2917,7 @@ Resources:
       Code:
         S3Bucket:
           Fn::Sub: cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}
-        S3Key: 43f498d8aa4afbe171809f5f8e9554a2247a55116fa0a18e6c3ed1b31c3ea5e8.zip
+        S3Key: cd86fe109a6131d92af62de9d0a2df1d1bb3c28c3a93ac37855ade090beb73b7.zip
       Role:
         Fn::GetAtt:
           - ConstructHubStatsServiceRole48DCA379
@@ -3068,7 +3068,7 @@ Resources:
       Code:
         S3Bucket:
           Fn::Sub: cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}
-        S3Key: c1c579bd9934dca3a507d18a75bbada5e55248de83a509a0ad35a3c4a7c06eab.zip
+        S3Key: eff6d29049503f68b2a61f077c12e9cfe5778eb36a065284a0c2bf8c9706bbb2.zip
       Role:
         Fn::GetAtt:
           - ConstructHubVersionTrackerServiceRole721EE863
@@ -3293,7 +3293,7 @@ Resources:
       Code:
         S3Bucket:
           Fn::Sub: cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}
-        S3Key: 7ef5e11a8c4ae831ada41b1f7fd7191d236e267a0bc8c4a787f06b2faaf5eba4.zip
+        S3Key: 0145275b3b965add1bc57d0bc932372228c7e6f6342c579945ab10c53d676cd5.zip
       Role:
         Fn::GetAtt:
           - ConstructHubFeedBuilderReleaseNotesUpdateFeedServiceRoleC857E364
@@ -3480,7 +3480,7 @@ Resources:
       Code:
         S3Bucket:
           Fn::Sub: cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}
-        S3Key: 1592e560b3c4802dd557ad3c64116a94904ac65cfcf806fb0599abd287d91293.zip
+        S3Key: c96826c1d068c5795f20a5424b8dfbad26862a56968d67a5e4eaba99c162f0a2.zip
       Role:
         Fn::GetAtt:
           - ConstructHubOrchestrationCatalogBuilderServiceRole851C750C
@@ -4765,7 +4765,7 @@ Resources:
                   - repositoryEndpoint
           Essential: true
           Image:
-            Fn::Sub: \${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:e4192559d3fc9b857ca48f539758b8ed446932cec826ad69f476ccf51bf83608
+            Fn::Sub: \${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:51d8648f10d76daa58bbec167b98d9b41ece67c11bb49f46e0b9c27fbfdbf296
           LogConfiguration:
             LogDriver: awslogs
             Options:
@@ -6340,7 +6340,7 @@ Resources:
       Code:
         S3Bucket:
           Fn::Sub: cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}
-        S3Key: 61f21ac0cd9ff8688d263582cec405e6682833924caee6d9d5eda14388a68dee.zip
+        S3Key: 9b7fda00c17df0c47e27052089a5e46eeba2bd87974084ee4bad975412180a63.zip
       Role:
         Fn::GetAtt:
           - ConstructHubIngestionServiceRole6380BAB6

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -2917,7 +2917,7 @@ Resources:
       Code:
         S3Bucket:
           Fn::Sub: cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}
-        S3Key: cd86fe109a6131d92af62de9d0a2df1d1bb3c28c3a93ac37855ade090beb73b7.zip
+        S3Key: 43f498d8aa4afbe171809f5f8e9554a2247a55116fa0a18e6c3ed1b31c3ea5e8.zip
       Role:
         Fn::GetAtt:
           - ConstructHubStatsServiceRole48DCA379
@@ -3068,7 +3068,7 @@ Resources:
       Code:
         S3Bucket:
           Fn::Sub: cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}
-        S3Key: eff6d29049503f68b2a61f077c12e9cfe5778eb36a065284a0c2bf8c9706bbb2.zip
+        S3Key: c1c579bd9934dca3a507d18a75bbada5e55248de83a509a0ad35a3c4a7c06eab.zip
       Role:
         Fn::GetAtt:
           - ConstructHubVersionTrackerServiceRole721EE863
@@ -3293,7 +3293,7 @@ Resources:
       Code:
         S3Bucket:
           Fn::Sub: cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}
-        S3Key: 0145275b3b965add1bc57d0bc932372228c7e6f6342c579945ab10c53d676cd5.zip
+        S3Key: 7ef5e11a8c4ae831ada41b1f7fd7191d236e267a0bc8c4a787f06b2faaf5eba4.zip
       Role:
         Fn::GetAtt:
           - ConstructHubFeedBuilderReleaseNotesUpdateFeedServiceRoleC857E364
@@ -3480,7 +3480,7 @@ Resources:
       Code:
         S3Bucket:
           Fn::Sub: cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}
-        S3Key: c96826c1d068c5795f20a5424b8dfbad26862a56968d67a5e4eaba99c162f0a2.zip
+        S3Key: 1592e560b3c4802dd557ad3c64116a94904ac65cfcf806fb0599abd287d91293.zip
       Role:
         Fn::GetAtt:
           - ConstructHubOrchestrationCatalogBuilderServiceRole851C750C
@@ -4765,7 +4765,7 @@ Resources:
                   - repositoryEndpoint
           Essential: true
           Image:
-            Fn::Sub: \${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:01a0d1dd4f783f872c259befa49d8181e8a5962c8f80f19e6f4e4b8d564bf439
+            Fn::Sub: \${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:e4192559d3fc9b857ca48f539758b8ed446932cec826ad69f476ccf51bf83608
           LogConfiguration:
             LogDriver: awslogs
             Options:
@@ -6340,7 +6340,7 @@ Resources:
       Code:
         S3Bucket:
           Fn::Sub: cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}
-        S3Key: 9b7fda00c17df0c47e27052089a5e46eeba2bd87974084ee4bad975412180a63.zip
+        S3Key: 61f21ac0cd9ff8688d263582cec405e6682833924caee6d9d5eda14388a68dee.zip
       Role:
         Fn::GetAtt:
           - ConstructHubIngestionServiceRole6380BAB6

--- a/src/__tests__/package-sources/__snapshots__/code-artifact.test.ts.snap
+++ b/src/__tests__/package-sources/__snapshots__/code-artifact.test.ts.snap
@@ -240,7 +240,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b8c060ba3f0e47032efc44ec311ff7d08ef119a9cd0c61495e2f6a9f0397afc6.zip",
+          "S3Key": "21e75cc2562ad797176722e3a1cfb6ff7f6e9f481f05faccd5534cd2feb60266.zip",
         },
         "DeadLetterConfig": Object {
           "TargetArn": Object {
@@ -721,7 +721,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b8c060ba3f0e47032efc44ec311ff7d08ef119a9cd0c61495e2f6a9f0397afc6.zip",
+          "S3Key": "21e75cc2562ad797176722e3a1cfb6ff7f6e9f481f05faccd5534cd2feb60266.zip",
         },
         "DeadLetterConfig": Object {
           "TargetArn": Object {

--- a/src/__tests__/package-sources/__snapshots__/code-artifact.test.ts.snap
+++ b/src/__tests__/package-sources/__snapshots__/code-artifact.test.ts.snap
@@ -240,7 +240,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "21e75cc2562ad797176722e3a1cfb6ff7f6e9f481f05faccd5534cd2feb60266.zip",
+          "S3Key": "b8c060ba3f0e47032efc44ec311ff7d08ef119a9cd0c61495e2f6a9f0397afc6.zip",
         },
         "DeadLetterConfig": Object {
           "TargetArn": Object {
@@ -721,7 +721,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "21e75cc2562ad797176722e3a1cfb6ff7f6e9f481f05faccd5534cd2feb60266.zip",
+          "S3Key": "b8c060ba3f0e47032efc44ec311ff7d08ef119a9cd0c61495e2f6a9f0397afc6.zip",
         },
         "DeadLetterConfig": Object {
           "TargetArn": Object {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2830,7 +2830,7 @@
     chalk "^4.1.2"
     semver "^7.3.7"
 
-"@jsii/spec@1.63.2", "@jsii/spec@^1.57.0", "@jsii/spec@^1.63.2":
+"@jsii/spec@1.63.2", "@jsii/spec@^1.63.2":
   version "1.63.2"
   resolved "https://registry.yarnpkg.com/@jsii/spec/-/spec-1.63.2.tgz#36cdde3279ba8e1d212bbcba9b4766b1a3aaab95"
   integrity sha512-zIFZDG/qtQJWa2I7W1cUXExeshr4WSSuMNHWGkJzIn4hFtYv4eQG7cP3gF2ToqAwS2WgsX7fQ7dDrLg0Pzfc2A==
@@ -9079,18 +9079,18 @@ jsii-diff@^1.63.2:
     log4js "^6.6.1"
     yargs "^16.2.0"
 
-jsii-docgen@^6.3.27:
-  version "6.3.27"
-  resolved "https://registry.yarnpkg.com/jsii-docgen/-/jsii-docgen-6.3.27.tgz#b5e7a69ee71c2e1252380f5d623c937465080c3f"
-  integrity sha512-BuDpCO3S1rlPuP+mM8UJP+4d+2ca34DUhnEdVxiD6E8XE4xj5hZDnbX3Z6ocD3h2eJG4Xt644ZC5byWOlBiAQw==
+jsii-docgen@^7.0.56:
+  version "7.0.67"
+  resolved "https://registry.yarnpkg.com/jsii-docgen/-/jsii-docgen-7.0.67.tgz#bbb0b4983297c8794baac5ae6a8429af803d3f4a"
+  integrity sha512-a9bcReY9gtBp2Xb/YHiC/P0jLMJ1H5l3GOeUPIBw0dYQju9QOVoo+HLItcxjItycdPrGVOqy2BlA1HymchSirg==
   dependencies:
-    "@jsii/spec" "^1.57.0"
+    "@jsii/spec" "^1.63.2"
     case "^1.6.3"
     fs-extra "^10.1.0"
-    glob "^7.2.0"
+    glob "^7.2.3"
     glob-promise "^3.4.0"
-    jsii-reflect "^1.57.0"
-    jsii-rosetta "^1.57.0"
+    jsii-reflect "^1.63.2"
+    jsii-rosetta "^1.63.2"
     semver "^7.3.7"
     yargs "^16.2.0"
 
@@ -9113,7 +9113,7 @@ jsii-pacmak@^1.63.2:
     xmlbuilder "^15.1.1"
     yargs "^16.2.0"
 
-jsii-reflect@^1.57.0, jsii-reflect@^1.63.2:
+jsii-reflect@^1.63.2:
   version "1.63.2"
   resolved "https://registry.yarnpkg.com/jsii-reflect/-/jsii-reflect-1.63.2.tgz#1f8d130a1cb5a03b30651543dd52c77eb9f620fe"
   integrity sha512-eawNN/ySYVznYY2ZJYe5FNcSly12KgC8/MBDl4qln3daag3Ts/d7ocfbS9sjFayn4AhBojq1h1DDs8sjoG38Kg==
@@ -9125,7 +9125,7 @@ jsii-reflect@^1.57.0, jsii-reflect@^1.63.2:
     oo-ascii-tree "^1.63.2"
     yargs "^16.2.0"
 
-jsii-rosetta@^1.57.0, jsii-rosetta@^1.63.2:
+jsii-rosetta@^1.63.2:
   version "1.63.2"
   resolved "https://registry.yarnpkg.com/jsii-rosetta/-/jsii-rosetta-1.63.2.tgz#42c1ee7a418392f0dcee8fa89277559871b76117"
   integrity sha512-cBl8uAtNYuWqrwGue2Sr7cdgPhWx/QiAAE70lDec0OtBSNdGq0MUA04GD1/peQw4LPhE+1ikdeyspJYJaTtQgg==


### PR DESCRIPTION
Fixes #956. The earliest jsii-docgen version that supports compressed assemblies is v7.0.56. Therefore, construct hub must have a minimum dependency on that as well.

The only breaking change between jsii-docgen v6 and v7 is dropping node support below node 14. Since construct hub requires node 14, I don't believe this version upgrade will break anything.

Tested this on my local construct hub instance to ensure that transliteration works after this change.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*