### PR TITLE
fix: use node16 in ECR image

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -529,7 +529,7 @@
       },
       "steps": [
         {
-          "exec": "esbuild --bundle src/backend/transliterator/transliterator.ecs-entrypoint.ts --target=\"node18\" --platform=\"node\" --outfile=\"$BUNDLE_DIR/index.js\" --sourcemap"
+          "exec": "esbuild --bundle src/backend/transliterator/transliterator.ecs-entrypoint.ts --target=\"node16\" --platform=\"node\" --outfile=\"$BUNDLE_DIR/index.js\" --sourcemap"
         },
         {
           "exec": "esbuild --bundle node_modules/jsii-rosetta/lib/translate_all_worker.js --target=\"node16\" --platform=\"node\" --outfile=\"$BUNDLE_DIR/translate_all_worker.js\" --sourcemap  --tsconfig=tsconfig.dev.json"
@@ -547,7 +547,7 @@
           "exec": "esbuild --bundle node_modules/jsii-rosetta/lib/translate_all_worker.js --target=\"node16\" --platform=\"node\" --outfile=\"$BUNDLE_DIR/translate_all_worker.js\" --sourcemap  --tsconfig=tsconfig.dev.json"
         },
         {
-          "exec": "esbuild --bundle src/backend/transliterator/transliterator.ecs-entrypoint.ts --target=\"node18\" --platform=\"node\" --outfile=\"$BUNDLE_DIR/index.js\" --sourcemap --watch"
+          "exec": "esbuild --bundle src/backend/transliterator/transliterator.ecs-entrypoint.ts --target=\"node16\" --platform=\"node\" --outfile=\"$BUNDLE_DIR/index.js\" --sourcemap --watch"
         }
       ]
     },

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -663,7 +663,7 @@ function newEcsTask(entrypoint) {
   df.line('FROM public.ecr.aws/amazonlinux/amazonlinux:2');
   df.line();
   // Install node the regular way...
-  df.line('RUN curl -sL https://rpm.nodesource.com/setup_18.x | bash - \\');
+  df.line('RUN curl -fsSL https://rpm.nodesource.com/setup_16.x | bash - \\');
   df.line(' && yum update -y \\');
   df.line(' && yum install -y git nodejs \\');
   // Clean up the yum cache in the interest of image size
@@ -687,7 +687,7 @@ function newEcsTask(entrypoint) {
     'esbuild',
     '--bundle',
     ecsMain,
-    '--target="node18"',
+    '--target="node16"',
     '--platform="node"',
     `--outfile="$${BUNDLE_DIR_ENV}/${dockerEntry}"`,
     '--sourcemap',

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -434,7 +434,7 @@ function newLambdaHandler(entrypoint, trigger) {
   ts.line();
   ts.open(
     `export class ${className} extends lambda.${
-      isSingleton ? 'SingletonFunction' : 'Function'
+    isSingleton ? 'SingletonFunction' : 'Function'
     } {`
   );
   // NOTE: unlike the array splat (`[...arr]`), the object splat (`{...obj}`) is
@@ -665,6 +665,7 @@ function newEcsTask(entrypoint) {
   // Install node the regular way...
   df.line('RUN curl -fsSL https://rpm.nodesource.com/setup_16.x | bash - \\');
   df.line(' && yum update -y \\');
+  df.line(' && yum upgrade -y \\');
   df.line(' && yum install -y git nodejs \\');
   // Clean up the yum cache in the interest of image size
   df.line(' && yum clean all \\');

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -434,7 +434,7 @@ function newLambdaHandler(entrypoint, trigger) {
   ts.line();
   ts.open(
     `export class ${className} extends lambda.${
-    isSingleton ? 'SingletonFunction' : 'Function'
+      isSingleton ? 'SingletonFunction' : 'Function'
     } {`
   );
   // NOTE: unlike the array splat (`[...arr]`), the object splat (`{...obj}`) is

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -6436,7 +6436,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:862c9e3a325c329cc0e67e01b918fc843a01618437d6122a84679ba6ca80e418",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:1a512d5e5e91e2fde33a5cc894ccda0c938bf556083c28bcfeb821f8169844a4",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -18977,7 +18977,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:862c9e3a325c329cc0e67e01b918fc843a01618437d6122a84679ba6ca80e418",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:1a512d5e5e91e2fde33a5cc894ccda0c938bf556083c28bcfeb821f8169844a4",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -31182,7 +31182,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:862c9e3a325c329cc0e67e01b918fc843a01618437d6122a84679ba6ca80e418",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:1a512d5e5e91e2fde33a5cc894ccda0c938bf556083c28bcfeb821f8169844a4",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -43475,7 +43475,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:862c9e3a325c329cc0e67e01b918fc843a01618437d6122a84679ba6ca80e418",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:1a512d5e5e91e2fde33a5cc894ccda0c938bf556083c28bcfeb821f8169844a4",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -55707,7 +55707,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:862c9e3a325c329cc0e67e01b918fc843a01618437d6122a84679ba6ca80e418",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:1a512d5e5e91e2fde33a5cc894ccda0c938bf556083c28bcfeb821f8169844a4",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",

--- a/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
+++ b/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
@@ -118,7 +118,7 @@ Object {
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:862c9e3a325c329cc0e67e01b918fc843a01618437d6122a84679ba6ca80e418",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:1a512d5e5e91e2fde33a5cc894ccda0c938bf556083c28bcfeb821f8169844a4",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -2422,7 +2422,7 @@ Object {
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:862c9e3a325c329cc0e67e01b918fc843a01618437d6122a84679ba6ca80e418",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:1a512d5e5e91e2fde33a5cc894ccda0c938bf556083c28bcfeb821f8169844a4",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -4777,7 +4777,7 @@ Object {
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:862c9e3a325c329cc0e67e01b918fc843a01618437d6122a84679ba6ca80e418",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:1a512d5e5e91e2fde33a5cc894ccda0c938bf556083c28bcfeb821f8169844a4",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -7077,7 +7077,7 @@ Object {
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:862c9e3a325c329cc0e67e01b918fc843a01618437d6122a84679ba6ca80e418",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:1a512d5e5e91e2fde33a5cc894ccda0c938bf556083c28bcfeb821f8169844a4",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -4813,7 +4813,7 @@ Resources:
                   - repositoryEndpoint
           Essential: true
           Image:
-            Fn::Sub: \${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:862c9e3a325c329cc0e67e01b918fc843a01618437d6122a84679ba6ca80e418
+            Fn::Sub: \${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:1a512d5e5e91e2fde33a5cc894ccda0c938bf556083c28bcfeb821f8169844a4
           LogConfiguration:
             LogDriver: awslogs
             Options:


### PR DESCRIPTION
The AmazonLinux 2 image does not come with a GLibc that
is compatible with node 18 from nodesource.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*