### PR TITLE
fix(version-tracker): upgrade to AWS SDK v3

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -10775,7 +10775,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "eb4501965f7ea0193d601b7dcd1f1f69d9cf227e863771a9491e649723bdf108.zip",
+          "S3Key": "4e52bca3e523be444d777af91d673585256b942b596cb6d562c8b1e731f47625.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -23774,7 +23774,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "eb4501965f7ea0193d601b7dcd1f1f69d9cf227e863771a9491e649723bdf108.zip",
+          "S3Key": "4e52bca3e523be444d777af91d673585256b942b596cb6d562c8b1e731f47625.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -36345,7 +36345,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "eb4501965f7ea0193d601b7dcd1f1f69d9cf227e863771a9491e649723bdf108.zip",
+          "S3Key": "4e52bca3e523be444d777af91d673585256b942b596cb6d562c8b1e731f47625.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -49052,7 +49052,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "eb4501965f7ea0193d601b7dcd1f1f69d9cf227e863771a9491e649723bdf108.zip",
+          "S3Key": "4e52bca3e523be444d777af91d673585256b942b596cb6d562c8b1e731f47625.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -64626,7 +64626,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "eb4501965f7ea0193d601b7dcd1f1f69d9cf227e863771a9491e649723bdf108.zip",
+          "S3Key": "4e52bca3e523be444d777af91d673585256b942b596cb6d562c8b1e731f47625.zip",
         },
         "Description": {
           "Fn::Join": [

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -15042,7 +15042,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "eb4501965f7ea0193d601b7dcd1f1f69d9cf227e863771a9491e649723bdf108.zip",
+          "S3Key": "4e52bca3e523be444d777af91d673585256b942b596cb6d562c8b1e731f47625.zip",
         },
         "Description": {
           "Fn::Join": [


### PR DESCRIPTION
Refactor the version-tracker function to use AWS SDK v3. Tests updated accordingly.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*