### PR TITLE
fix: misinterpreted what it means to have no `languages`

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -6436,7 +6436,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:ff24b126b3cf533d75d8035269c978010feb75cd9c7cf18918fa7b0305e22e01",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:c71f9e46c2acd33c17b3692e915b481b9f4abe0fc39647f63e81cb6a20de73a4",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -18984,7 +18984,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:ff24b126b3cf533d75d8035269c978010feb75cd9c7cf18918fa7b0305e22e01",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:c71f9e46c2acd33c17b3692e915b481b9f4abe0fc39647f63e81cb6a20de73a4",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -31196,7 +31196,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:ff24b126b3cf533d75d8035269c978010feb75cd9c7cf18918fa7b0305e22e01",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:c71f9e46c2acd33c17b3692e915b481b9f4abe0fc39647f63e81cb6a20de73a4",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -43496,7 +43496,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:ff24b126b3cf533d75d8035269c978010feb75cd9c7cf18918fa7b0305e22e01",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:c71f9e46c2acd33c17b3692e915b481b9f4abe0fc39647f63e81cb6a20de73a4",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -55735,7 +55735,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:ff24b126b3cf533d75d8035269c978010feb75cd9c7cf18918fa7b0305e22e01",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:c71f9e46c2acd33c17b3692e915b481b9f4abe0fc39647f63e81cb6a20de73a4",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",

--- a/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
+++ b/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
@@ -118,7 +118,7 @@ Object {
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:ff24b126b3cf533d75d8035269c978010feb75cd9c7cf18918fa7b0305e22e01",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:c71f9e46c2acd33c17b3692e915b481b9f4abe0fc39647f63e81cb6a20de73a4",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -2429,7 +2429,7 @@ Object {
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:ff24b126b3cf533d75d8035269c978010feb75cd9c7cf18918fa7b0305e22e01",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:c71f9e46c2acd33c17b3692e915b481b9f4abe0fc39647f63e81cb6a20de73a4",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -4791,7 +4791,7 @@ Object {
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:ff24b126b3cf533d75d8035269c978010feb75cd9c7cf18918fa7b0305e22e01",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:c71f9e46c2acd33c17b3692e915b481b9f4abe0fc39647f63e81cb6a20de73a4",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -7098,7 +7098,7 @@ Object {
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:ff24b126b3cf533d75d8035269c978010feb75cd9c7cf18918fa7b0305e22e01",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:c71f9e46c2acd33c17b3692e915b481b9f4abe0fc39647f63e81cb6a20de73a4",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",

--- a/src/__tests__/backend/transliterator/transliterator.ecstask.test.ts
+++ b/src/__tests__/backend/transliterator/transliterator.ecstask.test.ts
@@ -460,6 +460,12 @@ test.each([true, false])(
     forPackage.mockImplementation(async (target: string) => {
       return new MockDocumentation(target) as unknown as Documentation;
     });
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const fromSchema = require('jsii-docgen').MarkdownRenderer
+      .fromSchema as jest.MockedFunction<typeof MarkdownRenderer.fromSchema>;
+    fromSchema.mockImplementation((_schema, _options) => {
+      return new MarkdownDocument();
+    });
 
     // GIVEN
     const packageName = '@scope/package-with-a-pretty-long-name';
@@ -480,7 +486,7 @@ test.each([true, false])(
     const assembly: spec.Assembly = {
       targets: { python: {} },
       submodules: Object.fromEntries(
-        range(10000).map((i) => [`${packageName}.sub${i}`, {}])
+        range(1000).map((i) => [`${packageName}.sub${i}`, {}])
       ),
     } as any;
 
@@ -497,6 +503,7 @@ test.each([true, false])(
     const { created } = await handler(event);
 
     // THEN: We didn't write and return all of the requested submodules
+    console.log('Uploaded', writtenKeys);
     expect(JSON.stringify({ created }).length).toBeLessThan(260_000);
     expect(writtenKeys.length).toBeLessThan(3000);
     expect(created.length).toEqual(writtenKeys.length);

--- a/src/__tests__/backend/transliterator/transliterator.ecstask.test.ts
+++ b/src/__tests__/backend/transliterator/transliterator.ecstask.test.ts
@@ -451,54 +451,57 @@ test('uploads a file per submodule (unscoped package)', async () => {
   ]);
 });
 
-test('will not translate more submodules than fit in a response', async () => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const forPackage = require('jsii-docgen').Documentation
-    .forPackage as jest.MockedFunction<typeof Documentation.forPackage>;
-  forPackage.mockImplementation(async (target: string) => {
-    return new MockDocumentation(target) as unknown as Documentation;
-  });
+test.each([true, false])(
+  'will not translate more submodules than fit in a response: %p',
+  async (explicitLanguages) => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const forPackage = require('jsii-docgen').Documentation
+      .forPackage as jest.MockedFunction<typeof Documentation.forPackage>;
+    forPackage.mockImplementation(async (target: string) => {
+      return new MockDocumentation(target) as unknown as Documentation;
+    });
 
-  // GIVEN
-  const packageName = '@scope/package-with-a-pretty-long-name';
-  const packageVersion = '1.2.3-dev.4';
-  const event: TransliteratorInput = {
-    bucket: 'dummy-bucket',
-    assembly: {
-      key: `${constants.STORAGE_KEY_PREFIX}${packageName}/v${packageVersion}${constants.ASSEMBLY_KEY_SUFFIX}`,
-      versionId: 'VersionId',
-    },
-    package: {
-      key: `${constants.STORAGE_KEY_PREFIX}${packageName}/v${packageVersion}${constants.PACKAGE_KEY_SUFFIX}`,
-      versionId: 'VersionId',
-    },
-    languages: { typescript: true },
-  };
+    // GIVEN
+    const packageName = '@scope/package-with-a-pretty-long-name';
+    const packageVersion = '1.2.3-dev.4';
+    const event: TransliteratorInput = {
+      bucket: 'dummy-bucket',
+      assembly: {
+        key: `${constants.STORAGE_KEY_PREFIX}${packageName}/v${packageVersion}${constants.ASSEMBLY_KEY_SUFFIX}`,
+        versionId: 'VersionId',
+      },
+      package: {
+        key: `${constants.STORAGE_KEY_PREFIX}${packageName}/v${packageVersion}${constants.PACKAGE_KEY_SUFFIX}`,
+        versionId: 'VersionId',
+      },
+      ...(explicitLanguages ? { languages: { typescript: true } } : {}),
+    };
 
-  const assembly: spec.Assembly = {
-    targets: { python: {} },
-    submodules: Object.fromEntries(
-      range(10000).map((i) => [`${packageName}.sub${i}`, {}])
-    ),
-  } as any;
+    const assembly: spec.Assembly = {
+      targets: { python: {} },
+      submodules: Object.fromEntries(
+        range(10000).map((i) => [`${packageName}.sub${i}`, {}])
+      ),
+    } as any;
 
-  // mock the s3ObjectExists call
-  mockHeadRequest('package.tgz');
+    // mock the s3ObjectExists call
+    mockHeadRequest('package.tgz');
 
-  // mock the assembly and tarball requests
-  mockFetchRequests(assembly, Buffer.from('fake-tarball', 'utf8'));
+    // mock the assembly and tarball requests
+    mockFetchRequests(assembly, Buffer.from('fake-tarball', 'utf8'));
 
-  // mock the file uploads
-  const writtenKeys = mockPutRequestCollectAll();
+    // mock the file uploads
+    const writtenKeys = mockPutRequestCollectAll();
 
-  // WHEN
-  const { created } = await handler(event);
+    // WHEN
+    const { created } = await handler(event);
 
-  // THEN: We didn't write and return all of the requested submodules
-  expect(JSON.stringify({ created }).length).toBeLessThan(260_000);
-  expect(writtenKeys.length).toBeLessThan(3000);
-  expect(created.length).toEqual(writtenKeys.length);
-});
+    // THEN: We didn't write and return all of the requested submodules
+    expect(JSON.stringify({ created }).length).toBeLessThan(260_000);
+    expect(writtenKeys.length).toBeLessThan(3000);
+    expect(created.length).toEqual(writtenKeys.length);
+  }
+);
 
 describe('markers for un-supported languages', () => {
   test('uploads ".not-supported" markers as relevant', async () => {

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -4813,7 +4813,7 @@ Resources:
                   - repositoryEndpoint
           Essential: true
           Image:
-            Fn::Sub: \${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:ff24b126b3cf533d75d8035269c978010feb75cd9c7cf18918fa7b0305e22e01
+            Fn::Sub: \${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:c71f9e46c2acd33c17b3692e915b481b9f4abe0fc39647f63e81cb6a20de73a4
           LogConfiguration:
             LogDriver: awslogs
             Options:

--- a/src/backend/transliterator/transliterator.ecstask.ts
+++ b/src/backend/transliterator/transliterator.ecstask.ts
@@ -508,8 +508,8 @@ function restrictSubmoduleCountToReturnable(
 
     return (
       DocumentationLanguage.ALL
-        // For each requested language
-        .filter((l) => event?.languages?.[l.toString()])
+        // For each requested language (field missing = all languages)
+        .filter((l) => !event?.languages || event.languages[l.toString()])
         // A .json and .md file plus their quotes and a comma
         .map(
           (l) =>


### PR DESCRIPTION
In the previous fix PR, I missed that `languages` can be absent which is implied to mean "all languages", which caused underestimation of response size.

Fix that.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*