### PR TITLE
chore: switch to Fargate vCPU usage metrics

### DIFF
--- a/src/backend-dashboard.ts
+++ b/src/backend-dashboard.ts
@@ -546,8 +546,8 @@ export class BackendDashboard extends Construct {
     ];
     const mFargateUsage = new Metric({
       dimensionsMap: {
-        Class: 'None',
-        Resource: 'OnDemand',
+        Class: 'Standard/OnDemand',
+        Resource: 'vCPU',
         Service: 'Fargate',
         Type: 'Resource',
       },
@@ -562,10 +562,10 @@ export class BackendDashboard extends Construct {
         width: 12,
         title: 'Fargate Resources',
         left: [
-          mFargateUsage.with({ label: 'Fargate Usage (On-Demand)' }),
+          mFargateUsage.with({ label: 'Fargate vCPU Usage (On-Demand)' }),
           new MathExpression({
             expression: 'SERVICE_QUOTA(mFargateUsage)',
-            label: 'Fargate Quota (On-Demand)',
+            label: 'Fargate vCPU Quota (On-Demand)',
             usingMetrics: { mFargateUsage },
           }),
         ],


### PR DESCRIPTION
The metrics for Fargate changed how vPCU consumption is accounted for, which also changed how the quotas apply. As a result, the old metric no longuer has an associated quota, which caused the dashboard to fail rendering. Switching to the directional metric about vCPUs to address this.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*