### PR TITLE
chore: revert update create-pull-request to v4

### DIFF
--- a/.github/workflows/update-vpc-acl-allow-lists.yml
+++ b/.github/workflows/update-vpc-acl-allow-lists.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Update GitHub IP lists
         run: node ./update-github-ip-allowlist.js
       - name: Make Pull Request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           branch: automation/update-vpc-acl-allow-lists

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -206,7 +206,7 @@ function addVpcAllowListManagement() {
         // And now make a PR if necessary
         {
           name: 'Make Pull Request',
-          uses: 'peter-evans/create-pull-request@v4',
+          uses: 'peter-evans/create-pull-request@v3',
           with: {
             token: project.github.projenCredentials.tokenRef,
             branch: `automation/${workflow.name}`,


### PR DESCRIPTION
Reverts the update to our ACL list update gh action to use v4 of the create-pull-request action as it breaks when using a personal access token. Apparently we can't grant the permissions needed to request reviews from teams using personal access tokens and can only do so using a github app.

Other actions built into projen use v3 of this action anyway so less variance feels better.

reverts: 4042a227ac7893aeb1891268ae08de365e08f8f3, b4fb2cddc4c5151b87a03039fb82b95338954642