### PR TITLE
fix: ingestion function tries to execute more than once if the package name and version are duplicated

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -1923,7 +1923,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "e55b620ec4d010c6cfb2488a9face8b7ec926a240aed917134fce3dd9e03bbb0.zip",
+          "S3Key": "ff88fae9ffb002eab83af77146fc7320529b22f94a175d278b2fcc3d00417513.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": Object {
@@ -2147,7 +2147,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "46c439171ce3ebe85a8181e7c10f21acb1df86119cbeecf0017276cb6e472812.zip",
+          "S3Key": "ad12f50d226bb41a734f602d535a23af48b4736362a44825a9c3744cfe03a2cb.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": Object {
@@ -4695,7 +4695,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "7a08859eedeb45a22b1f97f1b033ef94333fbc040ed59090fe660b3f89e4a833.zip",
+          "S3Key": "d5c23568f85b07fccf830b0e6a3b185d7cf674c81fd1bc3638705841b49d3e19.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -6436,7 +6436,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:04d441df4f7ccbbea4d5c2644f6638c5854193dd9e65794d23d74e447d3116c3",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:18b238eb39c400246a458e44b987b73c9583bfbbc8dae67e9398d31aa46e63fd",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -10182,7 +10182,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d2299a82ca9c916cea04a392e1b7df93aaba66a270275e42dffae62bc29c1695.zip",
+          "S3Key": "6c61175e3c41586bd6dc789ace22789e73127b3cd8413cb8b6c1355bd0980634.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -10386,7 +10386,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "679b8c457886c27a1a820875be0a752a07e378007856a48e47fdd292c2fcd71e.zip",
+          "S3Key": "24eb68ede374b363ad08819ce748d41d13c752d38a85727b2e8d2a6a0234d985.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -14346,7 +14346,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "e55b620ec4d010c6cfb2488a9face8b7ec926a240aed917134fce3dd9e03bbb0.zip",
+          "S3Key": "ff88fae9ffb002eab83af77146fc7320529b22f94a175d278b2fcc3d00417513.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": Object {
@@ -14570,7 +14570,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "46c439171ce3ebe85a8181e7c10f21acb1df86119cbeecf0017276cb6e472812.zip",
+          "S3Key": "ad12f50d226bb41a734f602d535a23af48b4736362a44825a9c3744cfe03a2cb.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": Object {
@@ -17216,7 +17216,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "7a08859eedeb45a22b1f97f1b033ef94333fbc040ed59090fe660b3f89e4a833.zip",
+          "S3Key": "d5c23568f85b07fccf830b0e6a3b185d7cf674c81fd1bc3638705841b49d3e19.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -18984,7 +18984,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:04d441df4f7ccbbea4d5c2644f6638c5854193dd9e65794d23d74e447d3116c3",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:18b238eb39c400246a458e44b987b73c9583bfbbc8dae67e9398d31aa46e63fd",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -22776,7 +22776,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d2299a82ca9c916cea04a392e1b7df93aaba66a270275e42dffae62bc29c1695.zip",
+          "S3Key": "6c61175e3c41586bd6dc789ace22789e73127b3cd8413cb8b6c1355bd0980634.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -22980,7 +22980,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "679b8c457886c27a1a820875be0a752a07e378007856a48e47fdd292c2fcd71e.zip",
+          "S3Key": "24eb68ede374b363ad08819ce748d41d13c752d38a85727b2e8d2a6a0234d985.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -26683,7 +26683,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "e55b620ec4d010c6cfb2488a9face8b7ec926a240aed917134fce3dd9e03bbb0.zip",
+          "S3Key": "ff88fae9ffb002eab83af77146fc7320529b22f94a175d278b2fcc3d00417513.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": Object {
@@ -26907,7 +26907,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "46c439171ce3ebe85a8181e7c10f21acb1df86119cbeecf0017276cb6e472812.zip",
+          "S3Key": "ad12f50d226bb41a734f602d535a23af48b4736362a44825a9c3744cfe03a2cb.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": Object {
@@ -29455,7 +29455,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "7a08859eedeb45a22b1f97f1b033ef94333fbc040ed59090fe660b3f89e4a833.zip",
+          "S3Key": "d5c23568f85b07fccf830b0e6a3b185d7cf674c81fd1bc3638705841b49d3e19.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -31196,7 +31196,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:04d441df4f7ccbbea4d5c2644f6638c5854193dd9e65794d23d74e447d3116c3",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:18b238eb39c400246a458e44b987b73c9583bfbbc8dae67e9398d31aa46e63fd",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -34942,7 +34942,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d2299a82ca9c916cea04a392e1b7df93aaba66a270275e42dffae62bc29c1695.zip",
+          "S3Key": "6c61175e3c41586bd6dc789ace22789e73127b3cd8413cb8b6c1355bd0980634.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -35146,7 +35146,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "679b8c457886c27a1a820875be0a752a07e378007856a48e47fdd292c2fcd71e.zip",
+          "S3Key": "24eb68ede374b363ad08819ce748d41d13c752d38a85727b2e8d2a6a0234d985.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -38974,7 +38974,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "e55b620ec4d010c6cfb2488a9face8b7ec926a240aed917134fce3dd9e03bbb0.zip",
+          "S3Key": "ff88fae9ffb002eab83af77146fc7320529b22f94a175d278b2fcc3d00417513.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": Object {
@@ -39185,7 +39185,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "46c439171ce3ebe85a8181e7c10f21acb1df86119cbeecf0017276cb6e472812.zip",
+          "S3Key": "ad12f50d226bb41a734f602d535a23af48b4736362a44825a9c3744cfe03a2cb.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": Object {
@@ -41755,7 +41755,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "7a08859eedeb45a22b1f97f1b033ef94333fbc040ed59090fe660b3f89e4a833.zip",
+          "S3Key": "d5c23568f85b07fccf830b0e6a3b185d7cf674c81fd1bc3638705841b49d3e19.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -43496,7 +43496,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:04d441df4f7ccbbea4d5c2644f6638c5854193dd9e65794d23d74e447d3116c3",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:18b238eb39c400246a458e44b987b73c9583bfbbc8dae67e9398d31aa46e63fd",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -47229,7 +47229,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d2299a82ca9c916cea04a392e1b7df93aaba66a270275e42dffae62bc29c1695.zip",
+          "S3Key": "6c61175e3c41586bd6dc789ace22789e73127b3cd8413cb8b6c1355bd0980634.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -47433,7 +47433,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "679b8c457886c27a1a820875be0a752a07e378007856a48e47fdd292c2fcd71e.zip",
+          "S3Key": "24eb68ede374b363ad08819ce748d41d13c752d38a85727b2e8d2a6a0234d985.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -51460,7 +51460,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "e55b620ec4d010c6cfb2488a9face8b7ec926a240aed917134fce3dd9e03bbb0.zip",
+          "S3Key": "ff88fae9ffb002eab83af77146fc7320529b22f94a175d278b2fcc3d00417513.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": Object {
@@ -51684,7 +51684,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "46c439171ce3ebe85a8181e7c10f21acb1df86119cbeecf0017276cb6e472812.zip",
+          "S3Key": "ad12f50d226bb41a734f602d535a23af48b4736362a44825a9c3744cfe03a2cb.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": Object {
@@ -54387,7 +54387,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "7a08859eedeb45a22b1f97f1b033ef94333fbc040ed59090fe660b3f89e4a833.zip",
+          "S3Key": "d5c23568f85b07fccf830b0e6a3b185d7cf674c81fd1bc3638705841b49d3e19.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -55735,7 +55735,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:04d441df4f7ccbbea4d5c2644f6638c5854193dd9e65794d23d74e447d3116c3",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:18b238eb39c400246a458e44b987b73c9583bfbbc8dae67e9398d31aa46e63fd",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -59543,7 +59543,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d2299a82ca9c916cea04a392e1b7df93aaba66a270275e42dffae62bc29c1695.zip",
+          "S3Key": "6c61175e3c41586bd6dc789ace22789e73127b3cd8413cb8b6c1355bd0980634.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -62599,7 +62599,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "679b8c457886c27a1a820875be0a752a07e378007856a48e47fdd292c2fcd71e.zip",
+          "S3Key": "24eb68ede374b363ad08819ce748d41d13c752d38a85727b2e8d2a6a0234d985.zip",
         },
         "Description": Object {
           "Fn::Join": Array [

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -1923,7 +1923,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "ff88fae9ffb002eab83af77146fc7320529b22f94a175d278b2fcc3d00417513.zip",
+          "S3Key": "e55b620ec4d010c6cfb2488a9face8b7ec926a240aed917134fce3dd9e03bbb0.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": Object {
@@ -2147,7 +2147,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "ad12f50d226bb41a734f602d535a23af48b4736362a44825a9c3744cfe03a2cb.zip",
+          "S3Key": "c701557bf6055e88d59d5abc1d55a3103f695766baee84882642e35c2b558ec9.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": Object {
@@ -4695,7 +4695,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d5c23568f85b07fccf830b0e6a3b185d7cf674c81fd1bc3638705841b49d3e19.zip",
+          "S3Key": "7a08859eedeb45a22b1f97f1b033ef94333fbc040ed59090fe660b3f89e4a833.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -6436,7 +6436,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:18b238eb39c400246a458e44b987b73c9583bfbbc8dae67e9398d31aa46e63fd",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:04d441df4f7ccbbea4d5c2644f6638c5854193dd9e65794d23d74e447d3116c3",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -10182,7 +10182,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "6c61175e3c41586bd6dc789ace22789e73127b3cd8413cb8b6c1355bd0980634.zip",
+          "S3Key": "d2299a82ca9c916cea04a392e1b7df93aaba66a270275e42dffae62bc29c1695.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -10386,7 +10386,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "24eb68ede374b363ad08819ce748d41d13c752d38a85727b2e8d2a6a0234d985.zip",
+          "S3Key": "679b8c457886c27a1a820875be0a752a07e378007856a48e47fdd292c2fcd71e.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -14346,7 +14346,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "ff88fae9ffb002eab83af77146fc7320529b22f94a175d278b2fcc3d00417513.zip",
+          "S3Key": "e55b620ec4d010c6cfb2488a9face8b7ec926a240aed917134fce3dd9e03bbb0.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": Object {
@@ -14570,7 +14570,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "ad12f50d226bb41a734f602d535a23af48b4736362a44825a9c3744cfe03a2cb.zip",
+          "S3Key": "c701557bf6055e88d59d5abc1d55a3103f695766baee84882642e35c2b558ec9.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": Object {
@@ -17216,7 +17216,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d5c23568f85b07fccf830b0e6a3b185d7cf674c81fd1bc3638705841b49d3e19.zip",
+          "S3Key": "7a08859eedeb45a22b1f97f1b033ef94333fbc040ed59090fe660b3f89e4a833.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -18984,7 +18984,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:18b238eb39c400246a458e44b987b73c9583bfbbc8dae67e9398d31aa46e63fd",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:04d441df4f7ccbbea4d5c2644f6638c5854193dd9e65794d23d74e447d3116c3",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -22776,7 +22776,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "6c61175e3c41586bd6dc789ace22789e73127b3cd8413cb8b6c1355bd0980634.zip",
+          "S3Key": "d2299a82ca9c916cea04a392e1b7df93aaba66a270275e42dffae62bc29c1695.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -22980,7 +22980,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "24eb68ede374b363ad08819ce748d41d13c752d38a85727b2e8d2a6a0234d985.zip",
+          "S3Key": "679b8c457886c27a1a820875be0a752a07e378007856a48e47fdd292c2fcd71e.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -26683,7 +26683,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "ff88fae9ffb002eab83af77146fc7320529b22f94a175d278b2fcc3d00417513.zip",
+          "S3Key": "e55b620ec4d010c6cfb2488a9face8b7ec926a240aed917134fce3dd9e03bbb0.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": Object {
@@ -26907,7 +26907,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "ad12f50d226bb41a734f602d535a23af48b4736362a44825a9c3744cfe03a2cb.zip",
+          "S3Key": "c701557bf6055e88d59d5abc1d55a3103f695766baee84882642e35c2b558ec9.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": Object {
@@ -29455,7 +29455,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d5c23568f85b07fccf830b0e6a3b185d7cf674c81fd1bc3638705841b49d3e19.zip",
+          "S3Key": "7a08859eedeb45a22b1f97f1b033ef94333fbc040ed59090fe660b3f89e4a833.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -31196,7 +31196,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:18b238eb39c400246a458e44b987b73c9583bfbbc8dae67e9398d31aa46e63fd",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:04d441df4f7ccbbea4d5c2644f6638c5854193dd9e65794d23d74e447d3116c3",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -34942,7 +34942,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "6c61175e3c41586bd6dc789ace22789e73127b3cd8413cb8b6c1355bd0980634.zip",
+          "S3Key": "d2299a82ca9c916cea04a392e1b7df93aaba66a270275e42dffae62bc29c1695.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -35146,7 +35146,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "24eb68ede374b363ad08819ce748d41d13c752d38a85727b2e8d2a6a0234d985.zip",
+          "S3Key": "679b8c457886c27a1a820875be0a752a07e378007856a48e47fdd292c2fcd71e.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -38974,7 +38974,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "ff88fae9ffb002eab83af77146fc7320529b22f94a175d278b2fcc3d00417513.zip",
+          "S3Key": "e55b620ec4d010c6cfb2488a9face8b7ec926a240aed917134fce3dd9e03bbb0.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": Object {
@@ -39185,7 +39185,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "ad12f50d226bb41a734f602d535a23af48b4736362a44825a9c3744cfe03a2cb.zip",
+          "S3Key": "c701557bf6055e88d59d5abc1d55a3103f695766baee84882642e35c2b558ec9.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": Object {
@@ -41755,7 +41755,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d5c23568f85b07fccf830b0e6a3b185d7cf674c81fd1bc3638705841b49d3e19.zip",
+          "S3Key": "7a08859eedeb45a22b1f97f1b033ef94333fbc040ed59090fe660b3f89e4a833.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -43496,7 +43496,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:18b238eb39c400246a458e44b987b73c9583bfbbc8dae67e9398d31aa46e63fd",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:04d441df4f7ccbbea4d5c2644f6638c5854193dd9e65794d23d74e447d3116c3",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -47229,7 +47229,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "6c61175e3c41586bd6dc789ace22789e73127b3cd8413cb8b6c1355bd0980634.zip",
+          "S3Key": "d2299a82ca9c916cea04a392e1b7df93aaba66a270275e42dffae62bc29c1695.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -47433,7 +47433,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "24eb68ede374b363ad08819ce748d41d13c752d38a85727b2e8d2a6a0234d985.zip",
+          "S3Key": "679b8c457886c27a1a820875be0a752a07e378007856a48e47fdd292c2fcd71e.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -51460,7 +51460,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "ff88fae9ffb002eab83af77146fc7320529b22f94a175d278b2fcc3d00417513.zip",
+          "S3Key": "e55b620ec4d010c6cfb2488a9face8b7ec926a240aed917134fce3dd9e03bbb0.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": Object {
@@ -51684,7 +51684,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "ad12f50d226bb41a734f602d535a23af48b4736362a44825a9c3744cfe03a2cb.zip",
+          "S3Key": "c701557bf6055e88d59d5abc1d55a3103f695766baee84882642e35c2b558ec9.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": Object {
@@ -54387,7 +54387,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d5c23568f85b07fccf830b0e6a3b185d7cf674c81fd1bc3638705841b49d3e19.zip",
+          "S3Key": "7a08859eedeb45a22b1f97f1b033ef94333fbc040ed59090fe660b3f89e4a833.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -55735,7 +55735,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:18b238eb39c400246a458e44b987b73c9583bfbbc8dae67e9398d31aa46e63fd",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:04d441df4f7ccbbea4d5c2644f6638c5854193dd9e65794d23d74e447d3116c3",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -59543,7 +59543,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "6c61175e3c41586bd6dc789ace22789e73127b3cd8413cb8b6c1355bd0980634.zip",
+          "S3Key": "d2299a82ca9c916cea04a392e1b7df93aaba66a270275e42dffae62bc29c1695.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -62599,7 +62599,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "24eb68ede374b363ad08819ce748d41d13c752d38a85727b2e8d2a6a0234d985.zip",
+          "S3Key": "679b8c457886c27a1a820875be0a752a07e378007856a48e47fdd292c2fcd71e.zip",
         },
         "Description": Object {
           "Fn::Join": Array [

--- a/src/__tests__/backend/ingestion/ingestion.lambda.test.ts
+++ b/src/__tests__/backend/ingestion/ingestion.lambda.test.ts
@@ -283,6 +283,246 @@ test('basic happy case', async () => {
   );
 });
 
+test('basic happy case with duplicated packages', async () => {
+  const mockBucketName = 'fake-bucket';
+  const mockStateMachineArn = 'fake-state-machine-arn';
+  const mockConfigBucket = 'fake-config-bucket';
+  const mockConfigkey = 'fake-config-obj-key';
+
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const mockRequireEnv = require('../../../backend/shared/env.lambda-shared')
+    .requireEnv as jest.MockedFunction<typeof requireEnv>;
+  mockRequireEnv.mockImplementation((name) => {
+    if (name === 'BUCKET_NAME') {
+      return mockBucketName;
+    }
+    if (name === 'STATE_MACHINE_ARN') {
+      return mockStateMachineArn;
+    }
+    if (name === 'CONFIG_BUCKET_NAME') {
+      return mockConfigBucket;
+    }
+    if (name === 'CONFIG_FILE_KEY') {
+      return mockConfigkey;
+    }
+    throw new Error(`Bad environment variable: "${name}"`);
+  });
+
+  const stagingBucket = 'staging-bucket';
+  const stagingKey = 'staging-key';
+  const stagingVersion = 'staging-version-id';
+  const fakeTarGz = Buffer.from('fake-tarball-content[gzipped]');
+  const fakeTar = Buffer.from('fake-tarball-content');
+  const tarballUri = `s3://${stagingBucket}.test-bermuda-2.s3.amazonaws.com/${stagingKey}?versionId=${stagingVersion}`;
+  const time = '2021-07-12T15:18:00.000000+02:00';
+  const integrity = 'sha256-1RyNs3cDpyTqBMqJIiHbCpl8PEN6h3uWx3lzF+3qcmY=';
+  const packageName = '@package-scope/package-name';
+  const packageVersion = '1.2.3-pre.4';
+  const packageLicense = 'Apache-2.0';
+  const fakeDotJsii = JSON.stringify(
+    fakeAssembly(packageName, packageVersion, packageLicense)
+  );
+  const mockConfig = Buffer.from(
+    JSON.stringify({
+      packageLinks: [],
+      packageTags: [],
+    })
+  );
+
+  const context: Context = {
+    awsRequestId: 'Fake-Request-ID',
+    logGroupName: 'Fake-Log-Group',
+    logStreamName: 'Fake-Log-Stream',
+  } as any;
+
+  AWSMock.mock(
+    'S3',
+    'getObject',
+    (req: AWS.S3.GetObjectRequest, cb: Response<AWS.S3.GetObjectOutput>) => {
+      if (req.Bucket === mockConfigBucket) {
+        try {
+          expect(req.Bucket).toBe(mockConfigBucket);
+          expect(req.Key).toBe(mockConfigkey);
+        } catch (e) {
+          return cb(e);
+        }
+        return cb(null, { Body: mockConfig });
+      }
+
+      try {
+        expect(req.Bucket).toBe(stagingBucket);
+        expect(req.Key).toBe(stagingKey);
+        expect(req.VersionId).toBe(stagingVersion);
+      } catch (e) {
+        return cb(e);
+      }
+      return cb(null, { Body: fakeTarGz });
+    }
+  );
+
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const mockCreateGunzip = require('zlib').createGunzip as jest.MockedFunction<
+    typeof createGunzip
+  >;
+  mockCreateGunzip.mockImplementation(
+    () => new FakeGunzip(fakeTarGz, fakeTar) as any
+  );
+
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const mockExtract = require('tar-stream').extract as jest.MockedFunction<
+    typeof extract
+  >;
+  mockExtract.mockImplementation(
+    () =>
+      new FakeExtract(fakeTar, {
+        [`package/${SPEC_FILE_NAME}`]: fakeDotJsii,
+        'package/index.js': '// Ignore me!',
+        'package/package.json': JSON.stringify({
+          name: packageName,
+          version: packageVersion,
+          license: packageLicense,
+        }),
+      }) as any
+  );
+
+  let mockTarballCreated = false;
+  let mockMetadataCreated = false;
+  const { assemblyKey, metadataKey, packageKey } = constants.getObjectKeys(
+    packageName,
+    packageVersion
+  );
+  AWSMock.mock(
+    'S3',
+    'putObject',
+    (req: AWS.S3.PutObjectRequest, cb: Response<AWS.S3.PutObjectOutput>) => {
+      try {
+        expect(req.Bucket).toBe(mockBucketName);
+        expect(req.Metadata?.['Lambda-Log-Group']).toBe(context.logGroupName);
+        expect(req.Metadata?.['Lambda-Log-Stream']).toBe(context.logStreamName);
+        expect(req.Metadata?.['Lambda-Run-Id']).toBe(context.awsRequestId);
+        switch (req.Key) {
+          case assemblyKey:
+            expect(req.ContentType).toBe('application/json');
+
+            // our service removes the "types" field from the assembly since it is not needed
+            // and takes up a lot of space.
+            assertAssembly(fakeDotJsii, req.Body?.toString());
+
+            // Must be created strictly after the tarball and metadata files have been uploaded.
+            expect(mockTarballCreated && mockMetadataCreated).toBeTruthy();
+            break;
+          case metadataKey:
+            expect(req.ContentType).toBe('application/json');
+            expect(Buffer.from(req.Body! as any)).toEqual(
+              Buffer.from(
+                JSON.stringify({
+                  constructFrameworks: [],
+                  date: time,
+                  packageLinks: {},
+                  packageTags: [],
+                })
+              )
+            );
+            mockMetadataCreated = true;
+            break;
+          case packageKey:
+            expect(req.ContentType).toBe('application/octet-stream');
+            expect(req.Body).toEqual(fakeTarGz);
+            mockTarballCreated = true;
+            break;
+          default:
+            fail(`Unexpected key: "${req.Key}"`);
+        }
+      } catch (e) {
+        return cb(e);
+      }
+      return cb(null, { VersionId: `${req.Key}-NewVersion` });
+    }
+  );
+
+  let executionsStarted = 0;
+  const executionArn = 'Fake-Execution-Arn';
+  AWSMock.mock(
+    'StepFunctions',
+    'startExecution',
+    (
+      req: AWS.StepFunctions.StartExecutionInput,
+      cb: Response<AWS.StepFunctions.StartExecutionOutput>
+    ) => {
+      executionsStarted++;
+      expect(executionsStarted).toEqual(1);
+      try {
+        expect(req.stateMachineArn).toBe(mockStateMachineArn);
+        expect(JSON.parse(req.input!)).toEqual({
+          bucket: mockBucketName,
+          assembly: {
+            key: assemblyKey,
+            versionId: `${assemblyKey}-NewVersion`,
+          },
+          metadata: {
+            key: metadataKey,
+            versionId: `${metadataKey}-NewVersion`,
+          },
+          package: { key: packageKey, versionId: `${packageKey}-NewVersion` },
+        });
+      } catch (e) {
+        return cb(e);
+      }
+      return cb(null, { executionArn, startDate: new Date() });
+    }
+  );
+
+  const event: SQSEvent = {
+    Records: [
+      {
+        attributes: {} as any,
+        awsRegion: 'test-bermuda-1',
+        body: JSON.stringify({ tarballUri, integrity, time }),
+        eventSource: 'sqs',
+        eventSourceARN: 'arn:aws:sqs:test-bermuda-1:123456789012:fake',
+        md5OfBody: 'Fake-MD5-Of-Body',
+        messageAttributes: {},
+        messageId: 'Fake-Message-ID1',
+        receiptHandle: 'Fake-Receipt-Handke1',
+      },
+      {
+        attributes: {} as any,
+        awsRegion: 'test-bermuda-1',
+        body: JSON.stringify({ tarballUri, integrity, time }),
+        eventSource: 'sqs',
+        eventSourceARN: 'arn:aws:sqs:test-bermuda-1:123456789012:fake',
+        md5OfBody: 'Fake-MD5-Of-Body',
+        messageAttributes: {},
+        messageId: 'Fake-Message-ID2',
+        receiptHandle: 'Fake-Receipt-Handke2',
+      },
+    ],
+  };
+
+  // We require the handler here so that any mocks to metricScope are set up
+  // prior to the handler being created.
+  //
+
+  await expect(
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require('../../../backend/ingestion/ingestion.lambda').handler(
+      event,
+      context
+    )
+  ).resolves.toEqual([executionArn]);
+
+  expect(mockPutMetric).toHaveBeenCalledWith(
+    MetricName.MISMATCHED_IDENTITY_REJECTIONS,
+    0,
+    'Count'
+  );
+  expect(mockPutMetric).toHaveBeenCalledWith(
+    MetricName.FOUND_LICENSE_FILE,
+    0,
+    'Count'
+  );
+});
+
 test('basic happy case with compressed assembly', async () => {
   const mockBucketName = 'fake-bucket';
   const mockStateMachineArn = 'fake-state-machine-arn';

--- a/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
+++ b/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
@@ -118,7 +118,7 @@ Object {
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:04d441df4f7ccbbea4d5c2644f6638c5854193dd9e65794d23d74e447d3116c3",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:18b238eb39c400246a458e44b987b73c9583bfbbc8dae67e9398d31aa46e63fd",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -2429,7 +2429,7 @@ Object {
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:04d441df4f7ccbbea4d5c2644f6638c5854193dd9e65794d23d74e447d3116c3",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:18b238eb39c400246a458e44b987b73c9583bfbbc8dae67e9398d31aa46e63fd",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -4791,7 +4791,7 @@ Object {
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:04d441df4f7ccbbea4d5c2644f6638c5854193dd9e65794d23d74e447d3116c3",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:18b238eb39c400246a458e44b987b73c9583bfbbc8dae67e9398d31aa46e63fd",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -7098,7 +7098,7 @@ Object {
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:04d441df4f7ccbbea4d5c2644f6638c5854193dd9e65794d23d74e447d3116c3",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:18b238eb39c400246a458e44b987b73c9583bfbbc8dae67e9398d31aa46e63fd",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",

--- a/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
+++ b/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
@@ -118,7 +118,7 @@ Object {
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:18b238eb39c400246a458e44b987b73c9583bfbbc8dae67e9398d31aa46e63fd",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:04d441df4f7ccbbea4d5c2644f6638c5854193dd9e65794d23d74e447d3116c3",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -2429,7 +2429,7 @@ Object {
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:18b238eb39c400246a458e44b987b73c9583bfbbc8dae67e9398d31aa46e63fd",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:04d441df4f7ccbbea4d5c2644f6638c5854193dd9e65794d23d74e447d3116c3",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -4791,7 +4791,7 @@ Object {
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:18b238eb39c400246a458e44b987b73c9583bfbbc8dae67e9398d31aa46e63fd",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:04d441df4f7ccbbea4d5c2644f6638c5854193dd9e65794d23d74e447d3116c3",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",
@@ -7098,7 +7098,7 @@ Object {
             ],
             "Essential": true,
             "Image": Object {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:18b238eb39c400246a458e44b987b73c9583bfbbc8dae67e9398d31aa46e63fd",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:04d441df4f7ccbbea4d5c2644f6638c5854193dd9e65794d23d74e447d3116c3",
             },
             "LogConfiguration": Object {
               "LogDriver": "awslogs",

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -2921,7 +2921,7 @@ Resources:
       Code:
         S3Bucket:
           Fn::Sub: cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}
-        S3Key: 6c61175e3c41586bd6dc789ace22789e73127b3cd8413cb8b6c1355bd0980634.zip
+        S3Key: d2299a82ca9c916cea04a392e1b7df93aaba66a270275e42dffae62bc29c1695.zip
       Role:
         Fn::GetAtt:
           - ConstructHubStatsServiceRole48DCA379
@@ -3072,7 +3072,7 @@ Resources:
       Code:
         S3Bucket:
           Fn::Sub: cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}
-        S3Key: 24eb68ede374b363ad08819ce748d41d13c752d38a85727b2e8d2a6a0234d985.zip
+        S3Key: 679b8c457886c27a1a820875be0a752a07e378007856a48e47fdd292c2fcd71e.zip
       Role:
         Fn::GetAtt:
           - ConstructHubVersionTrackerServiceRole721EE863
@@ -3297,7 +3297,7 @@ Resources:
       Code:
         S3Bucket:
           Fn::Sub: cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}
-        S3Key: ff88fae9ffb002eab83af77146fc7320529b22f94a175d278b2fcc3d00417513.zip
+        S3Key: e55b620ec4d010c6cfb2488a9face8b7ec926a240aed917134fce3dd9e03bbb0.zip
       Role:
         Fn::GetAtt:
           - ConstructHubFeedBuilderReleaseNotesUpdateFeedServiceRoleC857E364
@@ -3484,7 +3484,7 @@ Resources:
       Code:
         S3Bucket:
           Fn::Sub: cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}
-        S3Key: d5c23568f85b07fccf830b0e6a3b185d7cf674c81fd1bc3638705841b49d3e19.zip
+        S3Key: 7a08859eedeb45a22b1f97f1b033ef94333fbc040ed59090fe660b3f89e4a833.zip
       Role:
         Fn::GetAtt:
           - ConstructHubOrchestrationCatalogBuilderServiceRole851C750C
@@ -4813,7 +4813,7 @@ Resources:
                   - repositoryEndpoint
           Essential: true
           Image:
-            Fn::Sub: \${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:18b238eb39c400246a458e44b987b73c9583bfbbc8dae67e9398d31aa46e63fd
+            Fn::Sub: \${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:04d441df4f7ccbbea4d5c2644f6638c5854193dd9e65794d23d74e447d3116c3
           LogConfiguration:
             LogDriver: awslogs
             Options:
@@ -6393,7 +6393,7 @@ Resources:
       Code:
         S3Bucket:
           Fn::Sub: cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}
-        S3Key: ad12f50d226bb41a734f602d535a23af48b4736362a44825a9c3744cfe03a2cb.zip
+        S3Key: c701557bf6055e88d59d5abc1d55a3103f695766baee84882642e35c2b558ec9.zip
       Role:
         Fn::GetAtt:
           - ConstructHubIngestionServiceRole6380BAB6

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -2921,7 +2921,7 @@ Resources:
       Code:
         S3Bucket:
           Fn::Sub: cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}
-        S3Key: d2299a82ca9c916cea04a392e1b7df93aaba66a270275e42dffae62bc29c1695.zip
+        S3Key: 6c61175e3c41586bd6dc789ace22789e73127b3cd8413cb8b6c1355bd0980634.zip
       Role:
         Fn::GetAtt:
           - ConstructHubStatsServiceRole48DCA379
@@ -3072,7 +3072,7 @@ Resources:
       Code:
         S3Bucket:
           Fn::Sub: cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}
-        S3Key: 679b8c457886c27a1a820875be0a752a07e378007856a48e47fdd292c2fcd71e.zip
+        S3Key: 24eb68ede374b363ad08819ce748d41d13c752d38a85727b2e8d2a6a0234d985.zip
       Role:
         Fn::GetAtt:
           - ConstructHubVersionTrackerServiceRole721EE863
@@ -3297,7 +3297,7 @@ Resources:
       Code:
         S3Bucket:
           Fn::Sub: cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}
-        S3Key: e55b620ec4d010c6cfb2488a9face8b7ec926a240aed917134fce3dd9e03bbb0.zip
+        S3Key: ff88fae9ffb002eab83af77146fc7320529b22f94a175d278b2fcc3d00417513.zip
       Role:
         Fn::GetAtt:
           - ConstructHubFeedBuilderReleaseNotesUpdateFeedServiceRoleC857E364
@@ -3484,7 +3484,7 @@ Resources:
       Code:
         S3Bucket:
           Fn::Sub: cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}
-        S3Key: 7a08859eedeb45a22b1f97f1b033ef94333fbc040ed59090fe660b3f89e4a833.zip
+        S3Key: d5c23568f85b07fccf830b0e6a3b185d7cf674c81fd1bc3638705841b49d3e19.zip
       Role:
         Fn::GetAtt:
           - ConstructHubOrchestrationCatalogBuilderServiceRole851C750C
@@ -4813,7 +4813,7 @@ Resources:
                   - repositoryEndpoint
           Essential: true
           Image:
-            Fn::Sub: \${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:04d441df4f7ccbbea4d5c2644f6638c5854193dd9e65794d23d74e447d3116c3
+            Fn::Sub: \${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:18b238eb39c400246a458e44b987b73c9583bfbbc8dae67e9398d31aa46e63fd
           LogConfiguration:
             LogDriver: awslogs
             Options:
@@ -6393,7 +6393,7 @@ Resources:
       Code:
         S3Bucket:
           Fn::Sub: cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}
-        S3Key: 46c439171ce3ebe85a8181e7c10f21acb1df86119cbeecf0017276cb6e472812.zip
+        S3Key: ad12f50d226bb41a734f602d535a23af48b4736362a44825a9c3744cfe03a2cb.zip
       Role:
         Fn::GetAtt:
           - ConstructHubIngestionServiceRole6380BAB6

--- a/src/backend/ingestion/ingestion.lambda.ts
+++ b/src/backend/ingestion/ingestion.lambda.ts
@@ -64,6 +64,8 @@ export const handler = metricScope(
 
     const result = new Array<string>();
 
+    const packagesSeen = new Set<string>();
+
     for (const record of event.Records ?? []) {
       const payload = JSON.parse(record.body) as IngestionInput;
 
@@ -144,6 +146,13 @@ export const handler = metricScope(
         packageName = name;
         packageVersion = version;
         packageReadme = readme?.markdown ?? '';
+
+        const packageId = `${packageName}@${packageVersion}`;
+        if (packagesSeen.has(packageId)) {
+          console.log(`Skipping duplicate package: ${packageId}`);
+          continue;
+        }
+        packagesSeen.add(packageId);
 
         // Delete some fields not used by the client to reduce the size of the assembly.
         // See https://github.com/cdklabs/construct-hub-webapp/issues/691


### PR DESCRIPTION
If the ingestion function receives two records for the same package, it will try to start the execution of the step function twice with the same name but different inputs, because the version ID returned by S3 is part of the input. In this case, the SDK will throw an [`ExecutionAlreadyExists`][1] error.

Prevent this by accumulating the packages that were seen in a set. Only unseen packages are processed.

[1]: https://docs.aws.amazon.com/step-functions/latest/apireference/API_StartExecution.html

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*