### PR TITLE
fix(couchdb follower): npmjs has stopped responding to POST requests

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -9406,7 +9406,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b951ba4645233045a4e5ac205bfedb8968b4da31cec36841f7149ae953bd02ce.zip",
+          "S3Key": "d0552f6826f7584200c7b223ac573a83b5d92848eee6e6aa71a637c0243ab955.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -22523,7 +22523,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b951ba4645233045a4e5ac205bfedb8968b4da31cec36841f7149ae953bd02ce.zip",
+          "S3Key": "d0552f6826f7584200c7b223ac573a83b5d92848eee6e6aa71a637c0243ab955.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -35212,7 +35212,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b951ba4645233045a4e5ac205bfedb8968b4da31cec36841f7149ae953bd02ce.zip",
+          "S3Key": "d0552f6826f7584200c7b223ac573a83b5d92848eee6e6aa71a637c0243ab955.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -48050,7 +48050,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b951ba4645233045a4e5ac205bfedb8968b4da31cec36841f7149ae953bd02ce.zip",
+          "S3Key": "d0552f6826f7584200c7b223ac573a83b5d92848eee6e6aa71a637c0243ab955.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -60869,7 +60869,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b951ba4645233045a4e5ac205bfedb8968b4da31cec36841f7149ae953bd02ce.zip",
+          "S3Key": "d0552f6826f7584200c7b223ac573a83b5d92848eee6e6aa71a637c0243ab955.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -9406,7 +9406,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d0552f6826f7584200c7b223ac573a83b5d92848eee6e6aa71a637c0243ab955.zip",
+          "S3Key": "2912b27f5b993216b4265e63be3f32ce81d778305e29f235c3224b02ab4bc771.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -22523,7 +22523,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d0552f6826f7584200c7b223ac573a83b5d92848eee6e6aa71a637c0243ab955.zip",
+          "S3Key": "2912b27f5b993216b4265e63be3f32ce81d778305e29f235c3224b02ab4bc771.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -35212,7 +35212,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d0552f6826f7584200c7b223ac573a83b5d92848eee6e6aa71a637c0243ab955.zip",
+          "S3Key": "2912b27f5b993216b4265e63be3f32ce81d778305e29f235c3224b02ab4bc771.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -48050,7 +48050,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d0552f6826f7584200c7b223ac573a83b5d92848eee6e6aa71a637c0243ab955.zip",
+          "S3Key": "2912b27f5b993216b4265e63be3f32ce81d778305e29f235c3224b02ab4bc771.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -60869,7 +60869,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d0552f6826f7584200c7b223ac573a83b5d92848eee6e6aa71a637c0243ab955.zip",
+          "S3Key": "2912b27f5b993216b4265e63be3f32ce81d778305e29f235c3224b02ab4bc771.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -10688,7 +10688,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b951ba4645233045a4e5ac205bfedb8968b4da31cec36841f7149ae953bd02ce.zip",
+          "S3Key": "d0552f6826f7584200c7b223ac573a83b5d92848eee6e6aa71a637c0243ab955.zip",
         },
         "Description": "[dev/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -10688,7 +10688,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d0552f6826f7584200c7b223ac573a83b5d92848eee6e6aa71a637c0243ab955.zip",
+          "S3Key": "2912b27f5b993216b4265e63be3f32ce81d778305e29f235c3224b02ab4bc771.zip",
         },
         "Description": "[dev/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {

--- a/src/package-sources/npmjs/couch-changes.lambda-shared.ts
+++ b/src/package-sources/npmjs/couch-changes.lambda-shared.ts
@@ -43,6 +43,8 @@ export class CouchChanges extends EventEmitter {
    * @param since     the sequence value since when history should be fetched.
    * @param batchSize the maximum amount of changes to return in a single page.
    *
+   * @see https://docs.couchdb.org/en/stable/api/database/changes.html
+   *
    * @returns a page of changes.
    */
   public async changes(
@@ -61,7 +63,7 @@ export class CouchChanges extends EventEmitter {
 
     const filter = { name: { $gt: null } };
 
-    return this.https('post', changesUrl, filter) as any;
+    return this.https('get', changesUrl, filter) as any;
   }
 
   /**


### PR DESCRIPTION
Since 2/19, the CouchDB leader of npmjs.com seems to have stopped responding to POST requests to the `_changes` endpoint.

The docs say that both GET and POST should be supported, but POST has stopped working for over a day now.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*