### PR TITLE
fix(ecs-task-monitor): upgrade to AWS SDK v3

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -5113,7 +5113,7 @@ RUNBOOK: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1108f454b78acab0dda3f0f3b1ace09a3394f7a4bab7e846ea24fa37ef4bad47.zip",
+          "S3Key": "a5b12bb02ff5cf2f86d656a3d5ba6bd4594dfcc2e64057adf632265f459577a7.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -18039,7 +18039,7 @@ RUNBOOK: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1108f454b78acab0dda3f0f3b1ace09a3394f7a4bab7e846ea24fa37ef4bad47.zip",
+          "S3Key": "a5b12bb02ff5cf2f86d656a3d5ba6bd4594dfcc2e64057adf632265f459577a7.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -30683,7 +30683,7 @@ RUNBOOK: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1108f454b78acab0dda3f0f3b1ace09a3394f7a4bab7e846ea24fa37ef4bad47.zip",
+          "S3Key": "a5b12bb02ff5cf2f86d656a3d5ba6bd4594dfcc2e64057adf632265f459577a7.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -43403,7 +43403,7 @@ RUNBOOK: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1108f454b78acab0dda3f0f3b1ace09a3394f7a4bab7e846ea24fa37ef4bad47.zip",
+          "S3Key": "a5b12bb02ff5cf2f86d656a3d5ba6bd4594dfcc2e64057adf632265f459577a7.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -56443,7 +56443,7 @@ RUNBOOK: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1108f454b78acab0dda3f0f3b1ace09a3394f7a4bab7e846ea24fa37ef4bad47.zip",
+          "S3Key": "a5b12bb02ff5cf2f86d656a3d5ba6bd4594dfcc2e64057adf632265f459577a7.zip",
         },
         "Description": {
           "Fn::Join": [

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -5719,7 +5719,7 @@ RUNBOOK: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1108f454b78acab0dda3f0f3b1ace09a3394f7a4bab7e846ea24fa37ef4bad47.zip",
+          "S3Key": "a5b12bb02ff5cf2f86d656a3d5ba6bd4594dfcc2e64057adf632265f459577a7.zip",
         },
         "Description": {
           "Fn::Join": [


### PR DESCRIPTION
Refactor the ecs-task-monitor lambda functions to use AWS SDK v3.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*