### PR TITLE
fix(transliterator): s3 uploads are not retried when slowed-down

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -6805,7 +6805,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:554632fa99b4f5890b8fa0c2d2ddfb3907e9a790f3239bd694aa6764b805d0f6",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:3c2935cb5985fa7abdbf086a90b388d235e486202c5a36766d24e8968f346248",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -19750,7 +19750,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:554632fa99b4f5890b8fa0c2d2ddfb3907e9a790f3239bd694aa6764b805d0f6",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:3c2935cb5985fa7abdbf086a90b388d235e486202c5a36766d24e8968f346248",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -32359,7 +32359,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:554632fa99b4f5890b8fa0c2d2ddfb3907e9a790f3239bd694aa6764b805d0f6",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:3c2935cb5985fa7abdbf086a90b388d235e486202c5a36766d24e8968f346248",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -45071,7 +45071,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:554632fa99b4f5890b8fa0c2d2ddfb3907e9a790f3239bd694aa6764b805d0f6",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:3c2935cb5985fa7abdbf086a90b388d235e486202c5a36766d24e8968f346248",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -57702,7 +57702,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:554632fa99b4f5890b8fa0c2d2ddfb3907e9a790f3239bd694aa6764b805d0f6",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:3c2935cb5985fa7abdbf086a90b388d235e486202c5a36766d24e8968f346248",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",

--- a/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
+++ b/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
@@ -118,7 +118,7 @@ exports[`CodeArtifact repository 1`] = `
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:554632fa99b4f5890b8fa0c2d2ddfb3907e9a790f3239bd694aa6764b805d0f6",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:3c2935cb5985fa7abdbf086a90b388d235e486202c5a36766d24e8968f346248",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -2426,7 +2426,7 @@ exports[`VPC Endpoints 1`] = `
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:554632fa99b4f5890b8fa0c2d2ddfb3907e9a790f3239bd694aa6764b805d0f6",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:3c2935cb5985fa7abdbf086a90b388d235e486202c5a36766d24e8968f346248",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -4785,7 +4785,7 @@ exports[`VPC Endpoints and CodeArtifact repository 1`] = `
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:554632fa99b4f5890b8fa0c2d2ddfb3907e9a790f3239bd694aa6764b805d0f6",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:3c2935cb5985fa7abdbf086a90b388d235e486202c5a36766d24e8968f346248",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -7089,7 +7089,7 @@ exports[`basic use 1`] = `
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:554632fa99b4f5890b8fa0c2d2ddfb3907e9a790f3239bd694aa6764b805d0f6",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:3c2935cb5985fa7abdbf086a90b388d235e486202c5a36766d24e8968f346248",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -7071,7 +7071,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:554632fa99b4f5890b8fa0c2d2ddfb3907e9a790f3239bd694aa6764b805d0f6",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:3c2935cb5985fa7abdbf086a90b388d235e486202c5a36766d24e8968f346248",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",

--- a/src/backend/transliterator/transliterator.ecstask.ts
+++ b/src/backend/transliterator/transliterator.ecstask.ts
@@ -540,7 +540,7 @@ interface S3Object {
  */
 async function retry<A>(cb: () => Promise<A>): Promise<A> {
   const deadline = Date.now() + 30_000; // Half a minute minute
-  let sleepMs = 10;
+  let sleepMs = 20;
   while (true) {
     try {
       return await cb();
@@ -557,7 +557,13 @@ async function retry<A>(cb: () => Promise<A>): Promise<A> {
 
 function isRetryableError(e: any) {
   // Prepare for AWS SDK v3 already
-  return e.code === 'SlowDown' || e.name === 'SlowDown';
+  return (
+    e.code === 'SlowDown' ||
+    e.name === 'SlowDown' ||
+    e.code === 503 ||
+    e.statusCode === 503 ||
+    e.retryable === true
+  );
 }
 
 function sleep(ms: number): Promise<void> {


### PR DESCRIPTION
In the observed logs, the slow down error return by S3 apparently do not contain the human friendly names.
According to the S3 docs [1], a `503` error always indicates a slow down request.
This PR adds a few more checks to detect retryable errors more reliably.

Also increases the wait time between retry requests slightly to make slow downs less likely.

[1] https://repost.aws/knowledge-center/http-5xx-errors-s3

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*