### PR TITLE
fix(license-list): upgrade to AWS SDK v3

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -9398,7 +9398,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "455dc8070938b6c14e85478c54597fbcdd4f5b1fe07673be6f0b8918329ff2c6.zip",
+          "S3Key": "58bb2023f45f37abe4943309d10c7ece45a905ce10b9b3bd07b5d5e8dd5651c5.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -22397,7 +22397,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "455dc8070938b6c14e85478c54597fbcdd4f5b1fe07673be6f0b8918329ff2c6.zip",
+          "S3Key": "58bb2023f45f37abe4943309d10c7ece45a905ce10b9b3bd07b5d5e8dd5651c5.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -34968,7 +34968,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "455dc8070938b6c14e85478c54597fbcdd4f5b1fe07673be6f0b8918329ff2c6.zip",
+          "S3Key": "58bb2023f45f37abe4943309d10c7ece45a905ce10b9b3bd07b5d5e8dd5651c5.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -47688,7 +47688,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "455dc8070938b6c14e85478c54597fbcdd4f5b1fe07673be6f0b8918329ff2c6.zip",
+          "S3Key": "58bb2023f45f37abe4943309d10c7ece45a905ce10b9b3bd07b5d5e8dd5651c5.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -60389,7 +60389,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "455dc8070938b6c14e85478c54597fbcdd4f5b1fe07673be6f0b8918329ff2c6.zip",
+          "S3Key": "58bb2023f45f37abe4943309d10c7ece45a905ce10b9b3bd07b5d5e8dd5651c5.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {

--- a/src/__tests__/backend/deny-list/mocks/trigger.prune-test.lambda.ts
+++ b/src/__tests__/backend/deny-list/mocks/trigger.prune-test.lambda.ts
@@ -1,7 +1,7 @@
-import * as AWS from 'aws-sdk';
+import { ListObjectsV2CommandInput, S3 } from '@aws-sdk/client-s3';
 import { requireEnv } from '../../../../backend/shared/env.lambda-shared';
 
-const s3 = new AWS.S3();
+const s3 = new S3();
 
 export async function handler() {
   const bucketName = requireEnv('BUCKET_NAME');
@@ -32,12 +32,12 @@ async function getAllObjectKeys(bucket: string) {
   let continuationToken;
   const objectKeys = new Array<string>();
   do {
-    const listRequest: AWS.S3.ListObjectsV2Request = {
+    const listRequest: ListObjectsV2CommandInput = {
       Bucket: bucket,
       ContinuationToken: continuationToken,
     };
     console.log(JSON.stringify({ listRequest }));
-    const listResponse = await s3.listObjectsV2(listRequest).promise();
+    const listResponse = await s3.listObjectsV2(listRequest);
     console.log(JSON.stringify({ listResponse }));
     continuationToken = listResponse.NextContinuationToken;
 

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -10680,7 +10680,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "455dc8070938b6c14e85478c54597fbcdd4f5b1fe07673be6f0b8918329ff2c6.zip",
+          "S3Key": "58bb2023f45f37abe4943309d10c7ece45a905ce10b9b3bd07b5d5e8dd5651c5.zip",
         },
         "Description": "[dev/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {

--- a/src/__tests__/package-sources/__snapshots__/code-artifact.test.ts.snap
+++ b/src/__tests__/package-sources/__snapshots__/code-artifact.test.ts.snap
@@ -243,7 +243,7 @@ exports[`default configuration 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "cef554c64ae6cb679b47371ce4759963a74eabba08cc65b570afce94c1821f0e.zip",
+          "S3Key": "5377ecd434fd63dc93637b4a750a5d5cc04a66cb172f5888980ee60ec82e004b.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -727,7 +727,7 @@ exports[`user-provided staging bucket 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "cef554c64ae6cb679b47371ce4759963a74eabba08cc65b570afce94c1821f0e.zip",
+          "S3Key": "5377ecd434fd63dc93637b4a750a5d5cc04a66cb172f5888980ee60ec82e004b.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {

--- a/test/integ.deny-list.ts.snapshot/DenyListInteg.assets.json
+++ b/test/integ.deny-list.ts.snapshot/DenyListInteg.assets.json
@@ -131,20 +131,20 @@
         }
       }
     },
-    "48d993869418a3dd49aa6559ab0ebdd0dd35dc070685d051d22e14c67485a75b": {
+    "6be4bf22009eec0ea992793595949f624067525cedfd25947ac148a371b0159d": {
       "source": {
-        "path": "asset.48d993869418a3dd49aa6559ab0ebdd0dd35dc070685d051d22e14c67485a75b.bundle",
+        "path": "asset.6be4bf22009eec0ea992793595949f624067525cedfd25947ac148a371b0159d.bundle",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "48d993869418a3dd49aa6559ab0ebdd0dd35dc070685d051d22e14c67485a75b.zip",
+          "objectKey": "6be4bf22009eec0ea992793595949f624067525cedfd25947ac148a371b0159d.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "3493864ccb154186e013addf6c6cc9d5f5811c0ea6b078d3d2d4507dc4c43371": {
+    "7bac9aa53fb2d35bac1f52f95821d12b446d626cc8281364f450fe0ac9a6508f": {
       "source": {
         "path": "DenyListInteg.template.json",
         "packaging": "file"
@@ -152,7 +152,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "3493864ccb154186e013addf6c6cc9d5f5811c0ea6b078d3d2d4507dc4c43371.json",
+          "objectKey": "7bac9aa53fb2d35bac1f52f95821d12b446d626cc8281364f450fe0ac9a6508f.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ.deny-list.ts.snapshot/DenyListInteg.template.json
+++ b/test/integ.deny-list.ts.snapshot/DenyListInteg.template.json
@@ -1981,7 +1981,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "48d993869418a3dd49aa6559ab0ebdd0dd35dc070685d051d22e14c67485a75b.zip"
+     "S3Key": "6be4bf22009eec0ea992793595949f624067525cedfd25947ac148a371b0159d.zip"
     },
     "Description": "__tests__/backend/deny-list/mocks/trigger.prune-test.lambda.ts",
     "Environment": {
@@ -2018,7 +2018,7 @@
      ]
     },
     "HandlerArn": {
-     "Ref": "PruneTestCurrentVersion332993F8f7b80c6aafda6dabc234ef63b21d065e"
+     "Ref": "PruneTestCurrentVersion332993F8757f75b11b0a281bf4ee6c5a433807fa"
     },
     "InvocationType": "RequestResponse",
     "Timeout": "120000",
@@ -2049,7 +2049,7 @@
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
   },
-  "PruneTestCurrentVersion332993F8f7b80c6aafda6dabc234ef63b21d065e": {
+  "PruneTestCurrentVersion332993F8757f75b11b0a281bf4ee6c5a433807fa": {
    "Type": "AWS::Lambda::Version",
    "Properties": {
     "FunctionName": {

--- a/test/integ.deny-list.ts.snapshot/manifest.json
+++ b/test/integ.deny-list.ts.snapshot/manifest.json
@@ -18,7 +18,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/3493864ccb154186e013addf6c6cc9d5f5811c0ea6b078d3d2d4507dc4c43371.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/7bac9aa53fb2d35bac1f52f95821d12b446d626cc8281364f450fe0ac9a6508f.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [
@@ -391,7 +391,7 @@
         "/DenyListInteg/PruneTest/CurrentVersion/Resource": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "PruneTestCurrentVersion332993F8f7b80c6aafda6dabc234ef63b21d065e"
+            "data": "PruneTestCurrentVersion332993F8757f75b11b0a281bf4ee6c5a433807fa"
           }
         ],
         "/DenyListInteg/PruneTest/Policy/Resource": [

--- a/test/integ.deny-list.ts.snapshot/tree.json
+++ b/test/integ.deny-list.ts.snapshot/tree.json
@@ -3020,7 +3020,7 @@
                       "s3Bucket": {
                         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                       },
-                      "s3Key": "48d993869418a3dd49aa6559ab0ebdd0dd35dc070685d051d22e14c67485a75b.zip"
+                      "s3Key": "6be4bf22009eec0ea992793595949f624067525cedfd25947ac148a371b0159d.zip"
                     },
                     "description": "__tests__/backend/deny-list/mocks/trigger.prune-test.lambda.ts",
                     "environment": {


### PR DESCRIPTION
Refactor the license-list client to use AWS SDK v3. Tests updated accordingly.

Also fixes a mock function for the deny-list integ test to use SDK v3.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*