### PR TITLE
fix: Feed builder lambda times out

### DIFF
--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -17,8 +17,8 @@ readily available.
 ### Storage Disaster
 
 Every deployment of Construct Hub automatically allocates a failover bucket for every bucket it creates and uses.
-The failover buckets are created with the exact same properites as the original buckets, but are not activated by default.
-They exist in order for operators to perform scheduled snapshots of the original data, in preparation for a disater.
+The failover buckets are created with the exact same properties as the original buckets, but are not activated by default.
+They exist in order for operators to perform scheduled snapshots of the original data, in preparation for a disaster.
 
 Construct Hub deployments provide CloudFormation outputs that list out the necessary commands you need to run in order to
 create those snapshots, and backup your data into the failover buckets.
@@ -57,12 +57,33 @@ When you restore the original data and are ready to go back to the original buck
 If the data loss/corruption is self-inflicted and continuous, i.e construct hub misbehaves and mutates its own data in a faulty manner.
 In this case switching to the failover won't help because the bad behavior will be applied on the failover buckets.
 
-#### When to use this procedure.
+#### When to use this procedure
 
 This procedure is designed to be used as a reaction to a single and isolated corruption/loss event, either by human error or by the system.
 **Its imperative you validate the corruption is not continuous!**
 
 ## :rotating_light: ConstructHub Alarms
+
+### `ConstructHub/FeedBuilder/Failure`
+
+#### Description
+
+This alarm goes off when the *Feed Builder Function* fails.
+
+#### Investigation
+
+The classical way of diagnosing Lambda Function failures is to dive into the
+logs in CloudWatch Logs. Those can easily be found by looking under the
+*Feed Builder Function* section of the backend dashboard, then clocking the *Search
+Log Group* button.
+
+For additional recommendations for diving into CloudWatch Logs, refer to the
+[Diving into Lambda Function logs in CloudWatch Logs][#lambda-log-dive] section.
+
+#### Resolution
+
+The alarm will automatically go back to green once the Lambda function stops
+failing.
 
 ### `ConstructHub/Ingestion/DLQNotEmpty`
 
@@ -112,7 +133,6 @@ default). Once the dead-letter queue has cleared up, disable that trigger again.
 > trigger and resume investigating. There may be a second problem that was
 > hidden by the original one.
 
-
 ### `ConstructHub/Ingestion/Failure`
 
 #### Description
@@ -145,7 +165,6 @@ queue, and caused the
 [`ConstructHub/Ingestion/DLQNotEmpty`](#constructhubingestiondlqnotempty) alarm
 to go off.
 
-
 ### `ConstructHub/InventoryCanary/Failures`
 
 #### Description
@@ -168,7 +187,6 @@ For additional recommendations for diving into CloudWatch Logs, refer to the
 
 The alarm will automatically go back to green once the Lambda function stops
 failing. No further action is needed.
-
 
 ### `ConstructHub/InventoryCanary/NotRunning`
 
@@ -201,7 +219,6 @@ request a quota increase.
 
 The alarm will automatically go back to green once the Lambda function starts
 running as scheduled again. No further action is needed.
-
 
 ### `ConstructHub/Orchestration/DLQ/NotEmpty`
 
@@ -276,7 +293,6 @@ Machine for re-processing by running the *Redrive DLQ* function, linked from the
 If messages are sent back to the dead-letter queue, perform the investigation
 steps again.
 
-
 ### `ConstructHub/Orchestration/CatalogBuilder/ShrinkingCatalog`
 
 #### Description
@@ -334,7 +350,6 @@ will always be different from the version ID you copied from):
   "VersionId": "YdnYvTCVDqRRFA.NFJjy36p0hxifMlkA"
 }
 ```
-
 
 ### `ConstructHub/Orchestration/Resource/ExecutionsFailed`
 
@@ -405,7 +420,6 @@ dead-letter queue need to be manually passed to new function invocations.
 > :construction: An automated way to replay messages from the dead-letter queue
 > will be provided in the future.
 
-
 ### `ConstructHub/Sources/CodeArtifact/*/Fowarder/Failures`
 
 #### Description
@@ -434,7 +448,6 @@ Some messages may have been sent to the dead-letter queue, and caused the
 [`ConstructHub/Sources/CodeArtifact/Fowarder/DLQNotEmpty`](#constructhubsourcescodeartifactfowarderdlqnotempty)
 alarm to go off.
 
-
 ### `ConstructHub/Sources/NpmJs/Follower/Failures`
 
 #### Description
@@ -458,7 +471,6 @@ For additional recommendations for diving into CloudWatch Logs, refer to the
 
 This alarm will automatically go back to green once the `NpmJs` follower stops
 failing. No futher action is needed.
-
 
 ### `ConstructHub/Sources/NpmJs/Follower/NotRunning`
 
@@ -553,7 +565,7 @@ For additional recommendations for diving into CloudWatch Logs, refer to the
 
 #### Resolution
 
-Once the root cause of the failures has been addressed, the messgaes from the
+Once the root cause of the failures has been addressed, the messages from the
 dead-letter queue can be automatically re-processed through the Lambda function
 by enabling the SQS Trigger that is automatically configured on the function,
 but is disabled by default.
@@ -566,7 +578,7 @@ disable the SQS Trigger again.
 ## :repeat: Bulk Re-processing
 
 In some cases, it might be useful to re-process indexed packages though parts or
-all of the back-end. This section descripts the options offered by the back-end
+all of the back-end. This section describes the options offered by the back-end
 system and when it is appropriate to use them.
 
 ### Overview
@@ -577,7 +589,7 @@ Two workflows are available for bulk-reprocessing:
    through the entire pipeline, including re-generating the `metadata.json`
    object. This is usually not necessary, unless an issue has been identified
    with many indexed packages (incorrect or missing `metadata.json`, incorrectly
-   identfied construct framework package, etc...). In most cases, re-generating
+   identified construct framework package, etc...). In most cases, re-generating
    the documentation is sufficient.
 1. The "re-generate all documentation" workflow re-runs all indexed packages
    through the documentation-generation process. This is useful when a new
@@ -612,7 +624,7 @@ object such as the following:
 }
 ```
 
-These informations may be useful to other operations as they observe the side
+This information may be useful to other operations as they observe the side
 effects of executing these workflows.
 
 --------------------------------------------------------------------------------
@@ -647,6 +659,7 @@ unable to evaluate the metric.
 
 Otherwise, look for traces of the package version in the logs of each step in
 the pipeline:
+
 - The NpmJs follower function
 - The NpmJs stager function
 - The backend orchestration workflow
@@ -695,12 +708,13 @@ to determine what is happening and resolve the problem.
 
 #### Resolution
 
-Once the canary starts unning normally again, the alarm will clear itself
+Once the canary starts running normally again, the alarm will clear itself
 without requiring any further intervention.
 
 ## :information_source: General Recommendations
 
 ### Diving into Lambda Function logs in CloudWatch Logs
+
 [#lambda-log-dive]: #diving-into-lambda-function-logs-in-cloudwatch-logs
 
 Diving into Lambda Function logs can seem daunting at first. The following are
@@ -713,9 +727,9 @@ often good first steps to take in such investigations:
   points.
 - Once you've homed in on a log entry from a failed Lambda execution, identify
   the request ID for this trace.
-  + Lambda log entries are formatted like so:
+  - Lambda log entries are formatted like so:
     `<timestamp> <request-id> <log-level> <message>`
-  + Extract the `request-id` segment (it is a UUID), and copy it in the search
+  - Extract the `request-id` segment (it is a UUID), and copy it in the search
     bar, surrounded by double quotes (`"`)
 - Remember, the search bar of CloudWatch Logs requires quoting if the searched
   string includes any character that is not alphanumeric or underscore.
@@ -729,6 +743,7 @@ often good first steps to take in such investigations:
   https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html
 
 ### Diving into ECS logs in CloudWatch Logs
+
 [#ecs-log-dive]: #diving-into-ecs-logs-in-cloudwatch-logs
 
 ECS tasks emit logs into CloudWatch under a log group called

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -2033,6 +2033,46 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       },
       "Type": "AWS::S3::BucketPolicy",
     },
+    "ConstructHubFeedBuilderFailureAlarmA4E080D6": {
+      "Properties": {
+        "AlarmActions": [
+          "arn:aws:sns:us-east-1:123456789012:mystack-mytopic-NZJ5JSMVGFIE",
+        ],
+        "AlarmDescription": {
+          "Fn::Join": [
+            "",
+            [
+              "The Feed Builder function is failing!
+
+RunBook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md
+
+Direct link to the function: /lambda/home#/functions/",
+              {
+                "Ref": "ConstructHubFeedBuilderReleaseNotesUpdateFeedBB0BA91D",
+              },
+            ],
+          ],
+        },
+        "AlarmName": "Test/ConstructHub/FeedBuilder/Failure",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "FunctionName",
+            "Value": {
+              "Ref": "ConstructHubFeedBuilderReleaseNotesUpdateFeedBB0BA91D",
+            },
+          },
+        ],
+        "EvaluationPeriods": 5,
+        "MetricName": "Errors",
+        "Namespace": "AWS/Lambda",
+        "Period": 300,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
     "ConstructHubFeedBuilderReleaseNotesUpdateFeedBB0BA91D": {
       "DependsOn": [
         "ConstructHubFeedBuilderReleaseNotesUpdateFeedServiceRoleDefaultPolicy5190869A",
@@ -2073,6 +2113,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           },
         },
         "Handler": "index.handler",
+        "MemorySize": 1024,
         "ReservedConcurrentExecutions": 1,
         "Role": {
           "Fn::GetAtt": [
@@ -4220,7 +4261,18 @@ Direct link to function: /lambda/home#/functions/",
           "Fn::Join": [
             "",
             [
-              "{"widgets":[{"type":"metric","width":24,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"Catalog Size Shrunk","region":"",
+              "{"widgets":[{"type":"metric","width":24,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"Feed builder failures","region":"",
+              {
+                "Ref": "AWS::Region",
+              },
+              "","annotations":{"alarms":["",
+              {
+                "Fn::GetAtt": [
+                  "ConstructHubFeedBuilderFailureAlarmA4E080D6",
+                  "Arn",
+                ],
+              },
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":6,"properties":{"view":"timeSeries","title":"Catalog Size Shrunk","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -4231,7 +4283,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":6,"properties":{"view":"timeSeries","title":"Backend Orchestration Failed","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":12,"properties":{"view":"timeSeries","title":"Backend Orchestration Failed","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -4242,7 +4294,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":12,"properties":{"view":"timeSeries","title":"Execution Failure Rate above 75%","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":18,"properties":{"view":"timeSeries","title":"Execution Failure Rate above 75%","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -4253,7 +4305,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":18,"properties":{"view":"timeSeries","title":"Ingestion failures","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":24,"properties":{"view":"timeSeries","title":"Ingestion failures","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -4264,7 +4316,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":24,"properties":{"view":"timeSeries","title":"Home Page Canary","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":30,"properties":{"view":"timeSeries","title":"Home Page Canary","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -4275,7 +4327,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":30,"properties":{"view":"timeSeries","title":"NpmJs/Follower Not Running","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":36,"properties":{"view":"timeSeries","title":"NpmJs/Follower Not Running","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -4286,7 +4338,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":36,"properties":{"view":"timeSeries","title":"NpmJs Follower Canary is not running or fails","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":42,"properties":{"view":"timeSeries","title":"NpmJs Follower Canary is not running or fails","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -14927,6 +14979,46 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       },
       "Type": "AWS::S3::BucketPolicy",
     },
+    "ConstructHubFeedBuilderFailureAlarmA4E080D6": {
+      "Properties": {
+        "AlarmActions": [
+          "arn:aws:sns:us-east-1:123456789012:mystack-mytopic-NZJ5JSMVGFIE",
+        ],
+        "AlarmDescription": {
+          "Fn::Join": [
+            "",
+            [
+              "The Feed Builder function is failing!
+
+RunBook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md
+
+Direct link to the function: /lambda/home#/functions/",
+              {
+                "Ref": "ConstructHubFeedBuilderReleaseNotesUpdateFeedBB0BA91D",
+              },
+            ],
+          ],
+        },
+        "AlarmName": "Test/ConstructHub/FeedBuilder/Failure",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "FunctionName",
+            "Value": {
+              "Ref": "ConstructHubFeedBuilderReleaseNotesUpdateFeedBB0BA91D",
+            },
+          },
+        ],
+        "EvaluationPeriods": 5,
+        "MetricName": "Errors",
+        "Namespace": "AWS/Lambda",
+        "Period": 300,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
     "ConstructHubFeedBuilderReleaseNotesUpdateFeedBB0BA91D": {
       "DependsOn": [
         "ConstructHubFeedBuilderReleaseNotesUpdateFeedServiceRoleDefaultPolicy5190869A",
@@ -14967,6 +15059,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           },
         },
         "Handler": "index.handler",
+        "MemorySize": 1024,
         "ReservedConcurrentExecutions": 1,
         "Role": {
           "Fn::GetAtt": [
@@ -17212,7 +17305,18 @@ Direct link to function: /lambda/home#/functions/",
           "Fn::Join": [
             "",
             [
-              "{"widgets":[{"type":"metric","width":24,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"Catalog Size Shrunk","region":"",
+              "{"widgets":[{"type":"metric","width":24,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"Feed builder failures","region":"",
+              {
+                "Ref": "AWS::Region",
+              },
+              "","annotations":{"alarms":["",
+              {
+                "Fn::GetAtt": [
+                  "ConstructHubFeedBuilderFailureAlarmA4E080D6",
+                  "Arn",
+                ],
+              },
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":6,"properties":{"view":"timeSeries","title":"Catalog Size Shrunk","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -17223,7 +17327,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":6,"properties":{"view":"timeSeries","title":"Backend Orchestration Failed","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":12,"properties":{"view":"timeSeries","title":"Backend Orchestration Failed","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -17234,7 +17338,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":12,"properties":{"view":"timeSeries","title":"Execution Failure Rate above 75%","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":18,"properties":{"view":"timeSeries","title":"Execution Failure Rate above 75%","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -17245,7 +17349,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":18,"properties":{"view":"timeSeries","title":"Ingestion failures","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":24,"properties":{"view":"timeSeries","title":"Ingestion failures","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -17256,7 +17360,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":24,"properties":{"view":"timeSeries","title":"Home Page Canary","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":30,"properties":{"view":"timeSeries","title":"Home Page Canary","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -17267,7 +17371,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":30,"properties":{"view":"timeSeries","title":"NpmJs/Follower Not Running","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":36,"properties":{"view":"timeSeries","title":"NpmJs/Follower Not Running","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -17278,7 +17382,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":36,"properties":{"view":"timeSeries","title":"NpmJs Follower Canary is not running or fails","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":42,"properties":{"view":"timeSeries","title":"NpmJs Follower Canary is not running or fails","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -27727,6 +27831,46 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       },
       "Type": "AWS::S3::BucketPolicy",
     },
+    "ConstructHubFeedBuilderFailureAlarmA4E080D6": {
+      "Properties": {
+        "AlarmActions": [
+          "arn:aws:sns:us-east-1:123456789012:mystack-mytopic-NZJ5JSMVGFIE",
+        ],
+        "AlarmDescription": {
+          "Fn::Join": [
+            "",
+            [
+              "The Feed Builder function is failing!
+
+RunBook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md
+
+Direct link to the function: /lambda/home#/functions/",
+              {
+                "Ref": "ConstructHubFeedBuilderReleaseNotesUpdateFeedBB0BA91D",
+              },
+            ],
+          ],
+        },
+        "AlarmName": "Test/ConstructHub/FeedBuilder/Failure",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "FunctionName",
+            "Value": {
+              "Ref": "ConstructHubFeedBuilderReleaseNotesUpdateFeedBB0BA91D",
+            },
+          },
+        ],
+        "EvaluationPeriods": 5,
+        "MetricName": "Errors",
+        "Namespace": "AWS/Lambda",
+        "Period": 300,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
     "ConstructHubFeedBuilderReleaseNotesUpdateFeedBB0BA91D": {
       "DependsOn": [
         "ConstructHubFeedBuilderReleaseNotesUpdateFeedServiceRoleDefaultPolicy5190869A",
@@ -27767,6 +27911,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           },
         },
         "Handler": "index.handler",
+        "MemorySize": 1024,
         "ReservedConcurrentExecutions": 1,
         "Role": {
           "Fn::GetAtt": [
@@ -29914,7 +30059,18 @@ Direct link to function: /lambda/home#/functions/",
           "Fn::Join": [
             "",
             [
-              "{"widgets":[{"type":"metric","width":24,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"Catalog Size Shrunk","region":"",
+              "{"widgets":[{"type":"metric","width":24,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"Feed builder failures","region":"",
+              {
+                "Ref": "AWS::Region",
+              },
+              "","annotations":{"alarms":["",
+              {
+                "Fn::GetAtt": [
+                  "ConstructHubFeedBuilderFailureAlarmA4E080D6",
+                  "Arn",
+                ],
+              },
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":6,"properties":{"view":"timeSeries","title":"Catalog Size Shrunk","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -29925,7 +30081,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":6,"properties":{"view":"timeSeries","title":"Backend Orchestration Failed","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":12,"properties":{"view":"timeSeries","title":"Backend Orchestration Failed","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -29936,7 +30092,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":12,"properties":{"view":"timeSeries","title":"Execution Failure Rate above 75%","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":18,"properties":{"view":"timeSeries","title":"Execution Failure Rate above 75%","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -29947,7 +30103,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":18,"properties":{"view":"timeSeries","title":"Ingestion failures","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":24,"properties":{"view":"timeSeries","title":"Ingestion failures","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -29958,7 +30114,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":24,"properties":{"view":"timeSeries","title":"Home Page Canary","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":30,"properties":{"view":"timeSeries","title":"Home Page Canary","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -29969,7 +30125,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":30,"properties":{"view":"timeSeries","title":"NpmJs/Follower Not Running","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":36,"properties":{"view":"timeSeries","title":"NpmJs/Follower Not Running","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -29980,7 +30136,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":36,"properties":{"view":"timeSeries","title":"NpmJs Follower Canary is not running or fails","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":42,"properties":{"view":"timeSeries","title":"NpmJs Follower Canary is not running or fails","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -40504,6 +40660,46 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       },
       "Type": "AWS::S3::BucketPolicy",
     },
+    "ConstructHubFeedBuilderFailureAlarmA4E080D6": {
+      "Properties": {
+        "AlarmActions": [
+          "arn:aws:sns:us-east-1:123456789012:mystack-mytopic-NZJ5JSMVGFIE",
+        ],
+        "AlarmDescription": {
+          "Fn::Join": [
+            "",
+            [
+              "The Feed Builder function is failing!
+
+RunBook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md
+
+Direct link to the function: /lambda/home#/functions/",
+              {
+                "Ref": "ConstructHubFeedBuilderReleaseNotesUpdateFeedBB0BA91D",
+              },
+            ],
+          ],
+        },
+        "AlarmName": "Test/ConstructHub/FeedBuilder/Failure",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "FunctionName",
+            "Value": {
+              "Ref": "ConstructHubFeedBuilderReleaseNotesUpdateFeedBB0BA91D",
+            },
+          },
+        ],
+        "EvaluationPeriods": 5,
+        "MetricName": "Errors",
+        "Namespace": "AWS/Lambda",
+        "Period": 300,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
     "ConstructHubFeedBuilderReleaseNotesUpdateFeedBB0BA91D": {
       "DependsOn": [
         "ConstructHubFeedBuilderReleaseNotesUpdateFeedServiceRoleDefaultPolicy5190869A",
@@ -40531,6 +40727,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           },
         },
         "Handler": "index.handler",
+        "MemorySize": 1024,
         "ReservedConcurrentExecutions": 1,
         "Role": {
           "Fn::GetAtt": [
@@ -42678,7 +42875,18 @@ Direct link to function: /lambda/home#/functions/",
           "Fn::Join": [
             "",
             [
-              "{"widgets":[{"type":"metric","width":24,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"Catalog Size Shrunk","region":"",
+              "{"widgets":[{"type":"metric","width":24,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"Feed builder failures","region":"",
+              {
+                "Ref": "AWS::Region",
+              },
+              "","annotations":{"alarms":["",
+              {
+                "Fn::GetAtt": [
+                  "ConstructHubFeedBuilderFailureAlarmA4E080D6",
+                  "Arn",
+                ],
+              },
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":6,"properties":{"view":"timeSeries","title":"Catalog Size Shrunk","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -42689,7 +42897,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":6,"properties":{"view":"timeSeries","title":"Backend Orchestration Failed","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":12,"properties":{"view":"timeSeries","title":"Backend Orchestration Failed","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -42700,7 +42908,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":12,"properties":{"view":"timeSeries","title":"Execution Failure Rate above 75%","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":18,"properties":{"view":"timeSeries","title":"Execution Failure Rate above 75%","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -42711,7 +42919,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":18,"properties":{"view":"timeSeries","title":"Ingestion failures","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":24,"properties":{"view":"timeSeries","title":"Ingestion failures","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -42722,7 +42930,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":24,"properties":{"view":"timeSeries","title":"ACM Certificate Expiry","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":30,"properties":{"view":"timeSeries","title":"ACM Certificate Expiry","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -42733,7 +42941,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":30,"properties":{"view":"timeSeries","title":"Endpoint Certificate Expiry","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":36,"properties":{"view":"timeSeries","title":"Endpoint Certificate Expiry","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -42744,7 +42952,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":36,"properties":{"view":"timeSeries","title":"Home Page Canary","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":42,"properties":{"view":"timeSeries","title":"Home Page Canary","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -42755,7 +42963,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":42,"properties":{"view":"timeSeries","title":"NpmJs/Follower Not Running","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":48,"properties":{"view":"timeSeries","title":"NpmJs/Follower Not Running","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -42766,7 +42974,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":48,"properties":{"view":"timeSeries","title":"NpmJs Follower Canary is not running or fails","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":54,"properties":{"view":"timeSeries","title":"NpmJs Follower Canary is not running or fails","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -53464,6 +53672,46 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       },
       "Type": "AWS::S3::BucketPolicy",
     },
+    "ConstructHubFeedBuilderFailureAlarmA4E080D6": {
+      "Properties": {
+        "AlarmActions": [
+          "arn:aws:sns:us-east-1:123456789012:mystack-mytopic-NZJ5JSMVGFIE",
+        ],
+        "AlarmDescription": {
+          "Fn::Join": [
+            "",
+            [
+              "The Feed Builder function is failing!
+
+RunBook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md
+
+Direct link to the function: /lambda/home#/functions/",
+              {
+                "Ref": "ConstructHubFeedBuilderReleaseNotesUpdateFeedBB0BA91D",
+              },
+            ],
+          ],
+        },
+        "AlarmName": "Test/ConstructHub/FeedBuilder/Failure",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "FunctionName",
+            "Value": {
+              "Ref": "ConstructHubFeedBuilderReleaseNotesUpdateFeedBB0BA91D",
+            },
+          },
+        ],
+        "EvaluationPeriods": 5,
+        "MetricName": "Errors",
+        "Namespace": "AWS/Lambda",
+        "Period": 300,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
     "ConstructHubFeedBuilderReleaseNotesUpdateFeedBB0BA91D": {
       "DependsOn": [
         "ConstructHubFeedBuilderReleaseNotesUpdateFeedServiceRoleDefaultPolicy5190869A",
@@ -53504,6 +53752,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           },
         },
         "Handler": "index.handler",
+        "MemorySize": 1024,
         "ReservedConcurrentExecutions": 1,
         "Role": {
           "Fn::GetAtt": [
@@ -55777,7 +56026,18 @@ Direct link to function: /lambda/home#/functions/",
           "Fn::Join": [
             "",
             [
-              "{"widgets":[{"type":"metric","width":24,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"Catalog Size Shrunk","region":"",
+              "{"widgets":[{"type":"metric","width":24,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"Feed builder failures","region":"",
+              {
+                "Ref": "AWS::Region",
+              },
+              "","annotations":{"alarms":["",
+              {
+                "Fn::GetAtt": [
+                  "ConstructHubFeedBuilderFailureAlarmA4E080D6",
+                  "Arn",
+                ],
+              },
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":6,"properties":{"view":"timeSeries","title":"Catalog Size Shrunk","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -55788,7 +56048,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":6,"properties":{"view":"timeSeries","title":"Backend Orchestration Failed","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":12,"properties":{"view":"timeSeries","title":"Backend Orchestration Failed","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -55799,7 +56059,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":12,"properties":{"view":"timeSeries","title":"Execution Failure Rate above 75%","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":18,"properties":{"view":"timeSeries","title":"Execution Failure Rate above 75%","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -55810,7 +56070,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":18,"properties":{"view":"timeSeries","title":"Ingestion failures","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":24,"properties":{"view":"timeSeries","title":"Ingestion failures","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -55821,7 +56081,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":24,"properties":{"view":"timeSeries","title":"Home Page Canary","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":30,"properties":{"view":"timeSeries","title":"Home Page Canary","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -55832,7 +56092,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":30,"properties":{"view":"timeSeries","title":"NpmJs/Follower Not Running","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":36,"properties":{"view":"timeSeries","title":"NpmJs/Follower Not Running","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -55843,7 +56103,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":36,"properties":{"view":"timeSeries","title":"NpmJs Follower Canary is not running or fails","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":42,"properties":{"view":"timeSeries","title":"NpmJs Follower Canary is not running or fails","region":"",
               {
                 "Ref": "AWS::Region",
               },

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -2497,6 +2497,43 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       },
       "Type": "AWS::S3::BucketPolicy",
     },
+    "ConstructHubFeedBuilderFailureAlarmA4E080D6": {
+      "Properties": {
+        "AlarmDescription": {
+          "Fn::Join": [
+            "",
+            [
+              "The Feed Builder function is failing!
+
+RunBook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md
+
+Direct link to the function: /lambda/home#/functions/",
+              {
+                "Ref": "ConstructHubFeedBuilderReleaseNotesUpdateFeedBB0BA91D",
+              },
+            ],
+          ],
+        },
+        "AlarmName": "dev/ConstructHub/FeedBuilder/Failure",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "FunctionName",
+            "Value": {
+              "Ref": "ConstructHubFeedBuilderReleaseNotesUpdateFeedBB0BA91D",
+            },
+          },
+        ],
+        "EvaluationPeriods": 5,
+        "MetricName": "Errors",
+        "Namespace": "AWS/Lambda",
+        "Period": 300,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
     "ConstructHubFeedBuilderReleaseNotesUpdateFeedBB0BA91D": {
       "DependsOn": [
         "ConstructHubFeedBuilderReleaseNotesUpdateFeedServiceRoleDefaultPolicy5190869A",
@@ -2539,6 +2576,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           },
         },
         "Handler": "index.handler",
+        "MemorySize": 1024,
         "ReservedConcurrentExecutions": 1,
         "Role": {
           "Fn::GetAtt": [
@@ -4820,7 +4858,18 @@ Direct link to function: /lambda/home#/functions/",
           "Fn::Join": [
             "",
             [
-              "{"widgets":[{"type":"metric","width":24,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"Catalog Size Shrunk","region":"",
+              "{"widgets":[{"type":"metric","width":24,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"Feed builder failures","region":"",
+              {
+                "Ref": "AWS::Region",
+              },
+              "","annotations":{"alarms":["",
+              {
+                "Fn::GetAtt": [
+                  "ConstructHubFeedBuilderFailureAlarmA4E080D6",
+                  "Arn",
+                ],
+              },
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":6,"properties":{"view":"timeSeries","title":"Catalog Size Shrunk","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -4831,7 +4880,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":6,"properties":{"view":"timeSeries","title":"Backend Orchestration Failed","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":12,"properties":{"view":"timeSeries","title":"Backend Orchestration Failed","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -4842,7 +4891,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":12,"properties":{"view":"timeSeries","title":"Execution Failure Rate above 75%","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":18,"properties":{"view":"timeSeries","title":"Execution Failure Rate above 75%","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -4853,7 +4902,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":18,"properties":{"view":"timeSeries","title":"ReleaseNotes generation Failure","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":24,"properties":{"view":"timeSeries","title":"ReleaseNotes generation Failure","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -4864,7 +4913,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":24,"properties":{"view":"timeSeries","title":"ReleaseNotes Github credential invalid","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":30,"properties":{"view":"timeSeries","title":"ReleaseNotes Github credential invalid","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -4875,7 +4924,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":30,"properties":{"view":"timeSeries","title":"Ingestion failures","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":36,"properties":{"view":"timeSeries","title":"Ingestion failures","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -4886,7 +4935,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":36,"properties":{"view":"timeSeries","title":"Home Page Canary","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":42,"properties":{"view":"timeSeries","title":"Home Page Canary","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -4897,7 +4946,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":42,"properties":{"view":"timeSeries","title":"NpmJs/Follower Not Running","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":48,"properties":{"view":"timeSeries","title":"NpmJs/Follower Not Running","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -4908,7 +4957,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":48,"properties":{"view":"timeSeries","title":"NpmJs Follower Canary is not running or fails","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":54,"properties":{"view":"timeSeries","title":"NpmJs Follower Canary is not running or fails","region":"",
               {
                 "Ref": "AWS::Region",
               },

--- a/src/construct-hub.ts
+++ b/src/construct-hub.ts
@@ -391,6 +391,7 @@ export class ConstructHub extends Construct implements iam.IGrantable {
       overviewDashboard,
       feedDescription: props.feedConfiguration?.feedDescription,
       feedTitle: props.feedConfiguration?.feedTitle,
+      monitoring: this.monitoring,
     });
 
     const orchestration = new Orchestration(this, 'Orchestration', {


### PR DESCRIPTION
## Problem

The feed builder lambda was timing out and consistently failing causing the atom feed to not be updated.

## Solution

After investigation, it was determined the default memory, 128MB, was insufficient for the lambda to correctly execute. This PR increases the memory to 1024MB, a number verified by dev testing, and adding an alarm such that future issues will be flagged.

### Investigation notes

Below you can see the metrics from the lambda function before and after increasing the memory allocation, approximately 21:45UTC.

<img width="1402" alt="Screenshot 2024-01-30 at 3 35 59 PM" src="https://github.com/cdklabs/construct-hub/assets/139287474/42e47e4e-aaef-4daa-91a1-e3f637dfd152">

Note that when the issue was resolved the invocations, throttles and events spike, then return to a low steady state. I believe this is due to the long backlog of work the lambda had to work through as it hasn't run correctly in ~seven months.

This fixes #1238.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*