### PR TITLE
fix(feed-builder): updating feed fails when package has no release notes

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -1982,7 +1982,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "c2b804973791668a31a3359fedc40ffe6b54a85b0c19238e5027d7236941ce63.zip",
+          "S3Key": "779788db14e2b444a77414c6b3dd2a45b281e06fbeae8fa48f8a217ed85340cc.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -14810,7 +14810,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "c2b804973791668a31a3359fedc40ffe6b54a85b0c19238e5027d7236941ce63.zip",
+          "S3Key": "779788db14e2b444a77414c6b3dd2a45b281e06fbeae8fa48f8a217ed85340cc.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -27552,7 +27552,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "c2b804973791668a31a3359fedc40ffe6b54a85b0c19238e5027d7236941ce63.zip",
+          "S3Key": "779788db14e2b444a77414c6b3dd2a45b281e06fbeae8fa48f8a217ed85340cc.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -40263,7 +40263,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "c2b804973791668a31a3359fedc40ffe6b54a85b0c19238e5027d7236941ce63.zip",
+          "S3Key": "779788db14e2b444a77414c6b3dd2a45b281e06fbeae8fa48f8a217ed85340cc.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -53157,7 +53157,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "c2b804973791668a31a3359fedc40ffe6b54a85b0c19238e5027d7236941ce63.zip",
+          "S3Key": "779788db14e2b444a77414c6b3dd2a45b281e06fbeae8fa48f8a217ed85340cc.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {

--- a/src/__tests__/backend/feed-builder/update-feed.lambda.test.ts
+++ b/src/__tests__/backend/feed-builder/update-feed.lambda.test.ts
@@ -1,6 +1,6 @@
 import {
   GetObjectCommand,
-  NotFound,
+  NoSuchKey,
   PutObjectCommand,
   S3Client,
   S3ServiceException,
@@ -94,8 +94,8 @@ beforeEach(() => {
       return { Body: s3ObjectMap.get(request.Key) };
     }
 
-    throw new NotFound({
-      message: `NotFound GET request: ${request.Key}`,
+    throw new NoSuchKey({
+      message: `NoSuchKey GET request: ${request.Key}`,
       $metadata: {},
     });
   });

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -2435,7 +2435,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "c2b804973791668a31a3359fedc40ffe6b54a85b0c19238e5027d7236941ce63.zip",
+          "S3Key": "779788db14e2b444a77414c6b3dd2a45b281e06fbeae8fa48f8a217ed85340cc.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {

--- a/src/backend/feed-builder/update-feed.lambda.ts
+++ b/src/backend/feed-builder/update-feed.lambda.ts
@@ -1,5 +1,6 @@
 import {
   GetObjectCommand,
+  NoSuchKey,
   NotFound,
   PutObjectCommand,
 } from '@aws-sdk/client-s3';
@@ -139,7 +140,8 @@ export const getPackageReleaseNotes = async (
     if (
       error instanceof NotFound ||
       error.name === 'NotFound' ||
-      error.statusCode === 404
+      error instanceof NoSuchKey ||
+      error.name === 'NoSuchKey'
     ) {
       return 'No release notes';
     }


### PR DESCRIPTION
In #1451 the update-feed function was migrated to SDK v3. For the migration the error handling needed to be adapted to SDK v3. With SDK v2 we checked for a `404` error status to conclude that no release notes are available. SDK v3 does not use http error codes, so we needed to convert to error names/types. Initially this was incompletely changed to only check for a `NotFound` error. However it also needs to check for `NoSuchKey` error. 

This has been fixed and the testcase updated.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*