### PR TITLE
fix: Update DLQNotEmpty evaluationPeriods

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -2462,7 +2462,7 @@ Direct link to the function: /lambda/home#/functions/",
         },
         "AlarmName": "Test/ConstructHub/Ingestion/DLQNotEmpty",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
-        "EvaluationPeriods": 1,
+        "EvaluationPeriods": 2,
         "Metrics": [
           {
             "Expression": "m1 + m2",
@@ -10600,7 +10600,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
         },
         "AlarmName": "Test/ConstructHub/Sources/NpmJs/Stager/DLQNotEmpty",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
-        "EvaluationPeriods": 1,
+        "EvaluationPeriods": 2,
         "Metrics": [
           {
             "Expression": "mVisible + mHidden",
@@ -15426,7 +15426,7 @@ Direct link to the function: /lambda/home#/functions/",
         },
         "AlarmName": "Test/ConstructHub/Ingestion/DLQNotEmpty",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
-        "EvaluationPeriods": 1,
+        "EvaluationPeriods": 2,
         "Metrics": [
           {
             "Expression": "m1 + m2",
@@ -23717,7 +23717,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
         },
         "AlarmName": "Test/ConstructHub/Sources/NpmJs/Stager/DLQNotEmpty",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
-        "EvaluationPeriods": 1,
+        "EvaluationPeriods": 2,
         "Metrics": [
           {
             "Expression": "mVisible + mHidden",
@@ -28260,7 +28260,7 @@ Direct link to the function: /lambda/home#/functions/",
         },
         "AlarmName": "Test/ConstructHub/Ingestion/DLQNotEmpty",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
-        "EvaluationPeriods": 1,
+        "EvaluationPeriods": 2,
         "Metrics": [
           {
             "Expression": "m1 + m2",
@@ -36398,7 +36398,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
         },
         "AlarmName": "Test/ConstructHub/Sources/NpmJs/Stager/DLQNotEmpty",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
-        "EvaluationPeriods": 1,
+        "EvaluationPeriods": 2,
         "Metrics": [
           {
             "Expression": "mVisible + mHidden",
@@ -41076,7 +41076,7 @@ Direct link to the function: /lambda/home#/functions/",
         },
         "AlarmName": "Test/ConstructHub/Ingestion/DLQNotEmpty",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
-        "EvaluationPeriods": 1,
+        "EvaluationPeriods": 2,
         "Metrics": [
           {
             "Expression": "m1 + m2",
@@ -49223,7 +49223,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
         },
         "AlarmName": "Test/ConstructHub/Sources/NpmJs/Stager/DLQNotEmpty",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
-        "EvaluationPeriods": 1,
+        "EvaluationPeriods": 2,
         "Metrics": [
           {
             "Expression": "mVisible + mHidden",
@@ -54101,7 +54101,7 @@ Direct link to the function: /lambda/home#/functions/",
         },
         "AlarmName": "Test/ConstructHub/Ingestion/DLQNotEmpty",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
-        "EvaluationPeriods": 1,
+        "EvaluationPeriods": 2,
         "Metrics": [
           {
             "Expression": "m1 + m2",
@@ -62055,7 +62055,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
         },
         "AlarmName": "Test/ConstructHub/Sources/NpmJs/Stager/DLQNotEmpty",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
-        "EvaluationPeriods": 1,
+        "EvaluationPeriods": 2,
         "Metrics": [
           {
             "Expression": "mVisible + mHidden",

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -2946,7 +2946,7 @@ Direct link to the function: /lambda/home#/functions/",
         },
         "AlarmName": "dev/ConstructHub/Ingestion/DLQNotEmpty",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
-        "EvaluationPeriods": 1,
+        "EvaluationPeriods": 2,
         "Metrics": [
           {
             "Expression": "m1 + m2",
@@ -11884,7 +11884,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
         },
         "AlarmName": "dev/ConstructHub/Sources/NpmJs/Stager/DLQNotEmpty",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
-        "EvaluationPeriods": 1,
+        "EvaluationPeriods": 2,
         "Metrics": [
           {
             "Expression": "mVisible + mHidden",

--- a/src/backend/ingestion/index.ts
+++ b/src/backend/ingestion/index.ts
@@ -304,7 +304,7 @@ export class Ingestion extends Construct implements IGrantable {
         ].join('\n'),
         comparisonOperator:
           ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
-        evaluationPeriods: 1,
+        evaluationPeriods: 2,
         threshold: 1,
         // SQS does not emit metrics if the queue has been empty for a while, which is GOOD.
         treatMissingData: TreatMissingData.NOT_BREACHING,

--- a/src/package-sources/npmjs.ts
+++ b/src/package-sources/npmjs.ts
@@ -540,7 +540,7 @@ export class NpmJs implements IPackageSource {
         `Runbook: ${RUNBOOK_URL}`,
       ].join('/n'),
       comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
-      evaluationPeriods: 1,
+      evaluationPeriods: 2,
       threshold: 1,
       treatMissingData: TreatMissingData.NOT_BREACHING,
     });


### PR DESCRIPTION
 ## Problem

 We are observing that the `DLQNotEmpty` alarms for both staging and ingestion are being regularly triggered. They auto-resolve after a single data point and do not leave meaningful info.

 ## Solution

 Update the evaluation period from 1 (5 minutes) to 2 (10 minutes) to allow the issue to auto-resolve without alarming.
 
 _By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_

This was original authored as #1401, but needed the snapshots updated.