### PR TITLE
fix(catalog-builder): average execution time is 100x slower than previously

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -4799,7 +4799,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2cf2ca466af24e2bec2273b34af840c470998978b2002e19653626fbd64b2622.zip",
+          "S3Key": "0d100f05c85d3e39e58bd70bca891deee9105c8fe9040d611cf98fcc11270e89.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -17725,7 +17725,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2cf2ca466af24e2bec2273b34af840c470998978b2002e19653626fbd64b2622.zip",
+          "S3Key": "0d100f05c85d3e39e58bd70bca891deee9105c8fe9040d611cf98fcc11270e89.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -30369,7 +30369,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2cf2ca466af24e2bec2273b34af840c470998978b2002e19653626fbd64b2622.zip",
+          "S3Key": "0d100f05c85d3e39e58bd70bca891deee9105c8fe9040d611cf98fcc11270e89.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -43089,7 +43089,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2cf2ca466af24e2bec2273b34af840c470998978b2002e19653626fbd64b2622.zip",
+          "S3Key": "0d100f05c85d3e39e58bd70bca891deee9105c8fe9040d611cf98fcc11270e89.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -56129,7 +56129,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2cf2ca466af24e2bec2273b34af840c470998978b2002e19653626fbd64b2622.zip",
+          "S3Key": "0d100f05c85d3e39e58bd70bca891deee9105c8fe9040d611cf98fcc11270e89.zip",
         },
         "Description": {
           "Fn::Join": [

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -5408,7 +5408,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2cf2ca466af24e2bec2273b34af840c470998978b2002e19653626fbd64b2622.zip",
+          "S3Key": "0d100f05c85d3e39e58bd70bca891deee9105c8fe9040d611cf98fcc11270e89.zip",
         },
         "Description": {
           "Fn::Join": [

--- a/src/backend/catalog-builder/catalog-builder.lambda.ts
+++ b/src/backend/catalog-builder/catalog-builder.lambda.ts
@@ -204,9 +204,11 @@ export async function handler(event: CatalogBuilderInput, context: Context) {
   } else {
     if (process.env.FEED_BUILDER_FUNCTION_NAME) {
       // Catalog is updated. Update the RSS/ATOM feed
+      console.log(`Updating feeds...`);
       await aws.LAMBDA_CLIENT.send(
         new InvokeCommand({
           FunctionName: process.env.FEED_BUILDER_FUNCTION_NAME,
+          InvocationType: 'Event',
           Payload: JSON.stringify({}),
         })
       );


### PR DESCRIPTION
In #1441 we upgraded the SDK to v3. During this upgrade we replaced the deprecated InvokeAsyncCommand with InvokeCommand. It was missed that the default invocation type for this command is `RequestResponse`, when it needs to be `Event`. This caused the catalog-builder function to await the completion of the feed-builder function.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*