### PR TITLE
fix: Add redirect to https viewer protocol policy

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -11287,7 +11287,7 @@ function handler(event) {
               ],
               "PathPattern": "/data/*",
               "TargetOriginId": "TestConstructHubWebAppDistributionOrigin276090F90",
-              "ViewerProtocolPolicy": "allow-all",
+              "ViewerProtocolPolicy": "redirect-to-https",
             },
             {
               "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
@@ -11305,7 +11305,7 @@ function handler(event) {
               ],
               "PathPattern": "/catalog.json",
               "TargetOriginId": "TestConstructHubWebAppDistributionOrigin276090F90",
-              "ViewerProtocolPolicy": "allow-all",
+              "ViewerProtocolPolicy": "redirect-to-https",
             },
             {
               "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
@@ -11323,7 +11323,7 @@ function handler(event) {
               ],
               "PathPattern": "/all-versions.json",
               "TargetOriginId": "TestConstructHubWebAppDistributionOrigin276090F90",
-              "ViewerProtocolPolicy": "allow-all",
+              "ViewerProtocolPolicy": "redirect-to-https",
             },
             {
               "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
@@ -11359,7 +11359,7 @@ function handler(event) {
               ],
               "PathPattern": "/atom",
               "TargetOriginId": "TestConstructHubWebAppDistributionOrigin276090F90",
-              "ViewerProtocolPolicy": "allow-all",
+              "ViewerProtocolPolicy": "redirect-to-https",
             },
             {
               "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
@@ -11377,7 +11377,7 @@ function handler(event) {
               ],
               "PathPattern": "/rss",
               "TargetOriginId": "TestConstructHubWebAppDistributionOrigin276090F90",
-              "ViewerProtocolPolicy": "allow-all",
+              "ViewerProtocolPolicy": "redirect-to-https",
             },
             {
               "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
@@ -11395,7 +11395,7 @@ function handler(event) {
               ],
               "PathPattern": "/stats.json",
               "TargetOriginId": "TestConstructHubWebAppDistributionOrigin276090F90",
-              "ViewerProtocolPolicy": "allow-all",
+              "ViewerProtocolPolicy": "redirect-to-https",
             },
           ],
           "CustomErrorResponses": [
@@ -11425,7 +11425,7 @@ function handler(event) {
               },
             ],
             "TargetOriginId": "TestConstructHubWebAppDistributionOrigin171FF58D3",
-            "ViewerProtocolPolicy": "allow-all",
+            "ViewerProtocolPolicy": "redirect-to-https",
           },
           "DefaultRootObject": "index.html",
           "Enabled": true,
@@ -24352,7 +24352,7 @@ function handler(event) {
               ],
               "PathPattern": "/data/*",
               "TargetOriginId": "TestConstructHubWebAppDistributionOrigin276090F90",
-              "ViewerProtocolPolicy": "allow-all",
+              "ViewerProtocolPolicy": "redirect-to-https",
             },
             {
               "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
@@ -24370,7 +24370,7 @@ function handler(event) {
               ],
               "PathPattern": "/catalog.json",
               "TargetOriginId": "TestConstructHubWebAppDistributionOrigin276090F90",
-              "ViewerProtocolPolicy": "allow-all",
+              "ViewerProtocolPolicy": "redirect-to-https",
             },
             {
               "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
@@ -24388,7 +24388,7 @@ function handler(event) {
               ],
               "PathPattern": "/all-versions.json",
               "TargetOriginId": "TestConstructHubWebAppDistributionOrigin276090F90",
-              "ViewerProtocolPolicy": "allow-all",
+              "ViewerProtocolPolicy": "redirect-to-https",
             },
             {
               "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
@@ -24424,7 +24424,7 @@ function handler(event) {
               ],
               "PathPattern": "/atom",
               "TargetOriginId": "TestConstructHubWebAppDistributionOrigin276090F90",
-              "ViewerProtocolPolicy": "allow-all",
+              "ViewerProtocolPolicy": "redirect-to-https",
             },
             {
               "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
@@ -24442,7 +24442,7 @@ function handler(event) {
               ],
               "PathPattern": "/rss",
               "TargetOriginId": "TestConstructHubWebAppDistributionOrigin276090F90",
-              "ViewerProtocolPolicy": "allow-all",
+              "ViewerProtocolPolicy": "redirect-to-https",
             },
             {
               "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
@@ -24460,7 +24460,7 @@ function handler(event) {
               ],
               "PathPattern": "/stats.json",
               "TargetOriginId": "TestConstructHubWebAppDistributionOrigin276090F90",
-              "ViewerProtocolPolicy": "allow-all",
+              "ViewerProtocolPolicy": "redirect-to-https",
             },
           ],
           "CustomErrorResponses": [
@@ -24490,7 +24490,7 @@ function handler(event) {
               },
             ],
             "TargetOriginId": "TestConstructHubWebAppDistributionOrigin171FF58D3",
-            "ViewerProtocolPolicy": "allow-all",
+            "ViewerProtocolPolicy": "redirect-to-https",
           },
           "DefaultRootObject": "index.html",
           "Enabled": true,
@@ -36981,7 +36981,7 @@ function handler(event) {
               ],
               "PathPattern": "/data/*",
               "TargetOriginId": "TestConstructHubWebAppDistributionOrigin276090F90",
-              "ViewerProtocolPolicy": "allow-all",
+              "ViewerProtocolPolicy": "redirect-to-https",
             },
             {
               "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
@@ -36999,7 +36999,7 @@ function handler(event) {
               ],
               "PathPattern": "/catalog.json",
               "TargetOriginId": "TestConstructHubWebAppDistributionOrigin276090F90",
-              "ViewerProtocolPolicy": "allow-all",
+              "ViewerProtocolPolicy": "redirect-to-https",
             },
             {
               "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
@@ -37017,7 +37017,7 @@ function handler(event) {
               ],
               "PathPattern": "/all-versions.json",
               "TargetOriginId": "TestConstructHubWebAppDistributionOrigin276090F90",
-              "ViewerProtocolPolicy": "allow-all",
+              "ViewerProtocolPolicy": "redirect-to-https",
             },
             {
               "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
@@ -37053,7 +37053,7 @@ function handler(event) {
               ],
               "PathPattern": "/atom",
               "TargetOriginId": "TestConstructHubWebAppDistributionOrigin276090F90",
-              "ViewerProtocolPolicy": "allow-all",
+              "ViewerProtocolPolicy": "redirect-to-https",
             },
             {
               "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
@@ -37071,7 +37071,7 @@ function handler(event) {
               ],
               "PathPattern": "/rss",
               "TargetOriginId": "TestConstructHubWebAppDistributionOrigin276090F90",
-              "ViewerProtocolPolicy": "allow-all",
+              "ViewerProtocolPolicy": "redirect-to-https",
             },
             {
               "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
@@ -37089,7 +37089,7 @@ function handler(event) {
               ],
               "PathPattern": "/stats.json",
               "TargetOriginId": "TestConstructHubWebAppDistributionOrigin276090F90",
-              "ViewerProtocolPolicy": "allow-all",
+              "ViewerProtocolPolicy": "redirect-to-https",
             },
           ],
           "CustomErrorResponses": [
@@ -37119,7 +37119,7 @@ function handler(event) {
               },
             ],
             "TargetOriginId": "TestConstructHubWebAppDistributionOrigin171FF58D3",
-            "ViewerProtocolPolicy": "allow-all",
+            "ViewerProtocolPolicy": "redirect-to-https",
           },
           "DefaultRootObject": "index.html",
           "Enabled": true,
@@ -49809,7 +49809,7 @@ function handler(event) {
               ],
               "PathPattern": "/data/*",
               "TargetOriginId": "TestConstructHubWebAppDistributionOrigin276090F90",
-              "ViewerProtocolPolicy": "allow-all",
+              "ViewerProtocolPolicy": "redirect-to-https",
             },
             {
               "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
@@ -49827,7 +49827,7 @@ function handler(event) {
               ],
               "PathPattern": "/catalog.json",
               "TargetOriginId": "TestConstructHubWebAppDistributionOrigin276090F90",
-              "ViewerProtocolPolicy": "allow-all",
+              "ViewerProtocolPolicy": "redirect-to-https",
             },
             {
               "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
@@ -49845,7 +49845,7 @@ function handler(event) {
               ],
               "PathPattern": "/all-versions.json",
               "TargetOriginId": "TestConstructHubWebAppDistributionOrigin276090F90",
-              "ViewerProtocolPolicy": "allow-all",
+              "ViewerProtocolPolicy": "redirect-to-https",
             },
             {
               "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
@@ -49881,7 +49881,7 @@ function handler(event) {
               ],
               "PathPattern": "/atom",
               "TargetOriginId": "TestConstructHubWebAppDistributionOrigin276090F90",
-              "ViewerProtocolPolicy": "allow-all",
+              "ViewerProtocolPolicy": "redirect-to-https",
             },
             {
               "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
@@ -49899,7 +49899,7 @@ function handler(event) {
               ],
               "PathPattern": "/rss",
               "TargetOriginId": "TestConstructHubWebAppDistributionOrigin276090F90",
-              "ViewerProtocolPolicy": "allow-all",
+              "ViewerProtocolPolicy": "redirect-to-https",
             },
             {
               "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
@@ -49917,7 +49917,7 @@ function handler(event) {
               ],
               "PathPattern": "/stats.json",
               "TargetOriginId": "TestConstructHubWebAppDistributionOrigin276090F90",
-              "ViewerProtocolPolicy": "allow-all",
+              "ViewerProtocolPolicy": "redirect-to-https",
             },
           ],
           "CustomErrorResponses": [
@@ -49947,7 +49947,7 @@ function handler(event) {
               },
             ],
             "TargetOriginId": "TestConstructHubWebAppDistributionOrigin171FF58D3",
-            "ViewerProtocolPolicy": "allow-all",
+            "ViewerProtocolPolicy": "redirect-to-https",
           },
           "DefaultRootObject": "index.html",
           "Enabled": true,
@@ -65394,7 +65394,7 @@ function handler(event) {
               ],
               "PathPattern": "/data/*",
               "TargetOriginId": "TestConstructHubWebAppDistributionOrigin276090F90",
-              "ViewerProtocolPolicy": "allow-all",
+              "ViewerProtocolPolicy": "redirect-to-https",
             },
             {
               "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
@@ -65412,7 +65412,7 @@ function handler(event) {
               ],
               "PathPattern": "/catalog.json",
               "TargetOriginId": "TestConstructHubWebAppDistributionOrigin276090F90",
-              "ViewerProtocolPolicy": "allow-all",
+              "ViewerProtocolPolicy": "redirect-to-https",
             },
             {
               "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
@@ -65430,7 +65430,7 @@ function handler(event) {
               ],
               "PathPattern": "/all-versions.json",
               "TargetOriginId": "TestConstructHubWebAppDistributionOrigin276090F90",
-              "ViewerProtocolPolicy": "allow-all",
+              "ViewerProtocolPolicy": "redirect-to-https",
             },
             {
               "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
@@ -65466,7 +65466,7 @@ function handler(event) {
               ],
               "PathPattern": "/atom",
               "TargetOriginId": "TestConstructHubWebAppDistributionOrigin276090F90",
-              "ViewerProtocolPolicy": "allow-all",
+              "ViewerProtocolPolicy": "redirect-to-https",
             },
             {
               "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
@@ -65484,7 +65484,7 @@ function handler(event) {
               ],
               "PathPattern": "/rss",
               "TargetOriginId": "TestConstructHubWebAppDistributionOrigin276090F90",
-              "ViewerProtocolPolicy": "allow-all",
+              "ViewerProtocolPolicy": "redirect-to-https",
             },
             {
               "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
@@ -65502,7 +65502,7 @@ function handler(event) {
               ],
               "PathPattern": "/stats.json",
               "TargetOriginId": "TestConstructHubWebAppDistributionOrigin276090F90",
-              "ViewerProtocolPolicy": "allow-all",
+              "ViewerProtocolPolicy": "redirect-to-https",
             },
           ],
           "CustomErrorResponses": [
@@ -65532,7 +65532,7 @@ function handler(event) {
               },
             ],
             "TargetOriginId": "TestConstructHubWebAppDistributionOrigin171FF58D3",
-            "ViewerProtocolPolicy": "allow-all",
+            "ViewerProtocolPolicy": "redirect-to-https",
           },
           "DefaultRootObject": "index.html",
           "Enabled": true,

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -15565,7 +15565,7 @@ function handler(event) {
               ],
               "PathPattern": "/data/*",
               "TargetOriginId": "devConstructHubWebAppDistributionOrigin2A726FD66",
-              "ViewerProtocolPolicy": "allow-all",
+              "ViewerProtocolPolicy": "redirect-to-https",
             },
             {
               "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
@@ -15583,7 +15583,7 @@ function handler(event) {
               ],
               "PathPattern": "/catalog.json",
               "TargetOriginId": "devConstructHubWebAppDistributionOrigin2A726FD66",
-              "ViewerProtocolPolicy": "allow-all",
+              "ViewerProtocolPolicy": "redirect-to-https",
             },
             {
               "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
@@ -15601,7 +15601,7 @@ function handler(event) {
               ],
               "PathPattern": "/all-versions.json",
               "TargetOriginId": "devConstructHubWebAppDistributionOrigin2A726FD66",
-              "ViewerProtocolPolicy": "allow-all",
+              "ViewerProtocolPolicy": "redirect-to-https",
             },
             {
               "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
@@ -15637,7 +15637,7 @@ function handler(event) {
               ],
               "PathPattern": "/atom",
               "TargetOriginId": "devConstructHubWebAppDistributionOrigin2A726FD66",
-              "ViewerProtocolPolicy": "allow-all",
+              "ViewerProtocolPolicy": "redirect-to-https",
             },
             {
               "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
@@ -15655,7 +15655,7 @@ function handler(event) {
               ],
               "PathPattern": "/rss",
               "TargetOriginId": "devConstructHubWebAppDistributionOrigin2A726FD66",
-              "ViewerProtocolPolicy": "allow-all",
+              "ViewerProtocolPolicy": "redirect-to-https",
             },
             {
               "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
@@ -15673,7 +15673,7 @@ function handler(event) {
               ],
               "PathPattern": "/stats.json",
               "TargetOriginId": "devConstructHubWebAppDistributionOrigin2A726FD66",
-              "ViewerProtocolPolicy": "allow-all",
+              "ViewerProtocolPolicy": "redirect-to-https",
             },
           ],
           "CustomErrorResponses": [
@@ -15703,7 +15703,7 @@ function handler(event) {
               },
             ],
             "TargetOriginId": "devConstructHubWebAppDistributionOrigin1FBBA04AE",
-            "ViewerProtocolPolicy": "allow-all",
+            "ViewerProtocolPolicy": "redirect-to-https",
           },
           "DefaultRootObject": "index.html",
           "Enabled": true,

--- a/src/webapp/index.ts
+++ b/src/webapp/index.ts
@@ -200,6 +200,7 @@ export class WebApp extends Construct {
           eventType: cloudfront.FunctionEventType.VIEWER_RESPONSE,
         },
       ],
+      viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
     };
 
     const websiteOrigin = new origins.S3Origin(this.bucket);


### PR DESCRIPTION
Fixes #1351 by making use of the [viewer protocol policy](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-defaultcachebehavior.html#cfn-cloudfront-distribution-defaultcachebehavior-viewerprotocolpolicy) of Cloudfront distributions.

* Enforces https redirects for clients that do not support HSTS header
* Applied to all behaviors of Cloudfront distribution

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*