### PR TITLE
fix(orchestration): handle new jsii-docgen transliteration error

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -1982,7 +1982,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "7a3654dd34b9e3f81f340cea3327eb1e8089449881225e55e76fb86c87403b64.zip",
+          "S3Key": "adc968265edfc49e5f153ec2f04b9ab181f039f99c730ada3b42d3699e689488.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -2210,7 +2210,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "305ae7e73e8ae5630d7c345f44903b9377db737cd4a7d28c43e4709f1e34a779.zip",
+          "S3Key": "af987f9430783f68b7d6f0b8fae90dda93e0ce2e0a9f79d4254bab88bf5a5e16.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": {
@@ -2636,7 +2636,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5fc37870326e0f818f6baac7c0d2ab25bf278030a366f3a365a3fad846aa2c23.zip",
+          "S3Key": "5bdecd559f0bb448b2c3a8dbbad93c959e80f6701b897d3954be4e6f8b4b1d3e.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -3302,7 +3302,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1ce0ff7a8d0ab6e2c2ac8e16a810e6bdf897676761a5c1cbf023448162e31b73.zip",
+          "S3Key": "ff5880beef3ba20fa5b666f07a87cbd542e8fd71f541e8fce69167574c4a7b30.zip",
         },
         "Description": "[ConstructHub/Inventory] A canary that periodically inspects the list of indexed packages",
         "Environment": {
@@ -4799,7 +4799,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2b597ca4b3eb67f1e54ceb41bdbd922882ca9737ad57215fedbb5879bfb25295.zip",
+          "S3Key": "21a9e4e9eef44a3ea3e5bb0b325435b9e6f594f80ee6531a594cf3a71bb7ffc0.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -5867,7 +5867,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d355e39fbde46b541ae05618d065eabb53246304a348db37b52c6a1a10746c05.zip",
+          "S3Key": "48117e416dde2f93ac3a350d403af0bc82b3eb7bb8ff3bb29ee11e743fb5cb32.zip",
         },
         "Description": "[ConstructHub/Orchestration/NeedsCatalogUpdate] Determines whether a package version requires a catalog update",
         "Environment": {
@@ -6805,7 +6805,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:5dcee5daa391e0e5efbf1dd7bcccab0e63f59baf018b388d87504c7bc3e683ca",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:0d9ea6e069b4c6a3cac0e6fa146e52ade1fa03bfd7d94d791d2099d347563278",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -14809,7 +14809,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "7a3654dd34b9e3f81f340cea3327eb1e8089449881225e55e76fb86c87403b64.zip",
+          "S3Key": "adc968265edfc49e5f153ec2f04b9ab181f039f99c730ada3b42d3699e689488.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -15037,7 +15037,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "305ae7e73e8ae5630d7c345f44903b9377db737cd4a7d28c43e4709f1e34a779.zip",
+          "S3Key": "af987f9430783f68b7d6f0b8fae90dda93e0ce2e0a9f79d4254bab88bf5a5e16.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": {
@@ -15481,7 +15481,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5fc37870326e0f818f6baac7c0d2ab25bf278030a366f3a365a3fad846aa2c23.zip",
+          "S3Key": "5bdecd559f0bb448b2c3a8dbbad93c959e80f6701b897d3954be4e6f8b4b1d3e.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -16227,7 +16227,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1ce0ff7a8d0ab6e2c2ac8e16a810e6bdf897676761a5c1cbf023448162e31b73.zip",
+          "S3Key": "ff5880beef3ba20fa5b666f07a87cbd542e8fd71f541e8fce69167574c4a7b30.zip",
         },
         "Description": "[ConstructHub/Inventory] A canary that periodically inspects the list of indexed packages",
         "Environment": {
@@ -17724,7 +17724,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2b597ca4b3eb67f1e54ceb41bdbd922882ca9737ad57215fedbb5879bfb25295.zip",
+          "S3Key": "21a9e4e9eef44a3ea3e5bb0b325435b9e6f594f80ee6531a594cf3a71bb7ffc0.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -18792,7 +18792,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d355e39fbde46b541ae05618d065eabb53246304a348db37b52c6a1a10746c05.zip",
+          "S3Key": "48117e416dde2f93ac3a350d403af0bc82b3eb7bb8ff3bb29ee11e743fb5cb32.zip",
         },
         "Description": "[ConstructHub/Orchestration/NeedsCatalogUpdate] Determines whether a package version requires a catalog update",
         "Environment": {
@@ -19757,7 +19757,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:5dcee5daa391e0e5efbf1dd7bcccab0e63f59baf018b388d87504c7bc3e683ca",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:0d9ea6e069b4c6a3cac0e6fa146e52ade1fa03bfd7d94d791d2099d347563278",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -27550,7 +27550,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "7a3654dd34b9e3f81f340cea3327eb1e8089449881225e55e76fb86c87403b64.zip",
+          "S3Key": "adc968265edfc49e5f153ec2f04b9ab181f039f99c730ada3b42d3699e689488.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -27778,7 +27778,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "305ae7e73e8ae5630d7c345f44903b9377db737cd4a7d28c43e4709f1e34a779.zip",
+          "S3Key": "af987f9430783f68b7d6f0b8fae90dda93e0ce2e0a9f79d4254bab88bf5a5e16.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": {
@@ -28204,7 +28204,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5fc37870326e0f818f6baac7c0d2ab25bf278030a366f3a365a3fad846aa2c23.zip",
+          "S3Key": "5bdecd559f0bb448b2c3a8dbbad93c959e80f6701b897d3954be4e6f8b4b1d3e.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -28870,7 +28870,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1ce0ff7a8d0ab6e2c2ac8e16a810e6bdf897676761a5c1cbf023448162e31b73.zip",
+          "S3Key": "ff5880beef3ba20fa5b666f07a87cbd542e8fd71f541e8fce69167574c4a7b30.zip",
         },
         "Description": "[ConstructHub/Inventory] A canary that periodically inspects the list of indexed packages",
         "Environment": {
@@ -30367,7 +30367,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2b597ca4b3eb67f1e54ceb41bdbd922882ca9737ad57215fedbb5879bfb25295.zip",
+          "S3Key": "21a9e4e9eef44a3ea3e5bb0b325435b9e6f594f80ee6531a594cf3a71bb7ffc0.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -31435,7 +31435,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d355e39fbde46b541ae05618d065eabb53246304a348db37b52c6a1a10746c05.zip",
+          "S3Key": "48117e416dde2f93ac3a350d403af0bc82b3eb7bb8ff3bb29ee11e743fb5cb32.zip",
         },
         "Description": "[ConstructHub/Orchestration/NeedsCatalogUpdate] Determines whether a package version requires a catalog update",
         "Environment": {
@@ -32373,7 +32373,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:5dcee5daa391e0e5efbf1dd7bcccab0e63f59baf018b388d87504c7bc3e683ca",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:0d9ea6e069b4c6a3cac0e6fa146e52ade1fa03bfd7d94d791d2099d347563278",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -40260,7 +40260,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "7a3654dd34b9e3f81f340cea3327eb1e8089449881225e55e76fb86c87403b64.zip",
+          "S3Key": "adc968265edfc49e5f153ec2f04b9ab181f039f99c730ada3b42d3699e689488.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -40475,7 +40475,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "305ae7e73e8ae5630d7c345f44903b9377db737cd4a7d28c43e4709f1e34a779.zip",
+          "S3Key": "af987f9430783f68b7d6f0b8fae90dda93e0ce2e0a9f79d4254bab88bf5a5e16.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": {
@@ -40901,7 +40901,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5fc37870326e0f818f6baac7c0d2ab25bf278030a366f3a365a3fad846aa2c23.zip",
+          "S3Key": "5bdecd559f0bb448b2c3a8dbbad93c959e80f6701b897d3954be4e6f8b4b1d3e.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -41567,7 +41567,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1ce0ff7a8d0ab6e2c2ac8e16a810e6bdf897676761a5c1cbf023448162e31b73.zip",
+          "S3Key": "ff5880beef3ba20fa5b666f07a87cbd542e8fd71f541e8fce69167574c4a7b30.zip",
         },
         "Description": "[ConstructHub/Inventory] A canary that periodically inspects the list of indexed packages",
         "Environment": {
@@ -43086,7 +43086,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2b597ca4b3eb67f1e54ceb41bdbd922882ca9737ad57215fedbb5879bfb25295.zip",
+          "S3Key": "21a9e4e9eef44a3ea3e5bb0b325435b9e6f594f80ee6531a594cf3a71bb7ffc0.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -44154,7 +44154,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d355e39fbde46b541ae05618d065eabb53246304a348db37b52c6a1a10746c05.zip",
+          "S3Key": "48117e416dde2f93ac3a350d403af0bc82b3eb7bb8ff3bb29ee11e743fb5cb32.zip",
         },
         "Description": "[ConstructHub/Orchestration/NeedsCatalogUpdate] Determines whether a package version requires a catalog update",
         "Environment": {
@@ -45092,7 +45092,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:5dcee5daa391e0e5efbf1dd7bcccab0e63f59baf018b388d87504c7bc3e683ca",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:0d9ea6e069b4c6a3cac0e6fa146e52ade1fa03bfd7d94d791d2099d347563278",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -53153,7 +53153,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "7a3654dd34b9e3f81f340cea3327eb1e8089449881225e55e76fb86c87403b64.zip",
+          "S3Key": "adc968265edfc49e5f153ec2f04b9ab181f039f99c730ada3b42d3699e689488.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -53381,7 +53381,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "305ae7e73e8ae5630d7c345f44903b9377db737cd4a7d28c43e4709f1e34a779.zip",
+          "S3Key": "af987f9430783f68b7d6f0b8fae90dda93e0ce2e0a9f79d4254bab88bf5a5e16.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": {
@@ -53807,7 +53807,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5fc37870326e0f818f6baac7c0d2ab25bf278030a366f3a365a3fad846aa2c23.zip",
+          "S3Key": "5bdecd559f0bb448b2c3a8dbbad93c959e80f6701b897d3954be4e6f8b4b1d3e.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -54599,7 +54599,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1ce0ff7a8d0ab6e2c2ac8e16a810e6bdf897676761a5c1cbf023448162e31b73.zip",
+          "S3Key": "ff5880beef3ba20fa5b666f07a87cbd542e8fd71f541e8fce69167574c4a7b30.zip",
         },
         "Description": "[ConstructHub/Inventory] A canary that periodically inspects the list of indexed packages",
         "Environment": {
@@ -56125,7 +56125,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2b597ca4b3eb67f1e54ceb41bdbd922882ca9737ad57215fedbb5879bfb25295.zip",
+          "S3Key": "21a9e4e9eef44a3ea3e5bb0b325435b9e6f594f80ee6531a594cf3a71bb7ffc0.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -56786,7 +56786,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d355e39fbde46b541ae05618d065eabb53246304a348db37b52c6a1a10746c05.zip",
+          "S3Key": "48117e416dde2f93ac3a350d403af0bc82b3eb7bb8ff3bb29ee11e743fb5cb32.zip",
         },
         "Description": "[ConstructHub/Orchestration/NeedsCatalogUpdate] Determines whether a package version requires a catalog update",
         "Environment": {
@@ -57730,7 +57730,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:5dcee5daa391e0e5efbf1dd7bcccab0e63f59baf018b388d87504c7bc3e683ca",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:0d9ea6e069b4c6a3cac0e6fa146e52ade1fa03bfd7d94d791d2099d347563278",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",

--- a/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
+++ b/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
@@ -118,7 +118,7 @@ exports[`CodeArtifact repository 1`] = `
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:5dcee5daa391e0e5efbf1dd7bcccab0e63f59baf018b388d87504c7bc3e683ca",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:0d9ea6e069b4c6a3cac0e6fa146e52ade1fa03bfd7d94d791d2099d347563278",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -2433,7 +2433,7 @@ exports[`VPC Endpoints 1`] = `
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:5dcee5daa391e0e5efbf1dd7bcccab0e63f59baf018b388d87504c7bc3e683ca",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:0d9ea6e069b4c6a3cac0e6fa146e52ade1fa03bfd7d94d791d2099d347563278",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -4799,7 +4799,7 @@ exports[`VPC Endpoints and CodeArtifact repository 1`] = `
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:5dcee5daa391e0e5efbf1dd7bcccab0e63f59baf018b388d87504c7bc3e683ca",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:0d9ea6e069b4c6a3cac0e6fa146e52ade1fa03bfd7d94d791d2099d347563278",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -7110,7 +7110,7 @@ exports[`basic use 1`] = `
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:5dcee5daa391e0e5efbf1dd7bcccab0e63f59baf018b388d87504c7bc3e683ca",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:0d9ea6e069b4c6a3cac0e6fa146e52ade1fa03bfd7d94d791d2099d347563278",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -2435,7 +2435,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "7a3654dd34b9e3f81f340cea3327eb1e8089449881225e55e76fb86c87403b64.zip",
+          "S3Key": "adc968265edfc49e5f153ec2f04b9ab181f039f99c730ada3b42d3699e689488.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -2665,7 +2665,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "305ae7e73e8ae5630d7c345f44903b9377db737cd4a7d28c43e4709f1e34a779.zip",
+          "S3Key": "af987f9430783f68b7d6f0b8fae90dda93e0ce2e0a9f79d4254bab88bf5a5e16.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": {
@@ -3109,7 +3109,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5fc37870326e0f818f6baac7c0d2ab25bf278030a366f3a365a3fad846aa2c23.zip",
+          "S3Key": "5bdecd559f0bb448b2c3a8dbbad93c959e80f6701b897d3954be4e6f8b4b1d3e.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -3868,7 +3868,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1ce0ff7a8d0ab6e2c2ac8e16a810e6bdf897676761a5c1cbf023448162e31b73.zip",
+          "S3Key": "ff5880beef3ba20fa5b666f07a87cbd542e8fd71f541e8fce69167574c4a7b30.zip",
         },
         "Description": "[ConstructHub/Inventory] A canary that periodically inspects the list of indexed packages",
         "Environment": {
@@ -5408,7 +5408,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2b597ca4b3eb67f1e54ceb41bdbd922882ca9737ad57215fedbb5879bfb25295.zip",
+          "S3Key": "21a9e4e9eef44a3ea3e5bb0b325435b9e6f594f80ee6531a594cf3a71bb7ffc0.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -6079,7 +6079,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d355e39fbde46b541ae05618d065eabb53246304a348db37b52c6a1a10746c05.zip",
+          "S3Key": "48117e416dde2f93ac3a350d403af0bc82b3eb7bb8ff3bb29ee11e743fb5cb32.zip",
         },
         "Description": "[ConstructHub/Orchestration/NeedsCatalogUpdate] Determines whether a package version requires a catalog update",
         "Environment": {
@@ -7071,7 +7071,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:5dcee5daa391e0e5efbf1dd7bcccab0e63f59baf018b388d87504c7bc3e683ca",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:0d9ea6e069b4c6a3cac0e6fa146e52ade1fa03bfd7d94d791d2099d347563278",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",

--- a/src/backend/shared/constants.ts
+++ b/src/backend/shared/constants.ts
@@ -164,6 +164,15 @@ export function notSupportedKeySuffix(
 }
 
 /**
+ * The key suffix for a not supported marker by language and submodule.
+ */
+export function transliterationErrorKeySuffix(
+  lang?: DocumentationLanguage | '*'
+) {
+  return `${docsKeySuffix(lang)}${TRANSLITERATION_ERROR}`;
+}
+
+/**
  * Key suffix for beacon files when a particular feature is not supported for
  * the particular package (i.e: Python docs for a package that does not have a
  * Python target configured).
@@ -175,6 +184,12 @@ export const NOT_SUPPORTED_SUFFIX = '.not-supported';
  * and we cannot generate docs from it.
  */
 export const CORRUPT_ASSEMBLY_SUFFIX = '.corruptassembly';
+
+/**
+ * Key suffix for beacon files when the transliteration for a particular language
+ * target has failed for a package.
+ */
+export const TRANSLITERATION_ERROR = '.transliteration-failed';
 
 /**
  * Key suffix for a beacon file when a package cannot be installed.


### PR DESCRIPTION
Without this, orchestration will always fail loudly.

A `TransliterationError` is emitted by `jsii-docgen` when transliteration by `jsii-rosetta` failed.
This always implies that all (sub-)modules for the given language will fail, since the transliteration step is not submodule specific.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*