### PR TITLE
fix: incorrect ecs:ListTasks permission

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -5234,8 +5234,22 @@ RUNBOOK: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "PolicyDocument": Object {
           "Statement": Array [
             Object {
+              "Action": "ecs:ListTasks",
+              "Condition": Object {
+                "ArnEquals": Object {
+                  "ecs:cluster": Object {
+                    "Fn::GetAtt": Array [
+                      "ConstructHubOrchestrationCluster3D6F0081",
+                      "Arn",
+                    ],
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            Object {
               "Action": Array [
-                "ecs:ListTasks",
                 "ecs:DescribeTasks",
                 "ecs:StopTask",
               ],
@@ -5250,56 +5264,30 @@ RUNBOOK: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
                 },
               },
               "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":ecs:",
-                      Object {
-                        "Ref": "AWS::Region",
-                      },
-                      ":",
-                      Object {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":container-instance/",
-                      Object {
-                        "Ref": "ConstructHubOrchestrationCluster3D6F0081",
-                      },
-                      "/*",
-                    ],
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":ecs:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":task/",
+                    Object {
+                      "Ref": "ConstructHubOrchestrationCluster3D6F0081",
+                    },
+                    "/*",
                   ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":ecs:",
-                      Object {
-                        "Ref": "AWS::Region",
-                      },
-                      ":",
-                      Object {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":task/",
-                      Object {
-                        "Ref": "ConstructHubOrchestrationCluster3D6F0081",
-                      },
-                      "/*",
-                    ],
-                  ],
-                },
-              ],
+                ],
+              },
             },
           ],
           "Version": "2012-10-17",
@@ -18109,8 +18097,22 @@ RUNBOOK: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "PolicyDocument": Object {
           "Statement": Array [
             Object {
+              "Action": "ecs:ListTasks",
+              "Condition": Object {
+                "ArnEquals": Object {
+                  "ecs:cluster": Object {
+                    "Fn::GetAtt": Array [
+                      "ConstructHubOrchestrationCluster3D6F0081",
+                      "Arn",
+                    ],
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            Object {
               "Action": Array [
-                "ecs:ListTasks",
                 "ecs:DescribeTasks",
                 "ecs:StopTask",
               ],
@@ -18125,56 +18127,30 @@ RUNBOOK: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
                 },
               },
               "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":ecs:",
-                      Object {
-                        "Ref": "AWS::Region",
-                      },
-                      ":",
-                      Object {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":container-instance/",
-                      Object {
-                        "Ref": "ConstructHubOrchestrationCluster3D6F0081",
-                      },
-                      "/*",
-                    ],
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":ecs:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":task/",
+                    Object {
+                      "Ref": "ConstructHubOrchestrationCluster3D6F0081",
+                    },
+                    "/*",
                   ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":ecs:",
-                      Object {
-                        "Ref": "AWS::Region",
-                      },
-                      ":",
-                      Object {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":task/",
-                      Object {
-                        "Ref": "ConstructHubOrchestrationCluster3D6F0081",
-                      },
-                      "/*",
-                    ],
-                  ],
-                },
-              ],
+                ],
+              },
             },
           ],
           "Version": "2012-10-17",
@@ -30694,8 +30670,22 @@ RUNBOOK: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "PolicyDocument": Object {
           "Statement": Array [
             Object {
+              "Action": "ecs:ListTasks",
+              "Condition": Object {
+                "ArnEquals": Object {
+                  "ecs:cluster": Object {
+                    "Fn::GetAtt": Array [
+                      "ConstructHubOrchestrationCluster3D6F0081",
+                      "Arn",
+                    ],
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            Object {
               "Action": Array [
-                "ecs:ListTasks",
                 "ecs:DescribeTasks",
                 "ecs:StopTask",
               ],
@@ -30710,56 +30700,30 @@ RUNBOOK: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
                 },
               },
               "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":ecs:",
-                      Object {
-                        "Ref": "AWS::Region",
-                      },
-                      ":",
-                      Object {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":container-instance/",
-                      Object {
-                        "Ref": "ConstructHubOrchestrationCluster3D6F0081",
-                      },
-                      "/*",
-                    ],
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":ecs:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":task/",
+                    Object {
+                      "Ref": "ConstructHubOrchestrationCluster3D6F0081",
+                    },
+                    "/*",
                   ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":ecs:",
-                      Object {
-                        "Ref": "AWS::Region",
-                      },
-                      ":",
-                      Object {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":task/",
-                      Object {
-                        "Ref": "ConstructHubOrchestrationCluster3D6F0081",
-                      },
-                      "/*",
-                    ],
-                  ],
-                },
-              ],
+                ],
+              },
             },
           ],
           "Version": "2012-10-17",
@@ -43363,8 +43327,22 @@ RUNBOOK: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "PolicyDocument": Object {
           "Statement": Array [
             Object {
+              "Action": "ecs:ListTasks",
+              "Condition": Object {
+                "ArnEquals": Object {
+                  "ecs:cluster": Object {
+                    "Fn::GetAtt": Array [
+                      "ConstructHubOrchestrationCluster3D6F0081",
+                      "Arn",
+                    ],
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            Object {
               "Action": Array [
-                "ecs:ListTasks",
                 "ecs:DescribeTasks",
                 "ecs:StopTask",
               ],
@@ -43379,56 +43357,30 @@ RUNBOOK: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
                 },
               },
               "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":ecs:",
-                      Object {
-                        "Ref": "AWS::Region",
-                      },
-                      ":",
-                      Object {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":container-instance/",
-                      Object {
-                        "Ref": "ConstructHubOrchestrationCluster3D6F0081",
-                      },
-                      "/*",
-                    ],
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":ecs:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":task/",
+                    Object {
+                      "Ref": "ConstructHubOrchestrationCluster3D6F0081",
+                    },
+                    "/*",
                   ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":ecs:",
-                      Object {
-                        "Ref": "AWS::Region",
-                      },
-                      ":",
-                      Object {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":task/",
-                      Object {
-                        "Ref": "ConstructHubOrchestrationCluster3D6F0081",
-                      },
-                      "/*",
-                    ],
-                  ],
-                },
-              ],
+                ],
+              },
             },
           ],
           "Version": "2012-10-17",
@@ -56349,8 +56301,22 @@ RUNBOOK: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "PolicyDocument": Object {
           "Statement": Array [
             Object {
+              "Action": "ecs:ListTasks",
+              "Condition": Object {
+                "ArnEquals": Object {
+                  "ecs:cluster": Object {
+                    "Fn::GetAtt": Array [
+                      "ConstructHubOrchestrationCluster3D6F0081",
+                      "Arn",
+                    ],
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            Object {
               "Action": Array [
-                "ecs:ListTasks",
                 "ecs:DescribeTasks",
                 "ecs:StopTask",
               ],
@@ -56365,56 +56331,30 @@ RUNBOOK: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
                 },
               },
               "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":ecs:",
-                      Object {
-                        "Ref": "AWS::Region",
-                      },
-                      ":",
-                      Object {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":container-instance/",
-                      Object {
-                        "Ref": "ConstructHubOrchestrationCluster3D6F0081",
-                      },
-                      "/*",
-                    ],
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":ecs:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":task/",
+                    Object {
+                      "Ref": "ConstructHubOrchestrationCluster3D6F0081",
+                    },
+                    "/*",
                   ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":ecs:",
-                      Object {
-                        "Ref": "AWS::Region",
-                      },
-                      ":",
-                      Object {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":task/",
-                      Object {
-                        "Ref": "ConstructHubOrchestrationCluster3D6F0081",
-                      },
-                      "/*",
-                    ],
-                  ],
-                },
-              ],
+                ],
+              },
             },
           ],
           "Version": "2012-10-17",

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -3659,8 +3659,16 @@ Resources:
     Properties:
       PolicyDocument:
         Statement:
+          - Action: ecs:ListTasks
+            Condition:
+              ArnEquals:
+                ecs:cluster:
+                  Fn::GetAtt:
+                    - ConstructHubOrchestrationCluster3D6F0081
+                    - Arn
+            Effect: Allow
+            Resource: "*"
           - Action:
-              - ecs:ListTasks
               - ecs:DescribeTasks
               - ecs:StopTask
             Condition:
@@ -3671,28 +3679,17 @@ Resources:
                     - Arn
             Effect: Allow
             Resource:
-              - Fn::Join:
-                  - ""
-                  - - "arn:"
-                    - Ref: AWS::Partition
-                    - ":ecs:"
-                    - Ref: AWS::Region
-                    - ":"
-                    - Ref: AWS::AccountId
-                    - :container-instance/
-                    - Ref: ConstructHubOrchestrationCluster3D6F0081
-                    - /*
-              - Fn::Join:
-                  - ""
-                  - - "arn:"
-                    - Ref: AWS::Partition
-                    - ":ecs:"
-                    - Ref: AWS::Region
-                    - ":"
-                    - Ref: AWS::AccountId
-                    - :task/
-                    - Ref: ConstructHubOrchestrationCluster3D6F0081
-                    - /*
+              Fn::Join:
+                - ""
+                - - "arn:"
+                  - Ref: AWS::Partition
+                  - ":ecs:"
+                  - Ref: AWS::Region
+                  - ":"
+                  - Ref: AWS::AccountId
+                  - :task/
+                  - Ref: ConstructHubOrchestrationCluster3D6F0081
+                  - /*
         Version: 2012-10-17
       PolicyName: ConstructHubOrchestrationClusterMonitorServiceRoleDefaultPolicy258B6050
       Roles:


### PR DESCRIPTION
The ECS task monitor lambda fails on the following error:

```
AccessDeniedException: User: arn:aws:sts::573688003310:assumed-role/<...> is not authorized to perform: ecs:ListTasks on resource: * because no identity-based policy allows the ecs:ListTasks action
```

This is because the `ecs:ListTasks` action may only be scoped by `container-instance`, and we're listing across all container instances in the main cluster, so the `Resource` being authorized for is `*`, and the `ecs:cluster` condition provides the necessary scoping down.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*