### PR TITLE
fix: READMEs are no longer rendered

### DIFF
--- a/src/backend/transliterator/transliterator.ecstask.ts
+++ b/src/backend/transliterator/transliterator.ecstask.ts
@@ -191,6 +191,7 @@ export function handler(
 
                 const docgenLang = docgen.Language.fromString(lang.name);
                 const json = await docs.toJson({
+                  readme: true,
                   submodule: submoduleFqn,
                   language: docgenLang,
                 });


### PR DESCRIPTION
https://github.com/cdklabs/jsii-docgen/pull/1117 changed the default of the `readme` flag from `true` to `false`, which is why Construct Hub was not rendering READMEs anymore.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*