### PR TITLE
fix: upgrade the update-feed and package-stats functions to SDK v3

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -1982,7 +1982,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "ea3bfaa031c0e35e007cf9b1cccc4de0e79a5c7c2dab10ec7f0489246a0c7c2e.zip",
+          "S3Key": "c2b804973791668a31a3359fedc40ffe6b54a85b0c19238e5027d7236941ce63.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -5867,7 +5867,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "e7b84cc7f34e84cd14b6df84bbf590d644c6bbef900e68943b0b8efbad2ca166.zip",
+          "S3Key": "a11d7eb83cc26dc9b771f4bd6a7a0d288c97cf306a6e477775ef96be1e9c47a5.zip",
         },
         "Description": "[ConstructHub/Orchestration/NeedsCatalogUpdate] Determines whether a package version requires a catalog update",
         "Environment": {
@@ -10568,7 +10568,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1854ecb6f125284eabd0fc07139332e7bf50a68003644eb857a277fc1cf11786.zip",
+          "S3Key": "dce7ea3e58a63f0486d731bdb3ea921fd232e2ea5b3808312323af4c4eabdb95.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -14810,7 +14810,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "ea3bfaa031c0e35e007cf9b1cccc4de0e79a5c7c2dab10ec7f0489246a0c7c2e.zip",
+          "S3Key": "c2b804973791668a31a3359fedc40ffe6b54a85b0c19238e5027d7236941ce63.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -18793,7 +18793,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "e7b84cc7f34e84cd14b6df84bbf590d644c6bbef900e68943b0b8efbad2ca166.zip",
+          "S3Key": "a11d7eb83cc26dc9b771f4bd6a7a0d288c97cf306a6e477775ef96be1e9c47a5.zip",
         },
         "Description": "[ConstructHub/Orchestration/NeedsCatalogUpdate] Determines whether a package version requires a catalog update",
         "Environment": {
@@ -23567,7 +23567,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1854ecb6f125284eabd0fc07139332e7bf50a68003644eb857a277fc1cf11786.zip",
+          "S3Key": "dce7ea3e58a63f0486d731bdb3ea921fd232e2ea5b3808312323af4c4eabdb95.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -27552,7 +27552,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "ea3bfaa031c0e35e007cf9b1cccc4de0e79a5c7c2dab10ec7f0489246a0c7c2e.zip",
+          "S3Key": "c2b804973791668a31a3359fedc40ffe6b54a85b0c19238e5027d7236941ce63.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -31437,7 +31437,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "e7b84cc7f34e84cd14b6df84bbf590d644c6bbef900e68943b0b8efbad2ca166.zip",
+          "S3Key": "a11d7eb83cc26dc9b771f4bd6a7a0d288c97cf306a6e477775ef96be1e9c47a5.zip",
         },
         "Description": "[ConstructHub/Orchestration/NeedsCatalogUpdate] Determines whether a package version requires a catalog update",
         "Environment": {
@@ -36138,7 +36138,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1854ecb6f125284eabd0fc07139332e7bf50a68003644eb857a277fc1cf11786.zip",
+          "S3Key": "dce7ea3e58a63f0486d731bdb3ea921fd232e2ea5b3808312323af4c4eabdb95.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -40263,7 +40263,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "ea3bfaa031c0e35e007cf9b1cccc4de0e79a5c7c2dab10ec7f0489246a0c7c2e.zip",
+          "S3Key": "c2b804973791668a31a3359fedc40ffe6b54a85b0c19238e5027d7236941ce63.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -44157,7 +44157,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "e7b84cc7f34e84cd14b6df84bbf590d644c6bbef900e68943b0b8efbad2ca166.zip",
+          "S3Key": "a11d7eb83cc26dc9b771f4bd6a7a0d288c97cf306a6e477775ef96be1e9c47a5.zip",
         },
         "Description": "[ConstructHub/Orchestration/NeedsCatalogUpdate] Determines whether a package version requires a catalog update",
         "Environment": {
@@ -48845,7 +48845,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1854ecb6f125284eabd0fc07139332e7bf50a68003644eb857a277fc1cf11786.zip",
+          "S3Key": "dce7ea3e58a63f0486d731bdb3ea921fd232e2ea5b3808312323af4c4eabdb95.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -53157,7 +53157,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "ea3bfaa031c0e35e007cf9b1cccc4de0e79a5c7c2dab10ec7f0489246a0c7c2e.zip",
+          "S3Key": "c2b804973791668a31a3359fedc40ffe6b54a85b0c19238e5027d7236941ce63.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -56790,7 +56790,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "e7b84cc7f34e84cd14b6df84bbf590d644c6bbef900e68943b0b8efbad2ca166.zip",
+          "S3Key": "a11d7eb83cc26dc9b771f4bd6a7a0d288c97cf306a6e477775ef96be1e9c47a5.zip",
         },
         "Description": "[ConstructHub/Orchestration/NeedsCatalogUpdate] Determines whether a package version requires a catalog update",
         "Environment": {
@@ -61559,7 +61559,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1854ecb6f125284eabd0fc07139332e7bf50a68003644eb857a277fc1cf11786.zip",
+          "S3Key": "dce7ea3e58a63f0486d731bdb3ea921fd232e2ea5b3808312323af4c4eabdb95.zip",
         },
         "Description": {
           "Fn::Join": [

--- a/src/__tests__/backend/transliterator/transliterator.ecstask.test.ts
+++ b/src/__tests__/backend/transliterator/transliterator.ecstask.test.ts
@@ -8,7 +8,6 @@ import {
 } from '@aws-sdk/client-s3';
 import * as spec from '@jsii/spec';
 import { sdkStreamMixin } from '@smithy/util-stream';
-
 import { mockClient } from 'aws-sdk-client-mock';
 import {
   LanguageNotSupportedError,

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -2435,7 +2435,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "ea3bfaa031c0e35e007cf9b1cccc4de0e79a5c7c2dab10ec7f0489246a0c7c2e.zip",
+          "S3Key": "c2b804973791668a31a3359fedc40ffe6b54a85b0c19238e5027d7236941ce63.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -6079,7 +6079,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "e7b84cc7f34e84cd14b6df84bbf590d644c6bbef900e68943b0b8efbad2ca166.zip",
+          "S3Key": "a11d7eb83cc26dc9b771f4bd6a7a0d288c97cf306a6e477775ef96be1e9c47a5.zip",
         },
         "Description": "[ConstructHub/Orchestration/NeedsCatalogUpdate] Determines whether a package version requires a catalog update",
         "Environment": {
@@ -11844,7 +11844,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1854ecb6f125284eabd0fc07139332e7bf50a68003644eb857a277fc1cf11786.zip",
+          "S3Key": "dce7ea3e58a63f0486d731bdb3ea921fd232e2ea5b3808312323af4c4eabdb95.zip",
         },
         "Description": {
           "Fn::Join": [

--- a/src/backend/package-stats/package-stats.lambda.ts
+++ b/src/backend/package-stats/package-stats.lambda.ts
@@ -1,3 +1,4 @@
+import { PutObjectCommand } from '@aws-sdk/client-s3';
 import { metricScope, Unit } from 'aws-embedded-metrics';
 import type { Context } from 'aws-lambda';
 import got from 'got';
@@ -9,7 +10,7 @@ import {
 } from './npm-downloads.lambda-shared';
 import { CacheStrategy } from '../../caching';
 import { CatalogClient } from '../catalog-builder/client.lambda-shared';
-import * as aws from '../shared/aws.lambda-shared';
+import { S3_CLIENT } from '../shared/aws.lambda-shared';
 import { requireEnv } from '../shared/env.lambda-shared';
 
 /**
@@ -72,9 +73,8 @@ export async function handler(event: any, context: Context) {
   })();
 
   // Upload the result to S3 and exit.
-  return aws
-    .s3()
-    .putObject({
+  return S3_CLIENT.send(
+    new PutObjectCommand({
       Bucket: STATS_BUCKET_NAME,
       Key: STATS_OBJECT_KEY,
       Body: JSON.stringify(stats, null, 2),
@@ -87,7 +87,7 @@ export async function handler(event: any, context: Context) {
         'Package-Stats-Count': `${statsCount}`,
       },
     })
-    .promise();
+  );
 }
 
 function updateStats(


### PR DESCRIPTION
Refactor the update-feed and package-stats functions to use AWS SDK v3. Tests updated accordingly.

Migrated these two together because they both needed a change to the catalog-builder client.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*