### PR TITLE
fix: Updating SLA-Breached evaluation periods

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -9604,7 +9604,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
 Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md",
         "AlarmName": "Test/ConstructHub/Sources/NpmJs/Canary/SLA-Breached",
         "ComparisonOperator": "GreaterThanThreshold",
-        "EvaluationPeriods": 2,
+        "EvaluationPeriods": 4,
         "Metrics": [
           {
             "Expression": "IF(FILL(mLag, REPEAT) < 900, MAX([mDwell, mTTC]))",
@@ -22721,7 +22721,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
 Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md",
         "AlarmName": "Test/ConstructHub/Sources/NpmJs/Canary/SLA-Breached",
         "ComparisonOperator": "GreaterThanThreshold",
-        "EvaluationPeriods": 2,
+        "EvaluationPeriods": 4,
         "Metrics": [
           {
             "Expression": "IF(FILL(mLag, REPEAT) < 900, MAX([mDwell, mTTC]))",
@@ -35402,7 +35402,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
 Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md",
         "AlarmName": "Test/ConstructHub/Sources/NpmJs/Canary/SLA-Breached",
         "ComparisonOperator": "GreaterThanThreshold",
-        "EvaluationPeriods": 2,
+        "EvaluationPeriods": 4,
         "Metrics": [
           {
             "Expression": "IF(FILL(mLag, REPEAT) < 900, MAX([mDwell, mTTC]))",
@@ -48227,7 +48227,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
 Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md",
         "AlarmName": "Test/ConstructHub/Sources/NpmJs/Canary/SLA-Breached",
         "ComparisonOperator": "GreaterThanThreshold",
-        "EvaluationPeriods": 2,
+        "EvaluationPeriods": 4,
         "Metrics": [
           {
             "Expression": "IF(FILL(mLag, REPEAT) < 900, MAX([mDwell, mTTC]))",
@@ -61059,7 +61059,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
 Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md",
         "AlarmName": "Test/ConstructHub/Sources/NpmJs/Canary/SLA-Breached",
         "ComparisonOperator": "GreaterThanThreshold",
-        "EvaluationPeriods": 2,
+        "EvaluationPeriods": 4,
         "Metrics": [
           {
             "Expression": "IF(FILL(mLag, REPEAT) < 900, MAX([mDwell, mTTC]))",

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -10894,7 +10894,7 @@ Direct link to the function: /lambda/home#/functions/",
 Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md",
         "AlarmName": "dev/ConstructHub/Sources/NpmJs/Canary/SLA-Breached",
         "ComparisonOperator": "GreaterThanThreshold",
-        "EvaluationPeriods": 2,
+        "EvaluationPeriods": 4,
         "Metrics": [
           {
             "Expression": "IF(FILL(mLag, REPEAT) < 900, MAX([mDwell, mTTC]))",

--- a/src/package-sources/npmjs.ts
+++ b/src/package-sources/npmjs.ts
@@ -41,7 +41,7 @@ import { S3StorageFactory } from '../s3/storage';
 /**
  * The periodicity at which the NpmJs follower will run. This MUST be a valid
  * CloudWatch Metric grain, as this will also be the period of the CloudWatch
- * alarm that montiors the health of the follower.
+ * alarm that monitors the health of the follower.
  */
 const FOLLOWER_RUN_RATE = Duration.minutes(5);
 
@@ -552,7 +552,7 @@ export class NpmJs implements IPackageSource {
     // Finally - the "not running" alarm depends on the schedule (it won't run until the schedule
     // exists!), and the schedule depends on the failure alarm existing (we don't want it to run
     // before we can know it is failing). This means the returned `IDependable` effectively ensures
-    // all alarms have been provisionned already! Isn't it nice!
+    // all alarms have been provisioned already! Isn't it nice!
     notRunningAlarm.node.addDependency(schedule);
     schedule.node.addDependency(failureAlarm);
   }
@@ -581,7 +581,7 @@ export class NpmJs implements IPackageSource {
       // able to register new canary package versions within the SLA. In such cases, there is
       // nothing that can be done except for waiting until the replica has finally caught up. We
       // hence suppress the alarm if the replica lag is getting within 3 evaluation periods of the
-      // visbility SLA.
+      // visibility SLA.
       expression: `IF(FILL(mLag, REPEAT) < ${Math.max(
         visibilitySla.toSeconds() - 3 * period.toSeconds(),
         3 * period.toSeconds()
@@ -599,7 +599,7 @@ export class NpmJs implements IPackageSource {
         `Runbook: ${RUNBOOK_URL}`,
       ].join('\n'),
       comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
-      evaluationPeriods: 2,
+      evaluationPeriods: 4,
       treatMissingData: TreatMissingData.NOT_BREACHING,
       threshold: visibilitySla.toSeconds(),
     });


### PR DESCRIPTION
## Problem

We are observing that upon resolution of npmjs replica lag, the `SLA-Breached` alarm triggers during the period of time where the application consumes the updates from the backlog. The alarm is self resolving as there is no issue with the backend.

## Solution

Update the evaluation period from 2 (10 minutes) to 4 (20 minutes) to allow for the system to catch up before reporting an alarm.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*