### PR TITLE
fix: transliterator task isn't using all available memory

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -556,7 +556,7 @@ function newEcsTask(entrypoint: string) {
   const memoryLimit = ECS_TASK_MEMORY_LIMIT_DEFINITIONS[entrypoint];
   if (!memoryLimit) {
     throw new Error(
-      `Unable to find heap size definition for entrypoint: ${entrypoint}`
+      `Unable to find memory limit definition for entrypoint: ${entrypoint}`
     );
   }
 

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -6786,7 +6786,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:cba55679a00b58f17f87500d59d395e9e6e2815477b442712ec7438afb7712f7",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:01b1052f0b4e3dc25aa89a8141b9fc234e58da807c0b2652fb17cddb3c44e627",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -19734,7 +19734,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:cba55679a00b58f17f87500d59d395e9e6e2815477b442712ec7438afb7712f7",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:01b1052f0b4e3dc25aa89a8141b9fc234e58da807c0b2652fb17cddb3c44e627",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -32338,7 +32338,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:cba55679a00b58f17f87500d59d395e9e6e2815477b442712ec7438afb7712f7",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:01b1052f0b4e3dc25aa89a8141b9fc234e58da807c0b2652fb17cddb3c44e627",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -45053,7 +45053,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:cba55679a00b58f17f87500d59d395e9e6e2815477b442712ec7438afb7712f7",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:01b1052f0b4e3dc25aa89a8141b9fc234e58da807c0b2652fb17cddb3c44e627",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -57687,7 +57687,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:cba55679a00b58f17f87500d59d395e9e6e2815477b442712ec7438afb7712f7",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:01b1052f0b4e3dc25aa89a8141b9fc234e58da807c0b2652fb17cddb3c44e627",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -6786,7 +6786,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:9b8e4131ca5189fc3403e30767744db16370f1c8208b8715fe70baf74bb1859d",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:cba55679a00b58f17f87500d59d395e9e6e2815477b442712ec7438afb7712f7",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -19734,7 +19734,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:9b8e4131ca5189fc3403e30767744db16370f1c8208b8715fe70baf74bb1859d",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:cba55679a00b58f17f87500d59d395e9e6e2815477b442712ec7438afb7712f7",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -32338,7 +32338,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:9b8e4131ca5189fc3403e30767744db16370f1c8208b8715fe70baf74bb1859d",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:cba55679a00b58f17f87500d59d395e9e6e2815477b442712ec7438afb7712f7",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -45053,7 +45053,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:9b8e4131ca5189fc3403e30767744db16370f1c8208b8715fe70baf74bb1859d",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:cba55679a00b58f17f87500d59d395e9e6e2815477b442712ec7438afb7712f7",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -57687,7 +57687,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:9b8e4131ca5189fc3403e30767744db16370f1c8208b8715fe70baf74bb1859d",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:cba55679a00b58f17f87500d59d395e9e6e2815477b442712ec7438afb7712f7",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",

--- a/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
+++ b/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
@@ -229,7 +229,7 @@ exports[`CodeArtifact repository 1`] = `
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:cba55679a00b58f17f87500d59d395e9e6e2815477b442712ec7438afb7712f7",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:01b1052f0b4e3dc25aa89a8141b9fc234e58da807c0b2652fb17cddb3c44e627",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -2544,7 +2544,7 @@ exports[`VPC Endpoints 1`] = `
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:cba55679a00b58f17f87500d59d395e9e6e2815477b442712ec7438afb7712f7",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:01b1052f0b4e3dc25aa89a8141b9fc234e58da807c0b2652fb17cddb3c44e627",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -5021,7 +5021,7 @@ exports[`VPC Endpoints and CodeArtifact repository 1`] = `
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:cba55679a00b58f17f87500d59d395e9e6e2815477b442712ec7438afb7712f7",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:01b1052f0b4e3dc25aa89a8141b9fc234e58da807c0b2652fb17cddb3c44e627",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -7332,7 +7332,7 @@ exports[`basic use 1`] = `
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:cba55679a00b58f17f87500d59d395e9e6e2815477b442712ec7438afb7712f7",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:01b1052f0b4e3dc25aa89a8141b9fc234e58da807c0b2652fb17cddb3c44e627",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",

--- a/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
+++ b/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
@@ -229,7 +229,7 @@ exports[`CodeArtifact repository 1`] = `
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:9b8e4131ca5189fc3403e30767744db16370f1c8208b8715fe70baf74bb1859d",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:cba55679a00b58f17f87500d59d395e9e6e2815477b442712ec7438afb7712f7",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -2544,7 +2544,7 @@ exports[`VPC Endpoints 1`] = `
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:9b8e4131ca5189fc3403e30767744db16370f1c8208b8715fe70baf74bb1859d",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:cba55679a00b58f17f87500d59d395e9e6e2815477b442712ec7438afb7712f7",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -5021,7 +5021,7 @@ exports[`VPC Endpoints and CodeArtifact repository 1`] = `
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:9b8e4131ca5189fc3403e30767744db16370f1c8208b8715fe70baf74bb1859d",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:cba55679a00b58f17f87500d59d395e9e6e2815477b442712ec7438afb7712f7",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -7332,7 +7332,7 @@ exports[`basic use 1`] = `
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:9b8e4131ca5189fc3403e30767744db16370f1c8208b8715fe70baf74bb1859d",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:cba55679a00b58f17f87500d59d395e9e6e2815477b442712ec7438afb7712f7",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -7066,7 +7066,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:cba55679a00b58f17f87500d59d395e9e6e2815477b442712ec7438afb7712f7",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:01b1052f0b4e3dc25aa89a8141b9fc234e58da807c0b2652fb17cddb3c44e627",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -7066,7 +7066,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:9b8e4131ca5189fc3403e30767744db16370f1c8208b8715fe70baf74bb1859d",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:cba55679a00b58f17f87500d59d395e9e6e2815477b442712ec7438afb7712f7",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",

--- a/src/backend/transliterator/index.ts
+++ b/src/backend/transliterator/index.ts
@@ -28,7 +28,7 @@ import {
   EcsRunTask,
 } from 'aws-cdk-lib/aws-stepfunctions-tasks';
 import { Construct } from 'constructs';
-import { Transliterator as Container, HEAP_SIZE } from './transliterator';
+import { Transliterator as Container, MEMORY_LIMIT } from './transliterator';
 import { Repository } from '../../codeartifact/repository';
 import { Monitoring } from '../../monitoring';
 import * as s3 from '../../s3';
@@ -167,7 +167,7 @@ export class Transliterator extends Construct {
       }),
       taskDefinition: new FargateTaskDefinition(this, 'TaskDefinition', {
         cpu: 4_096,
-        memoryLimitMiB: HEAP_SIZE,
+        memoryLimitMiB: MEMORY_LIMIT,
         runtimePlatform: {
           cpuArchitecture: CpuArchitecture.ARM64,
           operatingSystemFamily: OperatingSystemFamily.LINUX,

--- a/src/backend/transliterator/index.ts
+++ b/src/backend/transliterator/index.ts
@@ -28,7 +28,7 @@ import {
   EcsRunTask,
 } from 'aws-cdk-lib/aws-stepfunctions-tasks';
 import { Construct } from 'constructs';
-import { Transliterator as Container } from './transliterator';
+import { Transliterator as Container, HEAP_SIZE } from './transliterator';
 import { Repository } from '../../codeartifact/repository';
 import { Monitoring } from '../../monitoring';
 import * as s3 from '../../s3';
@@ -167,7 +167,7 @@ export class Transliterator extends Construct {
       }),
       taskDefinition: new FargateTaskDefinition(this, 'TaskDefinition', {
         cpu: 4_096,
-        memoryLimitMiB: 8_192,
+        memoryLimitMiB: HEAP_SIZE,
         runtimePlatform: {
           cpuArchitecture: CpuArchitecture.ARM64,
           operatingSystemFamily: OperatingSystemFamily.LINUX,

--- a/src/backend/transliterator/transliterator.ts
+++ b/src/backend/transliterator/transliterator.ts
@@ -5,7 +5,7 @@ import * as ecs from 'aws-cdk-lib/aws-ecs';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { Construct } from 'constructs';
 
-export const HEAP_SIZE = 8192
+export const MEMORY_LIMIT = 8192
 
 export interface TransliteratorProps extends Omit<ecs.ContainerDefinitionOptions, 'image'> {
   readonly taskDefinition: ecs.FargateTaskDefinition;

--- a/src/backend/transliterator/transliterator.ts
+++ b/src/backend/transliterator/transliterator.ts
@@ -5,6 +5,8 @@ import * as ecs from 'aws-cdk-lib/aws-ecs';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { Construct } from 'constructs';
 
+export const HEAP_SIZE = 8192
+
 export interface TransliteratorProps extends Omit<ecs.ContainerDefinitionOptions, 'image'> {
   readonly taskDefinition: ecs.FargateTaskDefinition;
 }


### PR DESCRIPTION
We never set the `--max-old-space-size` option when running the node process inside the transliterator task. I guess this was missed during our migration from Lambda to ECS. 

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*