### PR TITLE
chore: upgrade targets to node18

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -134,7 +134,7 @@
       "description": "Create an AWS Lambda bundle from src/backend/inventory/canary.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/backend/inventory/canary.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/backend/inventory/canary.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
+          "exec": "esbuild --bundle src/backend/inventory/canary.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/backend/inventory/canary.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
         }
       ]
     },
@@ -143,7 +143,7 @@
       "description": "Continuously update an AWS Lambda bundle from src/backend/inventory/canary.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/backend/inventory/canary.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/backend/inventory/canary.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
+          "exec": "esbuild --bundle src/backend/inventory/canary.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/backend/inventory/canary.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
         }
       ]
     },
@@ -152,7 +152,7 @@
       "description": "Create an AWS Lambda bundle from src/backend/catalog-builder/catalog-builder.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/backend/catalog-builder/catalog-builder.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/backend/catalog-builder/catalog-builder.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
+          "exec": "esbuild --bundle src/backend/catalog-builder/catalog-builder.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/backend/catalog-builder/catalog-builder.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
         }
       ]
     },
@@ -161,7 +161,7 @@
       "description": "Create an AWS Lambda bundle from src/__tests__/backend/deny-list/integ/catalog-builder-mock.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/__tests__/backend/deny-list/integ/catalog-builder-mock.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/__tests__/backend/deny-list/integ/catalog-builder-mock.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
+          "exec": "esbuild --bundle src/__tests__/backend/deny-list/integ/catalog-builder-mock.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/__tests__/backend/deny-list/integ/catalog-builder-mock.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
         }
       ]
     },
@@ -170,7 +170,7 @@
       "description": "Continuously update an AWS Lambda bundle from src/__tests__/backend/deny-list/integ/catalog-builder-mock.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/__tests__/backend/deny-list/integ/catalog-builder-mock.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/__tests__/backend/deny-list/integ/catalog-builder-mock.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
+          "exec": "esbuild --bundle src/__tests__/backend/deny-list/integ/catalog-builder-mock.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/__tests__/backend/deny-list/integ/catalog-builder-mock.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
         }
       ]
     },
@@ -179,7 +179,7 @@
       "description": "Continuously update an AWS Lambda bundle from src/backend/catalog-builder/catalog-builder.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/backend/catalog-builder/catalog-builder.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/backend/catalog-builder/catalog-builder.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
+          "exec": "esbuild --bundle src/backend/catalog-builder/catalog-builder.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/backend/catalog-builder/catalog-builder.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
         }
       ]
     },
@@ -188,7 +188,7 @@
       "description": "Create an AWS Lambda bundle from src/monitored-certificate/certificate-monitor.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/monitored-certificate/certificate-monitor.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/monitored-certificate/certificate-monitor.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
+          "exec": "esbuild --bundle src/monitored-certificate/certificate-monitor.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/monitored-certificate/certificate-monitor.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
         }
       ]
     },
@@ -197,7 +197,7 @@
       "description": "Continuously update an AWS Lambda bundle from src/monitored-certificate/certificate-monitor.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/monitored-certificate/certificate-monitor.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/monitored-certificate/certificate-monitor.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
+          "exec": "esbuild --bundle src/monitored-certificate/certificate-monitor.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/monitored-certificate/certificate-monitor.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
         }
       ]
     },
@@ -206,7 +206,7 @@
       "description": "Create an AWS Lambda bundle from src/package-sources/codeartifact/code-artifact-forwarder.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/package-sources/codeartifact/code-artifact-forwarder.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/package-sources/codeartifact/code-artifact-forwarder.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
+          "exec": "esbuild --bundle src/package-sources/codeartifact/code-artifact-forwarder.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/package-sources/codeartifact/code-artifact-forwarder.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
         }
       ]
     },
@@ -215,7 +215,7 @@
       "description": "Continuously update an AWS Lambda bundle from src/package-sources/codeartifact/code-artifact-forwarder.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/package-sources/codeartifact/code-artifact-forwarder.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/package-sources/codeartifact/code-artifact-forwarder.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
+          "exec": "esbuild --bundle src/package-sources/codeartifact/code-artifact-forwarder.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/package-sources/codeartifact/code-artifact-forwarder.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
         }
       ]
     },
@@ -224,7 +224,7 @@
       "description": "Continuously bundle all AWS Fargate functions",
       "steps": [
         {
-          "exec": "esbuild --bundle src/backend/transliterator/transliterator.ecs-entrypoint.ts --target=\"node16\" --platform=\"node\" --outbase=\"src\" --outdir=\"lib\" --entry-names=\"[dir]/[name].bundle/index\" --external:aws-sdk --sourcemap --watch"
+          "exec": "esbuild --bundle src/backend/transliterator/transliterator.ecs-entrypoint.ts --target=\"node18\" --platform=\"node\" --outbase=\"src\" --outdir=\"lib\" --entry-names=\"[dir]/[name].bundle/index\" --external:aws-sdk --sourcemap --watch"
         }
       ]
     },
@@ -233,7 +233,7 @@
       "description": "Create an AWS Lambda bundle from src/backend/release-notes/generate-release-notes.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/backend/release-notes/generate-release-notes.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/backend/release-notes/generate-release-notes.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
+          "exec": "esbuild --bundle src/backend/release-notes/generate-release-notes.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/backend/release-notes/generate-release-notes.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
         }
       ]
     },
@@ -242,7 +242,7 @@
       "description": "Continuously update an AWS Lambda bundle from src/backend/release-notes/generate-release-notes.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/backend/release-notes/generate-release-notes.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/backend/release-notes/generate-release-notes.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
+          "exec": "esbuild --bundle src/backend/release-notes/generate-release-notes.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/backend/release-notes/generate-release-notes.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
         }
       ]
     },
@@ -251,7 +251,7 @@
       "description": "Create an AWS Lambda bundle from src/backend/release-notes/get-messages-from-worker-queue.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/backend/release-notes/get-messages-from-worker-queue.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/backend/release-notes/get-messages-from-worker-queue.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
+          "exec": "esbuild --bundle src/backend/release-notes/get-messages-from-worker-queue.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/backend/release-notes/get-messages-from-worker-queue.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
         }
       ]
     },
@@ -260,7 +260,7 @@
       "description": "Continuously update an AWS Lambda bundle from src/backend/release-notes/get-messages-from-worker-queue.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/backend/release-notes/get-messages-from-worker-queue.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/backend/release-notes/get-messages-from-worker-queue.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
+          "exec": "esbuild --bundle src/backend/release-notes/get-messages-from-worker-queue.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/backend/release-notes/get-messages-from-worker-queue.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
         }
       ]
     },
@@ -269,7 +269,7 @@
       "description": "Create an AWS Lambda bundle from src/monitoring/http-get-function.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/monitoring/http-get-function.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/monitoring/http-get-function.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
+          "exec": "esbuild --bundle src/monitoring/http-get-function.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/monitoring/http-get-function.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
         }
       ]
     },
@@ -278,7 +278,7 @@
       "description": "Continuously update an AWS Lambda bundle from src/monitoring/http-get-function.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/monitoring/http-get-function.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/monitoring/http-get-function.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
+          "exec": "esbuild --bundle src/monitoring/http-get-function.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/monitoring/http-get-function.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
         }
       ]
     },
@@ -287,7 +287,7 @@
       "description": "Create an AWS Lambda bundle from src/backend/ingestion/ingestion.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/backend/ingestion/ingestion.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/backend/ingestion/ingestion.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
+          "exec": "esbuild --bundle src/backend/ingestion/ingestion.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/backend/ingestion/ingestion.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
         }
       ]
     },
@@ -296,7 +296,7 @@
       "description": "Continuously update an AWS Lambda bundle from src/backend/ingestion/ingestion.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/backend/ingestion/ingestion.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/backend/ingestion/ingestion.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
+          "exec": "esbuild --bundle src/backend/ingestion/ingestion.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/backend/ingestion/ingestion.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
         }
       ]
     },
@@ -314,7 +314,7 @@
       "description": "Create an AWS Lambda bundle from src/backend/ecs-task-monitor/monitor.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/backend/ecs-task-monitor/monitor.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/backend/ecs-task-monitor/monitor.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
+          "exec": "esbuild --bundle src/backend/ecs-task-monitor/monitor.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/backend/ecs-task-monitor/monitor.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
         }
       ]
     },
@@ -323,7 +323,7 @@
       "description": "Continuously update an AWS Lambda bundle from src/backend/ecs-task-monitor/monitor.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/backend/ecs-task-monitor/monitor.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/backend/ecs-task-monitor/monitor.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
+          "exec": "esbuild --bundle src/backend/ecs-task-monitor/monitor.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/backend/ecs-task-monitor/monitor.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
         }
       ]
     },
@@ -332,7 +332,7 @@
       "description": "Create an AWS Lambda bundle from src/backend/orchestration/needs-catalog-update.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/backend/orchestration/needs-catalog-update.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/backend/orchestration/needs-catalog-update.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
+          "exec": "esbuild --bundle src/backend/orchestration/needs-catalog-update.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/backend/orchestration/needs-catalog-update.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
         }
       ]
     },
@@ -341,7 +341,7 @@
       "description": "Continuously update an AWS Lambda bundle from src/backend/orchestration/needs-catalog-update.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/backend/orchestration/needs-catalog-update.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/backend/orchestration/needs-catalog-update.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
+          "exec": "esbuild --bundle src/backend/orchestration/needs-catalog-update.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/backend/orchestration/needs-catalog-update.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
         }
       ]
     },
@@ -350,7 +350,7 @@
       "description": "Create an AWS Lambda bundle from src/package-sources/npmjs/npm-js-follower.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/package-sources/npmjs/npm-js-follower.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/package-sources/npmjs/npm-js-follower.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
+          "exec": "esbuild --bundle src/package-sources/npmjs/npm-js-follower.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/package-sources/npmjs/npm-js-follower.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
         }
       ]
     },
@@ -359,7 +359,7 @@
       "description": "Continuously update an AWS Lambda bundle from src/package-sources/npmjs/npm-js-follower.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/package-sources/npmjs/npm-js-follower.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/package-sources/npmjs/npm-js-follower.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
+          "exec": "esbuild --bundle src/package-sources/npmjs/npm-js-follower.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/package-sources/npmjs/npm-js-follower.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
         }
       ]
     },
@@ -368,7 +368,7 @@
       "description": "Create an AWS Lambda bundle from src/package-sources/npmjs/canary/npmjs-package-canary.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/package-sources/npmjs/canary/npmjs-package-canary.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/package-sources/npmjs/canary/npmjs-package-canary.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
+          "exec": "esbuild --bundle src/package-sources/npmjs/canary/npmjs-package-canary.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/package-sources/npmjs/canary/npmjs-package-canary.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
         }
       ]
     },
@@ -377,7 +377,7 @@
       "description": "Continuously update an AWS Lambda bundle from src/package-sources/npmjs/canary/npmjs-package-canary.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/package-sources/npmjs/canary/npmjs-package-canary.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/package-sources/npmjs/canary/npmjs-package-canary.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
+          "exec": "esbuild --bundle src/package-sources/npmjs/canary/npmjs-package-canary.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/package-sources/npmjs/canary/npmjs-package-canary.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
         }
       ]
     },
@@ -386,7 +386,7 @@
       "description": "Create an AWS Lambda bundle from src/backend/package-stats/package-stats.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/backend/package-stats/package-stats.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/backend/package-stats/package-stats.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
+          "exec": "esbuild --bundle src/backend/package-stats/package-stats.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/backend/package-stats/package-stats.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
         }
       ]
     },
@@ -395,7 +395,7 @@
       "description": "Continuously update an AWS Lambda bundle from src/backend/package-stats/package-stats.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/backend/package-stats/package-stats.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/backend/package-stats/package-stats.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
+          "exec": "esbuild --bundle src/backend/package-stats/package-stats.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/backend/package-stats/package-stats.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
         }
       ]
     },
@@ -404,7 +404,7 @@
       "description": "Create an AWS Lambda bundle from src/backend/inventory/package-versions-table-widget-function.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/backend/inventory/package-versions-table-widget-function.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/backend/inventory/package-versions-table-widget-function.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
+          "exec": "esbuild --bundle src/backend/inventory/package-versions-table-widget-function.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/backend/inventory/package-versions-table-widget-function.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
         }
       ]
     },
@@ -413,7 +413,7 @@
       "description": "Continuously update an AWS Lambda bundle from src/backend/inventory/package-versions-table-widget-function.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/backend/inventory/package-versions-table-widget-function.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/backend/inventory/package-versions-table-widget-function.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
+          "exec": "esbuild --bundle src/backend/inventory/package-versions-table-widget-function.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/backend/inventory/package-versions-table-widget-function.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
         }
       ]
     },
@@ -422,7 +422,7 @@
       "description": "Create an AWS Lambda bundle from src/backend/deny-list/prune-handler.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/backend/deny-list/prune-handler.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/backend/deny-list/prune-handler.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
+          "exec": "esbuild --bundle src/backend/deny-list/prune-handler.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/backend/deny-list/prune-handler.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
         }
       ]
     },
@@ -431,7 +431,7 @@
       "description": "Continuously update an AWS Lambda bundle from src/backend/deny-list/prune-handler.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/backend/deny-list/prune-handler.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/backend/deny-list/prune-handler.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
+          "exec": "esbuild --bundle src/backend/deny-list/prune-handler.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/backend/deny-list/prune-handler.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
         }
       ]
     },
@@ -440,7 +440,7 @@
       "description": "Create an AWS Lambda bundle from src/backend/deny-list/prune-queue-handler.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/backend/deny-list/prune-queue-handler.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/backend/deny-list/prune-queue-handler.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
+          "exec": "esbuild --bundle src/backend/deny-list/prune-queue-handler.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/backend/deny-list/prune-queue-handler.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
         }
       ]
     },
@@ -449,7 +449,7 @@
       "description": "Continuously update an AWS Lambda bundle from src/backend/deny-list/prune-queue-handler.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/backend/deny-list/prune-queue-handler.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/backend/deny-list/prune-queue-handler.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
+          "exec": "esbuild --bundle src/backend/deny-list/prune-queue-handler.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/backend/deny-list/prune-queue-handler.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
         }
       ]
     },
@@ -458,7 +458,7 @@
       "description": "Create an AWS Lambda bundle from src/backend/ingestion/re-ingest.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/backend/ingestion/re-ingest.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/backend/ingestion/re-ingest.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
+          "exec": "esbuild --bundle src/backend/ingestion/re-ingest.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/backend/ingestion/re-ingest.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
         }
       ]
     },
@@ -467,7 +467,7 @@
       "description": "Continuously update an AWS Lambda bundle from src/backend/ingestion/re-ingest.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/backend/ingestion/re-ingest.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/backend/ingestion/re-ingest.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
+          "exec": "esbuild --bundle src/backend/ingestion/re-ingest.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/backend/ingestion/re-ingest.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
         }
       ]
     },
@@ -476,7 +476,7 @@
       "description": "Create an AWS Lambda bundle from src/backend/orchestration/redrive-state-machine.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/backend/orchestration/redrive-state-machine.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/backend/orchestration/redrive-state-machine.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
+          "exec": "esbuild --bundle src/backend/orchestration/redrive-state-machine.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/backend/orchestration/redrive-state-machine.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
         }
       ]
     },
@@ -485,7 +485,7 @@
       "description": "Continuously update an AWS Lambda bundle from src/backend/orchestration/redrive-state-machine.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/backend/orchestration/redrive-state-machine.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/backend/orchestration/redrive-state-machine.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
+          "exec": "esbuild --bundle src/backend/orchestration/redrive-state-machine.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/backend/orchestration/redrive-state-machine.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
         }
       ]
     },
@@ -494,7 +494,7 @@
       "description": "Create an AWS Lambda bundle from src/backend/release-notes/release-notes-trigger.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/backend/release-notes/release-notes-trigger.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/backend/release-notes/release-notes-trigger.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
+          "exec": "esbuild --bundle src/backend/release-notes/release-notes-trigger.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/backend/release-notes/release-notes-trigger.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
         }
       ]
     },
@@ -503,7 +503,7 @@
       "description": "Continuously update an AWS Lambda bundle from src/backend/release-notes/release-notes-trigger.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/backend/release-notes/release-notes-trigger.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/backend/release-notes/release-notes-trigger.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
+          "exec": "esbuild --bundle src/backend/release-notes/release-notes-trigger.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/backend/release-notes/release-notes-trigger.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
         }
       ]
     },
@@ -512,7 +512,7 @@
       "description": "Create an AWS Lambda bundle from src/overview-dashboard/sqs-dlq-stats-widget-function.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/overview-dashboard/sqs-dlq-stats-widget-function.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/overview-dashboard/sqs-dlq-stats-widget-function.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
+          "exec": "esbuild --bundle src/overview-dashboard/sqs-dlq-stats-widget-function.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/overview-dashboard/sqs-dlq-stats-widget-function.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
         }
       ]
     },
@@ -521,7 +521,7 @@
       "description": "Continuously update an AWS Lambda bundle from src/overview-dashboard/sqs-dlq-stats-widget-function.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/overview-dashboard/sqs-dlq-stats-widget-function.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/overview-dashboard/sqs-dlq-stats-widget-function.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
+          "exec": "esbuild --bundle src/overview-dashboard/sqs-dlq-stats-widget-function.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/overview-dashboard/sqs-dlq-stats-widget-function.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
         }
       ]
     },
@@ -530,7 +530,7 @@
       "description": "Create an AWS Lambda bundle from src/package-sources/npmjs/stage-and-notify.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/package-sources/npmjs/stage-and-notify.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/package-sources/npmjs/stage-and-notify.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
+          "exec": "esbuild --bundle src/package-sources/npmjs/stage-and-notify.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/package-sources/npmjs/stage-and-notify.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
         }
       ]
     },
@@ -539,7 +539,7 @@
       "description": "Continuously update an AWS Lambda bundle from src/package-sources/npmjs/stage-and-notify.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/package-sources/npmjs/stage-and-notify.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/package-sources/npmjs/stage-and-notify.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
+          "exec": "esbuild --bundle src/package-sources/npmjs/stage-and-notify.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/package-sources/npmjs/stage-and-notify.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
         }
       ]
     },
@@ -578,7 +578,7 @@
       "description": "Create an AWS Lambda bundle from src/__tests__/backend/deny-list/integ/trigger.client-test.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/__tests__/backend/deny-list/integ/trigger.client-test.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/__tests__/backend/deny-list/integ/trigger.client-test.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
+          "exec": "esbuild --bundle src/__tests__/backend/deny-list/integ/trigger.client-test.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/__tests__/backend/deny-list/integ/trigger.client-test.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
         }
       ]
     },
@@ -587,7 +587,7 @@
       "description": "Continuously update an AWS Lambda bundle from src/__tests__/backend/deny-list/integ/trigger.client-test.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/__tests__/backend/deny-list/integ/trigger.client-test.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/__tests__/backend/deny-list/integ/trigger.client-test.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
+          "exec": "esbuild --bundle src/__tests__/backend/deny-list/integ/trigger.client-test.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/__tests__/backend/deny-list/integ/trigger.client-test.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
         }
       ]
     },
@@ -596,7 +596,7 @@
       "description": "Create an AWS Lambda bundle from src/__tests__/backend/deny-list/integ/trigger.prune-test.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/__tests__/backend/deny-list/integ/trigger.prune-test.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/__tests__/backend/deny-list/integ/trigger.prune-test.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
+          "exec": "esbuild --bundle src/__tests__/backend/deny-list/integ/trigger.prune-test.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/__tests__/backend/deny-list/integ/trigger.prune-test.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
         }
       ]
     },
@@ -605,7 +605,7 @@
       "description": "Continuously update an AWS Lambda bundle from src/__tests__/backend/deny-list/integ/trigger.prune-test.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/__tests__/backend/deny-list/integ/trigger.prune-test.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/__tests__/backend/deny-list/integ/trigger.prune-test.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
+          "exec": "esbuild --bundle src/__tests__/backend/deny-list/integ/trigger.prune-test.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/__tests__/backend/deny-list/integ/trigger.prune-test.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
         }
       ]
     },
@@ -614,7 +614,7 @@
       "description": "Create an AWS Lambda bundle from src/backend/feed-builder/update-feed.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/backend/feed-builder/update-feed.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/backend/feed-builder/update-feed.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
+          "exec": "esbuild --bundle src/backend/feed-builder/update-feed.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/backend/feed-builder/update-feed.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
         }
       ]
     },
@@ -623,7 +623,7 @@
       "description": "Continuously update an AWS Lambda bundle from src/backend/feed-builder/update-feed.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/backend/feed-builder/update-feed.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/backend/feed-builder/update-feed.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
+          "exec": "esbuild --bundle src/backend/feed-builder/update-feed.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/backend/feed-builder/update-feed.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
         }
       ]
     },
@@ -632,7 +632,7 @@
       "description": "Create an AWS Lambda bundle from src/backend/version-tracker/version-tracker.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/backend/version-tracker/version-tracker.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/backend/version-tracker/version-tracker.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
+          "exec": "esbuild --bundle src/backend/version-tracker/version-tracker.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/backend/version-tracker/version-tracker.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json"
         }
       ]
     },
@@ -641,7 +641,7 @@
       "description": "Continuously update an AWS Lambda bundle from src/backend/version-tracker/version-tracker.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/backend/version-tracker/version-tracker.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"lib/backend/version-tracker/version-tracker.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
+          "exec": "esbuild --bundle src/backend/version-tracker/version-tracker.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"lib/backend/version-tracker/version-tracker.lambda.bundle/index.js\" --external:aws-sdk --sourcemap --tsconfig=tsconfig.dev.json --watch"
         }
       ]
     },

--- a/projenrc/bundle-javascript-for-ecs.exec.ts
+++ b/projenrc/bundle-javascript-for-ecs.exec.ts
@@ -18,7 +18,7 @@ async function main(args: string[]) {
     entryPoints: [entrypoint],
     outfile,
     sourcemap: true,
-    target: 'node16',
+    target: 'node18',
     platform: 'node',
     metafile: true,
 

--- a/projenrc/magic-ecs.ts
+++ b/projenrc/magic-ecs.ts
@@ -289,7 +289,7 @@ export function discoverEcsTasks(project: TypeScriptProject) {
       ...entrypoints.map((file) =>
         file.replace('ecstask.ts', 'ecs-entrypoint.ts')
       ),
-      '--target="node16"',
+      '--target="node18"',
       '--platform="node"',
       `--outbase="${project.srcdir}"`,
       `--outdir="${project.libdir}"`,

--- a/projenrc/magic-lambda.ts
+++ b/projenrc/magic-lambda.ts
@@ -136,7 +136,7 @@ function newLambdaHandler(
     'esbuild',
     '--bundle',
     entry,
-    '--target="node16"',
+    '--target="node18"',
     '--platform="node"',
     `--outfile="${outfile}"`,
     '--external:aws-sdk',

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -2046,7 +2046,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "9b8336be1392a7ae5bd352871cadc754c7132a592c6a9dd0e975d079d28c41b9.zip",
+          "S3Key": "666c3add60c6ca343dacebaaee5d7bbebb57e26fa6fbbe149209a6191619e465.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -2273,7 +2273,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5ddb295eb292a032f5c1398091f646240e7615f9d4f844da495ee33a6157790d.zip",
+          "S3Key": "1644d4d80dda668774436a85496d62b8d76d8791ed159b021e130fd9ee412824.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": {
@@ -2699,7 +2699,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "3dc7732a889e7c2c1a5aa358b0ff8b21c9988bf61c88350ee47c8f9fcd68cddd.zip",
+          "S3Key": "06ba2bffdbf26790c5fdbf50098c7a9065690437ba9518e321e7f5270425d77d.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -3365,7 +3365,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "35daeb9b0160519d61a0b506093ceeb16abbf14c4e1b352518226523ed9a5d12.zip",
+          "S3Key": "038a281174f7f7f97afd0cf9502a8842844f71529fcf79b58739edbfd652ed44.zip",
         },
         "Description": "[ConstructHub/Inventory] A canary that periodically inspects the list of indexed packages",
         "Environment": {
@@ -4851,7 +4851,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b584ad1147a19b6333b4c4eb67232a912ad73dfcc0ffc87732577e62611bec0d.zip",
+          "S3Key": "384b59ecd16e5ade067f60cb799c4270a166607770506323539dcae415951c3a.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -5919,7 +5919,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "460a11dea0bd521816385fee41bd8335452ab8134b65895b923088343f1c6e77.zip",
+          "S3Key": "a47014d3fd7c305dc4621653272c7fcc935db6f67362b99f470d6096da081706.zip",
         },
         "Description": "[ConstructHub/Orchestration/NeedsCatalogUpdate] Determines whether a package version requires a catalog update",
         "Environment": {
@@ -6857,7 +6857,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:42e6bd8e51fcd4bafd5e51637f2d9295e8b54c08ad2724fd9ea29d7148617999",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:3e8990a0f38e0a10ad8d5a6f290c1f29126b0bd598d9b53fbd10f7fe522c6141",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -9449,7 +9449,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d7dbbd507e81260d01b1c15db54952b58d26d01ee8903d18ae4e93c41231c87c.zip",
+          "S3Key": "22b39abd9a8a124d711a38f88323a3b232d46c8e7bd5be34f6c903a2fd0f3bd2.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -9503,7 +9503,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "793a6b2a7a1f24e2b82460179bf7c3dcc486a5213ecc2660b9c595a6e70cc0ff.zip",
+          "S3Key": "ffc6046d47bfbbbf722e3e3b8f291d5e8e9535e45a91cfebc09bcd6d48321d89.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": {
@@ -10208,7 +10208,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "47058db23b1174dbcbf6d367b70815c7ea429944659a8be61e58b47c28ad489a.zip",
+          "S3Key": "bbbf660d33a6f003af4aca12fa7687187e7366a785bd4417ea408b10c4f64a6c.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -10619,7 +10619,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "19eea026f359d2d192f966d7dc7f3d598c43034707667490b8fb685c5993c8aa.zip",
+          "S3Key": "aed225fb4c95b09e97398799f6dae753cfc9b2bcd56836f42cd66eb4bd724b7b.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -10826,7 +10826,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "00b82a0b04caf66ac5712f03413e49a1f6e63904c5e2d5aa4a751ff7eea4e06e.zip",
+          "S3Key": "fc5bc885f3712513a537102f2aea93a7f1f7330fa10d9a471ff59da9be80b311.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -12094,7 +12094,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "ff7298c24c4bb63de03f14b9b626c0a0250ccdc61cf0e93bb848a9b8da62c1bb.zip",
+          "S3Key": "e1bc3aa9f8f400838dfd8590446480c5187ff05967956fa1009cbd6572d30b5b.zip",
         },
         "Description": "[ConstructHub/MissingDocumentationWidget] Is a custom CloudWatch widget handler",
         "Environment": {
@@ -12520,7 +12520,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "7c0613ce606b9e6308279baae700fdb3c50869b33d0bb84e39f5f6ca21d9bdde.zip",
+          "S3Key": "0a3aa2907d0245d3c25a4929bfd034a9fa84b893ca2209de39684e757f4cc170.zip",
         },
         "Description": "[ConstructHub/SQSDLQWidget] Is a custom CloudWatch widget handler",
         "Handler": "index.handler",
@@ -14940,7 +14940,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "9b8336be1392a7ae5bd352871cadc754c7132a592c6a9dd0e975d079d28c41b9.zip",
+          "S3Key": "666c3add60c6ca343dacebaaee5d7bbebb57e26fa6fbbe149209a6191619e465.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -15167,7 +15167,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5ddb295eb292a032f5c1398091f646240e7615f9d4f844da495ee33a6157790d.zip",
+          "S3Key": "1644d4d80dda668774436a85496d62b8d76d8791ed159b021e130fd9ee412824.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": {
@@ -15611,7 +15611,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "3dc7732a889e7c2c1a5aa358b0ff8b21c9988bf61c88350ee47c8f9fcd68cddd.zip",
+          "S3Key": "06ba2bffdbf26790c5fdbf50098c7a9065690437ba9518e321e7f5270425d77d.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -16357,7 +16357,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "35daeb9b0160519d61a0b506093ceeb16abbf14c4e1b352518226523ed9a5d12.zip",
+          "S3Key": "038a281174f7f7f97afd0cf9502a8842844f71529fcf79b58739edbfd652ed44.zip",
         },
         "Description": "[ConstructHub/Inventory] A canary that periodically inspects the list of indexed packages",
         "Environment": {
@@ -17843,7 +17843,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b584ad1147a19b6333b4c4eb67232a912ad73dfcc0ffc87732577e62611bec0d.zip",
+          "S3Key": "384b59ecd16e5ade067f60cb799c4270a166607770506323539dcae415951c3a.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -18911,7 +18911,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "460a11dea0bd521816385fee41bd8335452ab8134b65895b923088343f1c6e77.zip",
+          "S3Key": "a47014d3fd7c305dc4621653272c7fcc935db6f67362b99f470d6096da081706.zip",
         },
         "Description": "[ConstructHub/Orchestration/NeedsCatalogUpdate] Determines whether a package version requires a catalog update",
         "Environment": {
@@ -19876,7 +19876,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:42e6bd8e51fcd4bafd5e51637f2d9295e8b54c08ad2724fd9ea29d7148617999",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:3e8990a0f38e0a10ad8d5a6f290c1f29126b0bd598d9b53fbd10f7fe522c6141",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -22514,7 +22514,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d7dbbd507e81260d01b1c15db54952b58d26d01ee8903d18ae4e93c41231c87c.zip",
+          "S3Key": "22b39abd9a8a124d711a38f88323a3b232d46c8e7bd5be34f6c903a2fd0f3bd2.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -22568,7 +22568,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "793a6b2a7a1f24e2b82460179bf7c3dcc486a5213ecc2660b9c595a6e70cc0ff.zip",
+          "S3Key": "ffc6046d47bfbbbf722e3e3b8f291d5e8e9535e45a91cfebc09bcd6d48321d89.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": {
@@ -23273,7 +23273,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "47058db23b1174dbcbf6d367b70815c7ea429944659a8be61e58b47c28ad489a.zip",
+          "S3Key": "bbbf660d33a6f003af4aca12fa7687187e7366a785bd4417ea408b10c4f64a6c.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -23684,7 +23684,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "19eea026f359d2d192f966d7dc7f3d598c43034707667490b8fb685c5993c8aa.zip",
+          "S3Key": "aed225fb4c95b09e97398799f6dae753cfc9b2bcd56836f42cd66eb4bd724b7b.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -23891,7 +23891,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "00b82a0b04caf66ac5712f03413e49a1f6e63904c5e2d5aa4a751ff7eea4e06e.zip",
+          "S3Key": "fc5bc885f3712513a537102f2aea93a7f1f7330fa10d9a471ff59da9be80b311.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -25159,7 +25159,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "ff7298c24c4bb63de03f14b9b626c0a0250ccdc61cf0e93bb848a9b8da62c1bb.zip",
+          "S3Key": "e1bc3aa9f8f400838dfd8590446480c5187ff05967956fa1009cbd6572d30b5b.zip",
         },
         "Description": "[ConstructHub/MissingDocumentationWidget] Is a custom CloudWatch widget handler",
         "Environment": {
@@ -25585,7 +25585,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "7c0613ce606b9e6308279baae700fdb3c50869b33d0bb84e39f5f6ca21d9bdde.zip",
+          "S3Key": "0a3aa2907d0245d3c25a4929bfd034a9fa84b893ca2209de39684e757f4cc170.zip",
         },
         "Description": "[ConstructHub/SQSDLQWidget] Is a custom CloudWatch widget handler",
         "Handler": "index.handler",
@@ -27740,7 +27740,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "9b8336be1392a7ae5bd352871cadc754c7132a592c6a9dd0e975d079d28c41b9.zip",
+          "S3Key": "666c3add60c6ca343dacebaaee5d7bbebb57e26fa6fbbe149209a6191619e465.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -27967,7 +27967,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5ddb295eb292a032f5c1398091f646240e7615f9d4f844da495ee33a6157790d.zip",
+          "S3Key": "1644d4d80dda668774436a85496d62b8d76d8791ed159b021e130fd9ee412824.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": {
@@ -28393,7 +28393,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "3dc7732a889e7c2c1a5aa358b0ff8b21c9988bf61c88350ee47c8f9fcd68cddd.zip",
+          "S3Key": "06ba2bffdbf26790c5fdbf50098c7a9065690437ba9518e321e7f5270425d77d.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -29059,7 +29059,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "35daeb9b0160519d61a0b506093ceeb16abbf14c4e1b352518226523ed9a5d12.zip",
+          "S3Key": "038a281174f7f7f97afd0cf9502a8842844f71529fcf79b58739edbfd652ed44.zip",
         },
         "Description": "[ConstructHub/Inventory] A canary that periodically inspects the list of indexed packages",
         "Environment": {
@@ -30545,7 +30545,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b584ad1147a19b6333b4c4eb67232a912ad73dfcc0ffc87732577e62611bec0d.zip",
+          "S3Key": "384b59ecd16e5ade067f60cb799c4270a166607770506323539dcae415951c3a.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -31613,7 +31613,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "460a11dea0bd521816385fee41bd8335452ab8134b65895b923088343f1c6e77.zip",
+          "S3Key": "a47014d3fd7c305dc4621653272c7fcc935db6f67362b99f470d6096da081706.zip",
         },
         "Description": "[ConstructHub/Orchestration/NeedsCatalogUpdate] Determines whether a package version requires a catalog update",
         "Environment": {
@@ -32551,7 +32551,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:42e6bd8e51fcd4bafd5e51637f2d9295e8b54c08ad2724fd9ea29d7148617999",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:3e8990a0f38e0a10ad8d5a6f290c1f29126b0bd598d9b53fbd10f7fe522c6141",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -35143,7 +35143,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d7dbbd507e81260d01b1c15db54952b58d26d01ee8903d18ae4e93c41231c87c.zip",
+          "S3Key": "22b39abd9a8a124d711a38f88323a3b232d46c8e7bd5be34f6c903a2fd0f3bd2.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -35197,7 +35197,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "793a6b2a7a1f24e2b82460179bf7c3dcc486a5213ecc2660b9c595a6e70cc0ff.zip",
+          "S3Key": "ffc6046d47bfbbbf722e3e3b8f291d5e8e9535e45a91cfebc09bcd6d48321d89.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": {
@@ -35902,7 +35902,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "47058db23b1174dbcbf6d367b70815c7ea429944659a8be61e58b47c28ad489a.zip",
+          "S3Key": "bbbf660d33a6f003af4aca12fa7687187e7366a785bd4417ea408b10c4f64a6c.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -36313,7 +36313,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "19eea026f359d2d192f966d7dc7f3d598c43034707667490b8fb685c5993c8aa.zip",
+          "S3Key": "aed225fb4c95b09e97398799f6dae753cfc9b2bcd56836f42cd66eb4bd724b7b.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -36520,7 +36520,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "00b82a0b04caf66ac5712f03413e49a1f6e63904c5e2d5aa4a751ff7eea4e06e.zip",
+          "S3Key": "fc5bc885f3712513a537102f2aea93a7f1f7330fa10d9a471ff59da9be80b311.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -37788,7 +37788,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "ff7298c24c4bb63de03f14b9b626c0a0250ccdc61cf0e93bb848a9b8da62c1bb.zip",
+          "S3Key": "e1bc3aa9f8f400838dfd8590446480c5187ff05967956fa1009cbd6572d30b5b.zip",
         },
         "Description": "[ConstructHub/MissingDocumentationWidget] Is a custom CloudWatch widget handler",
         "Environment": {
@@ -38214,7 +38214,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "7c0613ce606b9e6308279baae700fdb3c50869b33d0bb84e39f5f6ca21d9bdde.zip",
+          "S3Key": "0a3aa2907d0245d3c25a4929bfd034a9fa84b893ca2209de39684e757f4cc170.zip",
         },
         "Description": "[ConstructHub/SQSDLQWidget] Is a custom CloudWatch widget handler",
         "Handler": "index.handler",
@@ -40517,7 +40517,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "9b8336be1392a7ae5bd352871cadc754c7132a592c6a9dd0e975d079d28c41b9.zip",
+          "S3Key": "666c3add60c6ca343dacebaaee5d7bbebb57e26fa6fbbe149209a6191619e465.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -40731,7 +40731,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5ddb295eb292a032f5c1398091f646240e7615f9d4f844da495ee33a6157790d.zip",
+          "S3Key": "1644d4d80dda668774436a85496d62b8d76d8791ed159b021e130fd9ee412824.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": {
@@ -41157,7 +41157,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "3dc7732a889e7c2c1a5aa358b0ff8b21c9988bf61c88350ee47c8f9fcd68cddd.zip",
+          "S3Key": "06ba2bffdbf26790c5fdbf50098c7a9065690437ba9518e321e7f5270425d77d.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -41823,7 +41823,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "35daeb9b0160519d61a0b506093ceeb16abbf14c4e1b352518226523ed9a5d12.zip",
+          "S3Key": "038a281174f7f7f97afd0cf9502a8842844f71529fcf79b58739edbfd652ed44.zip",
         },
         "Description": "[ConstructHub/Inventory] A canary that periodically inspects the list of indexed packages",
         "Environment": {
@@ -43331,7 +43331,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b584ad1147a19b6333b4c4eb67232a912ad73dfcc0ffc87732577e62611bec0d.zip",
+          "S3Key": "384b59ecd16e5ade067f60cb799c4270a166607770506323539dcae415951c3a.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -44399,7 +44399,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "460a11dea0bd521816385fee41bd8335452ab8134b65895b923088343f1c6e77.zip",
+          "S3Key": "a47014d3fd7c305dc4621653272c7fcc935db6f67362b99f470d6096da081706.zip",
         },
         "Description": "[ConstructHub/Orchestration/NeedsCatalogUpdate] Determines whether a package version requires a catalog update",
         "Environment": {
@@ -45337,7 +45337,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:42e6bd8e51fcd4bafd5e51637f2d9295e8b54c08ad2724fd9ea29d7148617999",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:3e8990a0f38e0a10ad8d5a6f290c1f29126b0bd598d9b53fbd10f7fe522c6141",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -47929,7 +47929,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d7dbbd507e81260d01b1c15db54952b58d26d01ee8903d18ae4e93c41231c87c.zip",
+          "S3Key": "22b39abd9a8a124d711a38f88323a3b232d46c8e7bd5be34f6c903a2fd0f3bd2.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -47983,7 +47983,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "793a6b2a7a1f24e2b82460179bf7c3dcc486a5213ecc2660b9c595a6e70cc0ff.zip",
+          "S3Key": "ffc6046d47bfbbbf722e3e3b8f291d5e8e9535e45a91cfebc09bcd6d48321d89.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": {
@@ -48675,7 +48675,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "47058db23b1174dbcbf6d367b70815c7ea429944659a8be61e58b47c28ad489a.zip",
+          "S3Key": "bbbf660d33a6f003af4aca12fa7687187e7366a785bd4417ea408b10c4f64a6c.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -49086,7 +49086,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "19eea026f359d2d192f966d7dc7f3d598c43034707667490b8fb685c5993c8aa.zip",
+          "S3Key": "aed225fb4c95b09e97398799f6dae753cfc9b2bcd56836f42cd66eb4bd724b7b.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -49293,7 +49293,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "00b82a0b04caf66ac5712f03413e49a1f6e63904c5e2d5aa4a751ff7eea4e06e.zip",
+          "S3Key": "fc5bc885f3712513a537102f2aea93a7f1f7330fa10d9a471ff59da9be80b311.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -50811,7 +50811,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "ff7298c24c4bb63de03f14b9b626c0a0250ccdc61cf0e93bb848a9b8da62c1bb.zip",
+          "S3Key": "e1bc3aa9f8f400838dfd8590446480c5187ff05967956fa1009cbd6572d30b5b.zip",
         },
         "Description": "[ConstructHub/MissingDocumentationWidget] Is a custom CloudWatch widget handler",
         "Environment": {
@@ -51237,7 +51237,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "7c0613ce606b9e6308279baae700fdb3c50869b33d0bb84e39f5f6ca21d9bdde.zip",
+          "S3Key": "0a3aa2907d0245d3c25a4929bfd034a9fa84b893ca2209de39684e757f4cc170.zip",
         },
         "Description": "[ConstructHub/SQSDLQWidget] Is a custom CloudWatch widget handler",
         "Handler": "index.handler",
@@ -53477,7 +53477,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "9b8336be1392a7ae5bd352871cadc754c7132a592c6a9dd0e975d079d28c41b9.zip",
+          "S3Key": "666c3add60c6ca343dacebaaee5d7bbebb57e26fa6fbbe149209a6191619e465.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -53704,7 +53704,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5ddb295eb292a032f5c1398091f646240e7615f9d4f844da495ee33a6157790d.zip",
+          "S3Key": "1644d4d80dda668774436a85496d62b8d76d8791ed159b021e130fd9ee412824.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": {
@@ -54130,7 +54130,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "3dc7732a889e7c2c1a5aa358b0ff8b21c9988bf61c88350ee47c8f9fcd68cddd.zip",
+          "S3Key": "06ba2bffdbf26790c5fdbf50098c7a9065690437ba9518e321e7f5270425d77d.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -54922,7 +54922,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "35daeb9b0160519d61a0b506093ceeb16abbf14c4e1b352518226523ed9a5d12.zip",
+          "S3Key": "038a281174f7f7f97afd0cf9502a8842844f71529fcf79b58739edbfd652ed44.zip",
         },
         "Description": "[ConstructHub/Inventory] A canary that periodically inspects the list of indexed packages",
         "Environment": {
@@ -56437,7 +56437,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b584ad1147a19b6333b4c4eb67232a912ad73dfcc0ffc87732577e62611bec0d.zip",
+          "S3Key": "384b59ecd16e5ade067f60cb799c4270a166607770506323539dcae415951c3a.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -57098,7 +57098,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "460a11dea0bd521816385fee41bd8335452ab8134b65895b923088343f1c6e77.zip",
+          "S3Key": "a47014d3fd7c305dc4621653272c7fcc935db6f67362b99f470d6096da081706.zip",
         },
         "Description": "[ConstructHub/Orchestration/NeedsCatalogUpdate] Determines whether a package version requires a catalog update",
         "Environment": {
@@ -58042,7 +58042,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:42e6bd8e51fcd4bafd5e51637f2d9295e8b54c08ad2724fd9ea29d7148617999",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:3e8990a0f38e0a10ad8d5a6f290c1f29126b0bd598d9b53fbd10f7fe522c6141",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -60696,7 +60696,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d7dbbd507e81260d01b1c15db54952b58d26d01ee8903d18ae4e93c41231c87c.zip",
+          "S3Key": "22b39abd9a8a124d711a38f88323a3b232d46c8e7bd5be34f6c903a2fd0f3bd2.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -60750,7 +60750,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "793a6b2a7a1f24e2b82460179bf7c3dcc486a5213ecc2660b9c595a6e70cc0ff.zip",
+          "S3Key": "ffc6046d47bfbbbf722e3e3b8f291d5e8e9535e45a91cfebc09bcd6d48321d89.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": {
@@ -61455,7 +61455,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "47058db23b1174dbcbf6d367b70815c7ea429944659a8be61e58b47c28ad489a.zip",
+          "S3Key": "bbbf660d33a6f003af4aca12fa7687187e7366a785bd4417ea408b10c4f64a6c.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -61866,7 +61866,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "19eea026f359d2d192f966d7dc7f3d598c43034707667490b8fb685c5993c8aa.zip",
+          "S3Key": "aed225fb4c95b09e97398799f6dae753cfc9b2bcd56836f42cd66eb4bd724b7b.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -64933,7 +64933,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "00b82a0b04caf66ac5712f03413e49a1f6e63904c5e2d5aa4a751ff7eea4e06e.zip",
+          "S3Key": "fc5bc885f3712513a537102f2aea93a7f1f7330fa10d9a471ff59da9be80b311.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -66698,7 +66698,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "ff7298c24c4bb63de03f14b9b626c0a0250ccdc61cf0e93bb848a9b8da62c1bb.zip",
+          "S3Key": "e1bc3aa9f8f400838dfd8590446480c5187ff05967956fa1009cbd6572d30b5b.zip",
         },
         "Description": "[ConstructHub/MissingDocumentationWidget] Is a custom CloudWatch widget handler",
         "Environment": {
@@ -67124,7 +67124,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "7c0613ce606b9e6308279baae700fdb3c50869b33d0bb84e39f5f6ca21d9bdde.zip",
+          "S3Key": "0a3aa2907d0245d3c25a4929bfd034a9fa84b893ca2209de39684e757f4cc170.zip",
         },
         "Description": "[ConstructHub/SQSDLQWidget] Is a custom CloudWatch widget handler",
         "Handler": "index.handler",

--- a/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
+++ b/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
@@ -229,7 +229,7 @@ exports[`CodeArtifact repository 1`] = `
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:42e6bd8e51fcd4bafd5e51637f2d9295e8b54c08ad2724fd9ea29d7148617999",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:3e8990a0f38e0a10ad8d5a6f290c1f29126b0bd598d9b53fbd10f7fe522c6141",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -2544,7 +2544,7 @@ exports[`VPC Endpoints 1`] = `
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:42e6bd8e51fcd4bafd5e51637f2d9295e8b54c08ad2724fd9ea29d7148617999",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:3e8990a0f38e0a10ad8d5a6f290c1f29126b0bd598d9b53fbd10f7fe522c6141",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -5021,7 +5021,7 @@ exports[`VPC Endpoints and CodeArtifact repository 1`] = `
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:42e6bd8e51fcd4bafd5e51637f2d9295e8b54c08ad2724fd9ea29d7148617999",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:3e8990a0f38e0a10ad8d5a6f290c1f29126b0bd598d9b53fbd10f7fe522c6141",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -7332,7 +7332,7 @@ exports[`basic use 1`] = `
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:42e6bd8e51fcd4bafd5e51637f2d9295e8b54c08ad2724fd9ea29d7148617999",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:3e8990a0f38e0a10ad8d5a6f290c1f29126b0bd598d9b53fbd10f7fe522c6141",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -2510,7 +2510,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "9b8336be1392a7ae5bd352871cadc754c7132a592c6a9dd0e975d079d28c41b9.zip",
+          "S3Key": "666c3add60c6ca343dacebaaee5d7bbebb57e26fa6fbbe149209a6191619e465.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -2739,7 +2739,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5ddb295eb292a032f5c1398091f646240e7615f9d4f844da495ee33a6157790d.zip",
+          "S3Key": "1644d4d80dda668774436a85496d62b8d76d8791ed159b021e130fd9ee412824.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": {
@@ -3183,7 +3183,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "3dc7732a889e7c2c1a5aa358b0ff8b21c9988bf61c88350ee47c8f9fcd68cddd.zip",
+          "S3Key": "06ba2bffdbf26790c5fdbf50098c7a9065690437ba9518e321e7f5270425d77d.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -3942,7 +3942,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "35daeb9b0160519d61a0b506093ceeb16abbf14c4e1b352518226523ed9a5d12.zip",
+          "S3Key": "038a281174f7f7f97afd0cf9502a8842844f71529fcf79b58739edbfd652ed44.zip",
         },
         "Description": "[ConstructHub/Inventory] A canary that periodically inspects the list of indexed packages",
         "Environment": {
@@ -5471,7 +5471,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b584ad1147a19b6333b4c4eb67232a912ad73dfcc0ffc87732577e62611bec0d.zip",
+          "S3Key": "384b59ecd16e5ade067f60cb799c4270a166607770506323539dcae415951c3a.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -6142,7 +6142,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "460a11dea0bd521816385fee41bd8335452ab8134b65895b923088343f1c6e77.zip",
+          "S3Key": "a47014d3fd7c305dc4621653272c7fcc935db6f67362b99f470d6096da081706.zip",
         },
         "Description": "[ConstructHub/Orchestration/NeedsCatalogUpdate] Determines whether a package version requires a catalog update",
         "Environment": {
@@ -7134,7 +7134,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:42e6bd8e51fcd4bafd5e51637f2d9295e8b54c08ad2724fd9ea29d7148617999",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:3e8990a0f38e0a10ad8d5a6f290c1f29126b0bd598d9b53fbd10f7fe522c6141",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -9737,7 +9737,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "935d9fbd900bb177ec6251d1c2b2dc834e6b273f8cb5a579ee8d1d70b405b335.zip",
+          "S3Key": "108beffe27b3eddf267544a37dff989b7cf1baae1fadf78354a28e81440edcac.zip",
         },
         "Description": "ReleaseNotes generator",
         "Environment": {
@@ -9888,7 +9888,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "f79b1e11cfa208848b04d4af0546cdbcc768c2748d33c6e0e2ba94f6073e5f4f.zip",
+          "S3Key": "97e3d732c5d3fd243a68293c83fbf80b3929a12a99cc68878e187c52dfd71498.zip",
         },
         "Description": "ReleaseNotes get message from the worker queue",
         "Environment": {
@@ -10742,7 +10742,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d7dbbd507e81260d01b1c15db54952b58d26d01ee8903d18ae4e93c41231c87c.zip",
+          "S3Key": "22b39abd9a8a124d711a38f88323a3b232d46c8e7bd5be34f6c903a2fd0f3bd2.zip",
         },
         "Description": "[dev/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -10796,7 +10796,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "793a6b2a7a1f24e2b82460179bf7c3dcc486a5213ecc2660b9c595a6e70cc0ff.zip",
+          "S3Key": "ffc6046d47bfbbbf722e3e3b8f291d5e8e9535e45a91cfebc09bcd6d48321d89.zip",
         },
         "Description": "[dev/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": {
@@ -11495,7 +11495,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "47058db23b1174dbcbf6d367b70815c7ea429944659a8be61e58b47c28ad489a.zip",
+          "S3Key": "bbbf660d33a6f003af4aca12fa7687187e7366a785bd4417ea408b10c4f64a6c.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -11906,7 +11906,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "19eea026f359d2d192f966d7dc7f3d598c43034707667490b8fb685c5993c8aa.zip",
+          "S3Key": "aed225fb4c95b09e97398799f6dae753cfc9b2bcd56836f42cd66eb4bd724b7b.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -15104,7 +15104,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "00b82a0b04caf66ac5712f03413e49a1f6e63904c5e2d5aa4a751ff7eea4e06e.zip",
+          "S3Key": "fc5bc885f3712513a537102f2aea93a7f1f7330fa10d9a471ff59da9be80b311.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -16372,7 +16372,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "ff7298c24c4bb63de03f14b9b626c0a0250ccdc61cf0e93bb848a9b8da62c1bb.zip",
+          "S3Key": "e1bc3aa9f8f400838dfd8590446480c5187ff05967956fa1009cbd6572d30b5b.zip",
         },
         "Description": "[ConstructHub/MissingDocumentationWidget] Is a custom CloudWatch widget handler",
         "Environment": {
@@ -16798,7 +16798,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "7c0613ce606b9e6308279baae700fdb3c50869b33d0bb84e39f5f6ca21d9bdde.zip",
+          "S3Key": "0a3aa2907d0245d3c25a4929bfd034a9fa84b893ca2209de39684e757f4cc170.zip",
         },
         "Description": "[ConstructHub/SQSDLQWidget] Is a custom CloudWatch widget handler",
         "Handler": "index.handler",

--- a/src/__tests__/package-sources/__snapshots__/code-artifact.test.ts.snap
+++ b/src/__tests__/package-sources/__snapshots__/code-artifact.test.ts.snap
@@ -243,7 +243,7 @@ exports[`default configuration 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b5294c55fb450cc78f6034e6a1f836e581afaf957ae83b7435bf610b494f8d88.zip",
+          "S3Key": "348c0b5e9ac303d72576dfc8dbfcbf4f0346caa1268deaad033956af3703ee4b.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -727,7 +727,7 @@ exports[`user-provided staging bucket 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b5294c55fb450cc78f6034e6a1f836e581afaf957ae83b7435bf610b494f8d88.zip",
+          "S3Key": "348c0b5e9ac303d72576dfc8dbfcbf4f0346caa1268deaad033956af3703ee4b.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {


### PR DESCRIPTION
Replaces `node16` targets in projen tasks with `node18`.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*