### PR TITLE
fix: reprocess workflow fails when output is too large

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -1139,7 +1139,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "14700f3f8dd2f4997b0e6380f2714c17996184ef4a12d7990ce58b009105e158.zip",
+          "S3Key": "e42a736be21cd3134b9bff4e71e3afa99a4cc900ae489e9a7f7025c8d258f9b8.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -1505,7 +1505,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "95c4189864dbf50a528d71bba7983f1c72ecdb4e0a84b258370eb164a2d8b5f1.zip",
+          "S3Key": "ceb8637c8e04b94b162bc128e7a7c24d7ca560b4977e762837487bc934cec374.zip",
         },
         "Description": "backend/deny-list/prune-handler.lambda.ts",
         "Environment": {
@@ -1701,7 +1701,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "70eca9bc2a5f6d903868ff0f1d4b2a68171d2aa8762f79b2e2dceb61071952ee.zip",
+          "S3Key": "0e9bd53c8e4cc8a3d66c0a9c0e289a20644114d9925d5320894badf88f29f57b.zip",
         },
         "Description": "backend/deny-list/prune-queue-handler.lambda.ts",
         "Environment": {
@@ -1982,7 +1982,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "649504c66341123a000af00370bc1425ff679e340cc98fc16a854ffa71be9e87.zip",
+          "S3Key": "e4ab225c7936f2eae3602ace6c2d52ffce6265902becdacba8bfa453a7947993.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -2210,7 +2210,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "a323116d13e8b02fd6df324424f01a89d685b1cdd34085c24fceba637051ebea.zip",
+          "S3Key": "8e156a6d01a8cba082af6b52bf9b3f5d8ff0372fc2bd65db725e9320e703a33c.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": {
@@ -2422,7 +2422,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "14700f3f8dd2f4997b0e6380f2714c17996184ef4a12d7990ce58b009105e158.zip",
+          "S3Key": "e42a736be21cd3134b9bff4e71e3afa99a4cc900ae489e9a7f7025c8d258f9b8.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -2636,7 +2636,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "586a1de4c6dfa1effbf944e236b43ee8e7098f5fe44764b1abf7505aab6eb68b.zip",
+          "S3Key": "21d95dae27beb007008f118941bd01cdc870aa25991c17d5544375f72f926187.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -2814,7 +2814,7 @@ Direct link to the function: /lambda/home#/functions/",
               {
                 "Ref": "ConstructHubPackageDataDC5EF35E",
               },
-              "","Prefix":"data/"}},"Is there more?":{"Type":"Choice","Choices":[{"Variable":"$.response.NextContinuationToken","IsPresent":true,"Next":"Give room for on-demand work"}],"Default":"Process Result"},"S3.ListObjectsV2(NextPage)":{"Next":"Is there more?","Retry":[{"ErrorEquals":["S3.SdkClientException"]}],"Type":"Task","ResultPath":"$.response","Resource":"arn:",
+              "","Prefix":"data/","MaxKeys":900}},"Is there more?":{"Type":"Choice","Choices":[{"Variable":"$.response.NextContinuationToken","IsPresent":true,"Next":"Give room for on-demand work"}],"Default":"Process Result"},"S3.ListObjectsV2(NextPage)":{"Next":"Is there more?","Retry":[{"ErrorEquals":["S3.SdkClientException"]}],"Type":"Task","ResultPath":"$.response","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -2822,7 +2822,7 @@ Direct link to the function: /lambda/home#/functions/",
               {
                 "Ref": "ConstructHubPackageDataDC5EF35E",
               },
-              "","ContinuationToken.$":"$.ContinuationToken","Prefix":"data/"}},"Process Result":{"Type":"Map","ResultPath":null,"End":true,"InputPath":"$.response.Contents[*][?(@.Key =~ /^.*/metadata.json$/)]","Iterator":{"StartAt":"Send for reprocessing","States":{"Send for reprocessing":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["Lambda.TooManyRequestsException"],"IntervalSeconds":60,"MaxAttempts":30,"BackoffRate":1.1}],"Type":"Task","Resource":"arn:",
+              "","ContinuationToken.$":"$.ContinuationToken","Prefix":"data/","MaxKeys":900}},"Process Result":{"Type":"Map","ResultPath":null,"End":true,"InputPath":"$.response.Contents[*][?(@.Key =~ /^.*/metadata.json$/)]","Iterator":{"StartAt":"Send for reprocessing","States":{"Send for reprocessing":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["Lambda.TooManyRequestsException"],"IntervalSeconds":60,"MaxAttempts":30,"BackoffRate":1.1}],"Type":"Task","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -3302,7 +3302,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "3838f09986ecd1cf5f4e98caedec8eb0c845339172bcc8711b519a8987cc56ee.zip",
+          "S3Key": "92ea79a00d10208fdffeff6b1413b88ef1d6d6c927cd6129d66378ed694aad89.zip",
         },
         "Description": "[ConstructHub/Inventory] A canary that periodically inspects the list of indexed packages",
         "Environment": {
@@ -3963,7 +3963,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "14700f3f8dd2f4997b0e6380f2714c17996184ef4a12d7990ce58b009105e158.zip",
+          "S3Key": "e42a736be21cd3134b9bff4e71e3afa99a4cc900ae489e9a7f7025c8d258f9b8.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -4799,7 +4799,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1a89160600b3e2be7ade4a88a50d22e06a082f0fad411e72f7a9e50ea9753d57.zip",
+          "S3Key": "161c86d2d771967ab8aff9dbf517646eab724a16d0857b5a5b23ed8b8acc6d5d.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -5113,7 +5113,7 @@ RUNBOOK: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "aac6c06e2f850f244bd1349125480a92d2b7ddaaecafea7c9549adc1502e4689.zip",
+          "S3Key": "e78ec9ac5931add41bdf700f8036a5a8479040627b91be5ee9dc1939e19ae8fe.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -5867,7 +5867,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "42c84f4df5864e35ab9ea480fe64a7e118525bdc344197a746412f5bbef2bb0d.zip",
+          "S3Key": "1124b946bc8e940fb46cd2c462cdc1b7e54fe418faf9b3c9c5da6dbaab65a845.zip",
         },
         "Description": "[ConstructHub/Orchestration/NeedsCatalogUpdate] Determines whether a package version requires a catalog update",
         "Environment": {
@@ -6022,7 +6022,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "e6d7b8e2302080b4decb9b19e2e42698b613eaedbf8c76eaf3c05707834302e4.zip",
+          "S3Key": "103ed25c76ca9342bd8adde12b324f70d94bdb2e4bd9f323edd939cfe199046b.zip",
         },
         "Description": "[ConstructHub/Redrive] Manually redrives all messages from the backend dead letter queue",
         "Environment": {
@@ -6814,7 +6814,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:bf8b65e8cdcb3defed4173acd317d002bc89d243f6af4ea630944bd9d1588f97",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:ddb9ed165690d6ce66795af95dae2c6b20649748078572102587d317b2db0be7",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -9406,7 +9406,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "3d8d55e227ba16eb24dac3993e02e2fb06ba0ccc82f242a46c657e5e72012203.zip",
+          "S3Key": "fc45da1e5e21ad2d736d1d9043ce17cd8132932a3db40dd86fc17179ed2bd5c0.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -9460,7 +9460,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1eacc73709e81960105bc44d627f04480e4b44efb5efac714992814577bd92c4.zip",
+          "S3Key": "79a486bea9ba022ce3d8f154abcf61a411aea3c232d58104ef39a50f8aaff534.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": {
@@ -10165,7 +10165,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "7eeec3dd2bbda52e5b4dc6f329293bc1fd1adabc4a2427331a4e1e4fe8a46cc5.zip",
+          "S3Key": "3bf73d07c5e1a0bd778e16496f53f9802a317e45f13f6366315f49d9842104ef.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -10477,7 +10477,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "9d6ad85b84ac4981fd40d8a5c8d316149ef0351370a7270d736b7790a63f7aef.zip",
+          "S3Key": "06baeab70999632a4e3cc409b8cd2be5f792718c5b87c4b6e7c2a3e62f8dea5d.zip",
         },
         "Description": "Manually re-stage a package version",
         "Environment": {
@@ -10686,7 +10686,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8513ede87f1f78c8666c55181afd61f8a0bf5550fa2c7602ba1a1e29e51f13ea.zip",
+          "S3Key": "67484159781c7060cc7cdb33b8048e4716cb544b688651a21f3f911d27368f5a.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -10893,7 +10893,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "caf5affd59290949115d9efddec9219f76f903a26d7fcacad6c9347401b76dcc.zip",
+          "S3Key": "63f16dd0b96a26b73688f3466e919fcf23121ea9959b282716c2384846456b71.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -11246,7 +11246,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "14700f3f8dd2f4997b0e6380f2714c17996184ef4a12d7990ce58b009105e158.zip",
+          "S3Key": "e42a736be21cd3134b9bff4e71e3afa99a4cc900ae489e9a7f7025c8d258f9b8.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -11258,7 +11258,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "14700f3f8dd2f4997b0e6380f2714c17996184ef4a12d7990ce58b009105e158.zip",
+          "S3Key": "e42a736be21cd3134b9bff4e71e3afa99a4cc900ae489e9a7f7025c8d258f9b8.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -11325,7 +11325,7 @@ function handler(event) {
           },
         ],
         "SourceObjectKeys": [
-          "cfeb64a21b1bb5d2d1d9f1c76c63615906363b832b15503a5fcdca3ee49bbfa7.zip",
+          "03ff63241c3f1c9d7021041d8625bfb618c4168b528678b2a75bb4fdf5b9e494.zip",
         ],
         "SystemMetadata": {
           "cache-control": "public, max-age=300, must-revalidate, s-maxage=60, proxy-revalidate",
@@ -12154,7 +12154,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "e86d3b422569c60272b31220da71a30ded5f90d2ecc0ca5c58d9c4c9636eda33.zip",
+          "S3Key": "7137b7e7a9a48e520b475aa8e033a5bb06ccc23c444fb43f8bbb929b392856ef.zip",
         },
         "Description": "[ConstructHub/MissingDocumentationWidget] Is a custom CloudWatch widget handler",
         "Environment": {
@@ -12580,7 +12580,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "e231a43a9013f5f24f6a32022c61f09e9cd5fa08fe931e606bb81684040e7368.zip",
+          "S3Key": "6f514377b81eebe35b39ede58c98d89a6844c14c5a52e839071f48f96dad01d7.zip",
         },
         "Description": "[ConstructHub/SQSDLQWidget] Is a custom CloudWatch widget handler",
         "Handler": "index.handler",
@@ -14085,7 +14085,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "14700f3f8dd2f4997b0e6380f2714c17996184ef4a12d7990ce58b009105e158.zip",
+          "S3Key": "e42a736be21cd3134b9bff4e71e3afa99a4cc900ae489e9a7f7025c8d258f9b8.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -14451,7 +14451,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "95c4189864dbf50a528d71bba7983f1c72ecdb4e0a84b258370eb164a2d8b5f1.zip",
+          "S3Key": "ceb8637c8e04b94b162bc128e7a7c24d7ca560b4977e762837487bc934cec374.zip",
         },
         "Description": "backend/deny-list/prune-handler.lambda.ts",
         "Environment": {
@@ -14647,7 +14647,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "70eca9bc2a5f6d903868ff0f1d4b2a68171d2aa8762f79b2e2dceb61071952ee.zip",
+          "S3Key": "0e9bd53c8e4cc8a3d66c0a9c0e289a20644114d9925d5320894badf88f29f57b.zip",
         },
         "Description": "backend/deny-list/prune-queue-handler.lambda.ts",
         "Environment": {
@@ -14928,7 +14928,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "649504c66341123a000af00370bc1425ff679e340cc98fc16a854ffa71be9e87.zip",
+          "S3Key": "e4ab225c7936f2eae3602ace6c2d52ffce6265902becdacba8bfa453a7947993.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -15156,7 +15156,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "a323116d13e8b02fd6df324424f01a89d685b1cdd34085c24fceba637051ebea.zip",
+          "S3Key": "8e156a6d01a8cba082af6b52bf9b3f5d8ff0372fc2bd65db725e9320e703a33c.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": {
@@ -15386,7 +15386,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "14700f3f8dd2f4997b0e6380f2714c17996184ef4a12d7990ce58b009105e158.zip",
+          "S3Key": "e42a736be21cd3134b9bff4e71e3afa99a4cc900ae489e9a7f7025c8d258f9b8.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -15600,7 +15600,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "586a1de4c6dfa1effbf944e236b43ee8e7098f5fe44764b1abf7505aab6eb68b.zip",
+          "S3Key": "21d95dae27beb007008f118941bd01cdc870aa25991c17d5544375f72f926187.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -15778,7 +15778,7 @@ Direct link to the function: /lambda/home#/functions/",
               {
                 "Ref": "ConstructHubPackageDataDC5EF35E",
               },
-              "","Prefix":"data/"}},"Is there more?":{"Type":"Choice","Choices":[{"Variable":"$.response.NextContinuationToken","IsPresent":true,"Next":"Give room for on-demand work"}],"Default":"Process Result"},"S3.ListObjectsV2(NextPage)":{"Next":"Is there more?","Retry":[{"ErrorEquals":["S3.SdkClientException"]}],"Type":"Task","ResultPath":"$.response","Resource":"arn:",
+              "","Prefix":"data/","MaxKeys":900}},"Is there more?":{"Type":"Choice","Choices":[{"Variable":"$.response.NextContinuationToken","IsPresent":true,"Next":"Give room for on-demand work"}],"Default":"Process Result"},"S3.ListObjectsV2(NextPage)":{"Next":"Is there more?","Retry":[{"ErrorEquals":["S3.SdkClientException"]}],"Type":"Task","ResultPath":"$.response","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -15786,7 +15786,7 @@ Direct link to the function: /lambda/home#/functions/",
               {
                 "Ref": "ConstructHubPackageDataDC5EF35E",
               },
-              "","ContinuationToken.$":"$.ContinuationToken","Prefix":"data/"}},"Process Result":{"Type":"Map","ResultPath":null,"End":true,"InputPath":"$.response.Contents[*][?(@.Key =~ /^.*/metadata.json$/)]","Iterator":{"StartAt":"Send for reprocessing","States":{"Send for reprocessing":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["Lambda.TooManyRequestsException"],"IntervalSeconds":60,"MaxAttempts":30,"BackoffRate":1.1}],"Type":"Task","Resource":"arn:",
+              "","ContinuationToken.$":"$.ContinuationToken","Prefix":"data/","MaxKeys":900}},"Process Result":{"Type":"Map","ResultPath":null,"End":true,"InputPath":"$.response.Contents[*][?(@.Key =~ /^.*/metadata.json$/)]","Iterator":{"StartAt":"Send for reprocessing","States":{"Send for reprocessing":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["Lambda.TooManyRequestsException"],"IntervalSeconds":60,"MaxAttempts":30,"BackoffRate":1.1}],"Type":"Task","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -16346,7 +16346,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "3838f09986ecd1cf5f4e98caedec8eb0c845339172bcc8711b519a8987cc56ee.zip",
+          "S3Key": "92ea79a00d10208fdffeff6b1413b88ef1d6d6c927cd6129d66378ed694aad89.zip",
         },
         "Description": "[ConstructHub/Inventory] A canary that periodically inspects the list of indexed packages",
         "Environment": {
@@ -17007,7 +17007,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "14700f3f8dd2f4997b0e6380f2714c17996184ef4a12d7990ce58b009105e158.zip",
+          "S3Key": "e42a736be21cd3134b9bff4e71e3afa99a4cc900ae489e9a7f7025c8d258f9b8.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -17843,7 +17843,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1a89160600b3e2be7ade4a88a50d22e06a082f0fad411e72f7a9e50ea9753d57.zip",
+          "S3Key": "161c86d2d771967ab8aff9dbf517646eab724a16d0857b5a5b23ed8b8acc6d5d.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -18157,7 +18157,7 @@ RUNBOOK: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "aac6c06e2f850f244bd1349125480a92d2b7ddaaecafea7c9549adc1502e4689.zip",
+          "S3Key": "e78ec9ac5931add41bdf700f8036a5a8479040627b91be5ee9dc1939e19ae8fe.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -18911,7 +18911,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "42c84f4df5864e35ab9ea480fe64a7e118525bdc344197a746412f5bbef2bb0d.zip",
+          "S3Key": "1124b946bc8e940fb46cd2c462cdc1b7e54fe418faf9b3c9c5da6dbaab65a845.zip",
         },
         "Description": "[ConstructHub/Orchestration/NeedsCatalogUpdate] Determines whether a package version requires a catalog update",
         "Environment": {
@@ -19066,7 +19066,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "e6d7b8e2302080b4decb9b19e2e42698b613eaedbf8c76eaf3c05707834302e4.zip",
+          "S3Key": "103ed25c76ca9342bd8adde12b324f70d94bdb2e4bd9f323edd939cfe199046b.zip",
         },
         "Description": "[ConstructHub/Redrive] Manually redrives all messages from the backend dead letter queue",
         "Environment": {
@@ -19885,7 +19885,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:bf8b65e8cdcb3defed4173acd317d002bc89d243f6af4ea630944bd9d1588f97",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:ddb9ed165690d6ce66795af95dae2c6b20649748078572102587d317b2db0be7",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -22523,7 +22523,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "3d8d55e227ba16eb24dac3993e02e2fb06ba0ccc82f242a46c657e5e72012203.zip",
+          "S3Key": "fc45da1e5e21ad2d736d1d9043ce17cd8132932a3db40dd86fc17179ed2bd5c0.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -22577,7 +22577,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1eacc73709e81960105bc44d627f04480e4b44efb5efac714992814577bd92c4.zip",
+          "S3Key": "79a486bea9ba022ce3d8f154abcf61a411aea3c232d58104ef39a50f8aaff534.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": {
@@ -23282,7 +23282,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "7eeec3dd2bbda52e5b4dc6f329293bc1fd1adabc4a2427331a4e1e4fe8a46cc5.zip",
+          "S3Key": "3bf73d07c5e1a0bd778e16496f53f9802a317e45f13f6366315f49d9842104ef.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -23594,7 +23594,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "9d6ad85b84ac4981fd40d8a5c8d316149ef0351370a7270d736b7790a63f7aef.zip",
+          "S3Key": "06baeab70999632a4e3cc409b8cd2be5f792718c5b87c4b6e7c2a3e62f8dea5d.zip",
         },
         "Description": "Manually re-stage a package version",
         "Environment": {
@@ -23803,7 +23803,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8513ede87f1f78c8666c55181afd61f8a0bf5550fa2c7602ba1a1e29e51f13ea.zip",
+          "S3Key": "67484159781c7060cc7cdb33b8048e4716cb544b688651a21f3f911d27368f5a.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -24010,7 +24010,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "caf5affd59290949115d9efddec9219f76f903a26d7fcacad6c9347401b76dcc.zip",
+          "S3Key": "63f16dd0b96a26b73688f3466e919fcf23121ea9959b282716c2384846456b71.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -24363,7 +24363,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "14700f3f8dd2f4997b0e6380f2714c17996184ef4a12d7990ce58b009105e158.zip",
+          "S3Key": "e42a736be21cd3134b9bff4e71e3afa99a4cc900ae489e9a7f7025c8d258f9b8.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -24375,7 +24375,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "14700f3f8dd2f4997b0e6380f2714c17996184ef4a12d7990ce58b009105e158.zip",
+          "S3Key": "e42a736be21cd3134b9bff4e71e3afa99a4cc900ae489e9a7f7025c8d258f9b8.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -24442,7 +24442,7 @@ function handler(event) {
           },
         ],
         "SourceObjectKeys": [
-          "cfeb64a21b1bb5d2d1d9f1c76c63615906363b832b15503a5fcdca3ee49bbfa7.zip",
+          "03ff63241c3f1c9d7021041d8625bfb618c4168b528678b2a75bb4fdf5b9e494.zip",
         ],
         "SystemMetadata": {
           "cache-control": "public, max-age=300, must-revalidate, s-maxage=60, proxy-revalidate",
@@ -25271,7 +25271,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "e86d3b422569c60272b31220da71a30ded5f90d2ecc0ca5c58d9c4c9636eda33.zip",
+          "S3Key": "7137b7e7a9a48e520b475aa8e033a5bb06ccc23c444fb43f8bbb929b392856ef.zip",
         },
         "Description": "[ConstructHub/MissingDocumentationWidget] Is a custom CloudWatch widget handler",
         "Environment": {
@@ -25697,7 +25697,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "e231a43a9013f5f24f6a32022c61f09e9cd5fa08fe931e606bb81684040e7368.zip",
+          "S3Key": "6f514377b81eebe35b39ede58c98d89a6844c14c5a52e839071f48f96dad01d7.zip",
         },
         "Description": "[ConstructHub/SQSDLQWidget] Is a custom CloudWatch widget handler",
         "Handler": "index.handler",
@@ -26945,7 +26945,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "14700f3f8dd2f4997b0e6380f2714c17996184ef4a12d7990ce58b009105e158.zip",
+          "S3Key": "e42a736be21cd3134b9bff4e71e3afa99a4cc900ae489e9a7f7025c8d258f9b8.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -27311,7 +27311,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "95c4189864dbf50a528d71bba7983f1c72ecdb4e0a84b258370eb164a2d8b5f1.zip",
+          "S3Key": "ceb8637c8e04b94b162bc128e7a7c24d7ca560b4977e762837487bc934cec374.zip",
         },
         "Description": "backend/deny-list/prune-handler.lambda.ts",
         "Environment": {
@@ -27507,7 +27507,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "70eca9bc2a5f6d903868ff0f1d4b2a68171d2aa8762f79b2e2dceb61071952ee.zip",
+          "S3Key": "0e9bd53c8e4cc8a3d66c0a9c0e289a20644114d9925d5320894badf88f29f57b.zip",
         },
         "Description": "backend/deny-list/prune-queue-handler.lambda.ts",
         "Environment": {
@@ -27788,7 +27788,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "649504c66341123a000af00370bc1425ff679e340cc98fc16a854ffa71be9e87.zip",
+          "S3Key": "e4ab225c7936f2eae3602ace6c2d52ffce6265902becdacba8bfa453a7947993.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -28016,7 +28016,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "a323116d13e8b02fd6df324424f01a89d685b1cdd34085c24fceba637051ebea.zip",
+          "S3Key": "8e156a6d01a8cba082af6b52bf9b3f5d8ff0372fc2bd65db725e9320e703a33c.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": {
@@ -28228,7 +28228,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "14700f3f8dd2f4997b0e6380f2714c17996184ef4a12d7990ce58b009105e158.zip",
+          "S3Key": "e42a736be21cd3134b9bff4e71e3afa99a4cc900ae489e9a7f7025c8d258f9b8.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -28442,7 +28442,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "586a1de4c6dfa1effbf944e236b43ee8e7098f5fe44764b1abf7505aab6eb68b.zip",
+          "S3Key": "21d95dae27beb007008f118941bd01cdc870aa25991c17d5544375f72f926187.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -28620,7 +28620,7 @@ Direct link to the function: /lambda/home#/functions/",
               {
                 "Ref": "ConstructHubPackageDataDC5EF35E",
               },
-              "","Prefix":"data/"}},"Is there more?":{"Type":"Choice","Choices":[{"Variable":"$.response.NextContinuationToken","IsPresent":true,"Next":"Give room for on-demand work"}],"Default":"Process Result"},"S3.ListObjectsV2(NextPage)":{"Next":"Is there more?","Retry":[{"ErrorEquals":["S3.SdkClientException"]}],"Type":"Task","ResultPath":"$.response","Resource":"arn:",
+              "","Prefix":"data/","MaxKeys":900}},"Is there more?":{"Type":"Choice","Choices":[{"Variable":"$.response.NextContinuationToken","IsPresent":true,"Next":"Give room for on-demand work"}],"Default":"Process Result"},"S3.ListObjectsV2(NextPage)":{"Next":"Is there more?","Retry":[{"ErrorEquals":["S3.SdkClientException"]}],"Type":"Task","ResultPath":"$.response","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -28628,7 +28628,7 @@ Direct link to the function: /lambda/home#/functions/",
               {
                 "Ref": "ConstructHubPackageDataDC5EF35E",
               },
-              "","ContinuationToken.$":"$.ContinuationToken","Prefix":"data/"}},"Process Result":{"Type":"Map","ResultPath":null,"End":true,"InputPath":"$.response.Contents[*][?(@.Key =~ /^.*/metadata.json$/)]","Iterator":{"StartAt":"Send for reprocessing","States":{"Send for reprocessing":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["Lambda.TooManyRequestsException"],"IntervalSeconds":60,"MaxAttempts":30,"BackoffRate":1.1}],"Type":"Task","Resource":"arn:",
+              "","ContinuationToken.$":"$.ContinuationToken","Prefix":"data/","MaxKeys":900}},"Process Result":{"Type":"Map","ResultPath":null,"End":true,"InputPath":"$.response.Contents[*][?(@.Key =~ /^.*/metadata.json$/)]","Iterator":{"StartAt":"Send for reprocessing","States":{"Send for reprocessing":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["Lambda.TooManyRequestsException"],"IntervalSeconds":60,"MaxAttempts":30,"BackoffRate":1.1}],"Type":"Task","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -29108,7 +29108,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "3838f09986ecd1cf5f4e98caedec8eb0c845339172bcc8711b519a8987cc56ee.zip",
+          "S3Key": "92ea79a00d10208fdffeff6b1413b88ef1d6d6c927cd6129d66378ed694aad89.zip",
         },
         "Description": "[ConstructHub/Inventory] A canary that periodically inspects the list of indexed packages",
         "Environment": {
@@ -29769,7 +29769,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "14700f3f8dd2f4997b0e6380f2714c17996184ef4a12d7990ce58b009105e158.zip",
+          "S3Key": "e42a736be21cd3134b9bff4e71e3afa99a4cc900ae489e9a7f7025c8d258f9b8.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -30605,7 +30605,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1a89160600b3e2be7ade4a88a50d22e06a082f0fad411e72f7a9e50ea9753d57.zip",
+          "S3Key": "161c86d2d771967ab8aff9dbf517646eab724a16d0857b5a5b23ed8b8acc6d5d.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -30919,7 +30919,7 @@ RUNBOOK: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "aac6c06e2f850f244bd1349125480a92d2b7ddaaecafea7c9549adc1502e4689.zip",
+          "S3Key": "e78ec9ac5931add41bdf700f8036a5a8479040627b91be5ee9dc1939e19ae8fe.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -31673,7 +31673,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "42c84f4df5864e35ab9ea480fe64a7e118525bdc344197a746412f5bbef2bb0d.zip",
+          "S3Key": "1124b946bc8e940fb46cd2c462cdc1b7e54fe418faf9b3c9c5da6dbaab65a845.zip",
         },
         "Description": "[ConstructHub/Orchestration/NeedsCatalogUpdate] Determines whether a package version requires a catalog update",
         "Environment": {
@@ -31828,7 +31828,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "e6d7b8e2302080b4decb9b19e2e42698b613eaedbf8c76eaf3c05707834302e4.zip",
+          "S3Key": "103ed25c76ca9342bd8adde12b324f70d94bdb2e4bd9f323edd939cfe199046b.zip",
         },
         "Description": "[ConstructHub/Redrive] Manually redrives all messages from the backend dead letter queue",
         "Environment": {
@@ -32620,7 +32620,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:bf8b65e8cdcb3defed4173acd317d002bc89d243f6af4ea630944bd9d1588f97",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:ddb9ed165690d6ce66795af95dae2c6b20649748078572102587d317b2db0be7",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -35212,7 +35212,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "3d8d55e227ba16eb24dac3993e02e2fb06ba0ccc82f242a46c657e5e72012203.zip",
+          "S3Key": "fc45da1e5e21ad2d736d1d9043ce17cd8132932a3db40dd86fc17179ed2bd5c0.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -35266,7 +35266,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1eacc73709e81960105bc44d627f04480e4b44efb5efac714992814577bd92c4.zip",
+          "S3Key": "79a486bea9ba022ce3d8f154abcf61a411aea3c232d58104ef39a50f8aaff534.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": {
@@ -35971,7 +35971,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "7eeec3dd2bbda52e5b4dc6f329293bc1fd1adabc4a2427331a4e1e4fe8a46cc5.zip",
+          "S3Key": "3bf73d07c5e1a0bd778e16496f53f9802a317e45f13f6366315f49d9842104ef.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -36283,7 +36283,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "9d6ad85b84ac4981fd40d8a5c8d316149ef0351370a7270d736b7790a63f7aef.zip",
+          "S3Key": "06baeab70999632a4e3cc409b8cd2be5f792718c5b87c4b6e7c2a3e62f8dea5d.zip",
         },
         "Description": "Manually re-stage a package version",
         "Environment": {
@@ -36492,7 +36492,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8513ede87f1f78c8666c55181afd61f8a0bf5550fa2c7602ba1a1e29e51f13ea.zip",
+          "S3Key": "67484159781c7060cc7cdb33b8048e4716cb544b688651a21f3f911d27368f5a.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -36699,7 +36699,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "caf5affd59290949115d9efddec9219f76f903a26d7fcacad6c9347401b76dcc.zip",
+          "S3Key": "63f16dd0b96a26b73688f3466e919fcf23121ea9959b282716c2384846456b71.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -37052,7 +37052,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "14700f3f8dd2f4997b0e6380f2714c17996184ef4a12d7990ce58b009105e158.zip",
+          "S3Key": "e42a736be21cd3134b9bff4e71e3afa99a4cc900ae489e9a7f7025c8d258f9b8.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -37064,7 +37064,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "14700f3f8dd2f4997b0e6380f2714c17996184ef4a12d7990ce58b009105e158.zip",
+          "S3Key": "e42a736be21cd3134b9bff4e71e3afa99a4cc900ae489e9a7f7025c8d258f9b8.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -37131,7 +37131,7 @@ function handler(event) {
           },
         ],
         "SourceObjectKeys": [
-          "cfeb64a21b1bb5d2d1d9f1c76c63615906363b832b15503a5fcdca3ee49bbfa7.zip",
+          "03ff63241c3f1c9d7021041d8625bfb618c4168b528678b2a75bb4fdf5b9e494.zip",
         ],
         "SystemMetadata": {
           "cache-control": "public, max-age=300, must-revalidate, s-maxage=60, proxy-revalidate",
@@ -37960,7 +37960,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "e86d3b422569c60272b31220da71a30ded5f90d2ecc0ca5c58d9c4c9636eda33.zip",
+          "S3Key": "7137b7e7a9a48e520b475aa8e033a5bb06ccc23c444fb43f8bbb929b392856ef.zip",
         },
         "Description": "[ConstructHub/MissingDocumentationWidget] Is a custom CloudWatch widget handler",
         "Environment": {
@@ -38386,7 +38386,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "e231a43a9013f5f24f6a32022c61f09e9cd5fa08fe931e606bb81684040e7368.zip",
+          "S3Key": "6f514377b81eebe35b39ede58c98d89a6844c14c5a52e839071f48f96dad01d7.zip",
         },
         "Description": "[ConstructHub/SQSDLQWidget] Is a custom CloudWatch widget handler",
         "Handler": "index.handler",
@@ -39774,7 +39774,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "14700f3f8dd2f4997b0e6380f2714c17996184ef4a12d7990ce58b009105e158.zip",
+          "S3Key": "e42a736be21cd3134b9bff4e71e3afa99a4cc900ae489e9a7f7025c8d258f9b8.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -40140,7 +40140,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "95c4189864dbf50a528d71bba7983f1c72ecdb4e0a84b258370eb164a2d8b5f1.zip",
+          "S3Key": "ceb8637c8e04b94b162bc128e7a7c24d7ca560b4977e762837487bc934cec374.zip",
         },
         "Description": "backend/deny-list/prune-handler.lambda.ts",
         "Environment": {
@@ -40336,7 +40336,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "70eca9bc2a5f6d903868ff0f1d4b2a68171d2aa8762f79b2e2dceb61071952ee.zip",
+          "S3Key": "0e9bd53c8e4cc8a3d66c0a9c0e289a20644114d9925d5320894badf88f29f57b.zip",
         },
         "Description": "backend/deny-list/prune-queue-handler.lambda.ts",
         "Environment": {
@@ -40617,7 +40617,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "649504c66341123a000af00370bc1425ff679e340cc98fc16a854ffa71be9e87.zip",
+          "S3Key": "e4ab225c7936f2eae3602ace6c2d52ffce6265902becdacba8bfa453a7947993.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -40832,7 +40832,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "a323116d13e8b02fd6df324424f01a89d685b1cdd34085c24fceba637051ebea.zip",
+          "S3Key": "8e156a6d01a8cba082af6b52bf9b3f5d8ff0372fc2bd65db725e9320e703a33c.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": {
@@ -41044,7 +41044,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "14700f3f8dd2f4997b0e6380f2714c17996184ef4a12d7990ce58b009105e158.zip",
+          "S3Key": "e42a736be21cd3134b9bff4e71e3afa99a4cc900ae489e9a7f7025c8d258f9b8.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -41258,7 +41258,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "586a1de4c6dfa1effbf944e236b43ee8e7098f5fe44764b1abf7505aab6eb68b.zip",
+          "S3Key": "21d95dae27beb007008f118941bd01cdc870aa25991c17d5544375f72f926187.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -41436,7 +41436,7 @@ Direct link to the function: /lambda/home#/functions/",
               {
                 "Ref": "ConstructHubPackageDataDC5EF35E",
               },
-              "","Prefix":"data/"}},"Is there more?":{"Type":"Choice","Choices":[{"Variable":"$.response.NextContinuationToken","IsPresent":true,"Next":"Give room for on-demand work"}],"Default":"Process Result"},"S3.ListObjectsV2(NextPage)":{"Next":"Is there more?","Retry":[{"ErrorEquals":["S3.SdkClientException"]}],"Type":"Task","ResultPath":"$.response","Resource":"arn:",
+              "","Prefix":"data/","MaxKeys":900}},"Is there more?":{"Type":"Choice","Choices":[{"Variable":"$.response.NextContinuationToken","IsPresent":true,"Next":"Give room for on-demand work"}],"Default":"Process Result"},"S3.ListObjectsV2(NextPage)":{"Next":"Is there more?","Retry":[{"ErrorEquals":["S3.SdkClientException"]}],"Type":"Task","ResultPath":"$.response","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -41444,7 +41444,7 @@ Direct link to the function: /lambda/home#/functions/",
               {
                 "Ref": "ConstructHubPackageDataDC5EF35E",
               },
-              "","ContinuationToken.$":"$.ContinuationToken","Prefix":"data/"}},"Process Result":{"Type":"Map","ResultPath":null,"End":true,"InputPath":"$.response.Contents[*][?(@.Key =~ /^.*/metadata.json$/)]","Iterator":{"StartAt":"Send for reprocessing","States":{"Send for reprocessing":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["Lambda.TooManyRequestsException"],"IntervalSeconds":60,"MaxAttempts":30,"BackoffRate":1.1}],"Type":"Task","Resource":"arn:",
+              "","ContinuationToken.$":"$.ContinuationToken","Prefix":"data/","MaxKeys":900}},"Process Result":{"Type":"Map","ResultPath":null,"End":true,"InputPath":"$.response.Contents[*][?(@.Key =~ /^.*/metadata.json$/)]","Iterator":{"StartAt":"Send for reprocessing","States":{"Send for reprocessing":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["Lambda.TooManyRequestsException"],"IntervalSeconds":60,"MaxAttempts":30,"BackoffRate":1.1}],"Type":"Task","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -41924,7 +41924,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "3838f09986ecd1cf5f4e98caedec8eb0c845339172bcc8711b519a8987cc56ee.zip",
+          "S3Key": "92ea79a00d10208fdffeff6b1413b88ef1d6d6c927cd6129d66378ed694aad89.zip",
         },
         "Description": "[ConstructHub/Inventory] A canary that periodically inspects the list of indexed packages",
         "Environment": {
@@ -42585,7 +42585,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "14700f3f8dd2f4997b0e6380f2714c17996184ef4a12d7990ce58b009105e158.zip",
+          "S3Key": "e42a736be21cd3134b9bff4e71e3afa99a4cc900ae489e9a7f7025c8d258f9b8.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -43443,7 +43443,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1a89160600b3e2be7ade4a88a50d22e06a082f0fad411e72f7a9e50ea9753d57.zip",
+          "S3Key": "161c86d2d771967ab8aff9dbf517646eab724a16d0857b5a5b23ed8b8acc6d5d.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -43757,7 +43757,7 @@ RUNBOOK: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "aac6c06e2f850f244bd1349125480a92d2b7ddaaecafea7c9549adc1502e4689.zip",
+          "S3Key": "e78ec9ac5931add41bdf700f8036a5a8479040627b91be5ee9dc1939e19ae8fe.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -44511,7 +44511,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "42c84f4df5864e35ab9ea480fe64a7e118525bdc344197a746412f5bbef2bb0d.zip",
+          "S3Key": "1124b946bc8e940fb46cd2c462cdc1b7e54fe418faf9b3c9c5da6dbaab65a845.zip",
         },
         "Description": "[ConstructHub/Orchestration/NeedsCatalogUpdate] Determines whether a package version requires a catalog update",
         "Environment": {
@@ -44666,7 +44666,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "e6d7b8e2302080b4decb9b19e2e42698b613eaedbf8c76eaf3c05707834302e4.zip",
+          "S3Key": "103ed25c76ca9342bd8adde12b324f70d94bdb2e4bd9f323edd939cfe199046b.zip",
         },
         "Description": "[ConstructHub/Redrive] Manually redrives all messages from the backend dead letter queue",
         "Environment": {
@@ -45458,7 +45458,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:bf8b65e8cdcb3defed4173acd317d002bc89d243f6af4ea630944bd9d1588f97",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:ddb9ed165690d6ce66795af95dae2c6b20649748078572102587d317b2db0be7",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -48050,7 +48050,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "3d8d55e227ba16eb24dac3993e02e2fb06ba0ccc82f242a46c657e5e72012203.zip",
+          "S3Key": "fc45da1e5e21ad2d736d1d9043ce17cd8132932a3db40dd86fc17179ed2bd5c0.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -48104,7 +48104,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1eacc73709e81960105bc44d627f04480e4b44efb5efac714992814577bd92c4.zip",
+          "S3Key": "79a486bea9ba022ce3d8f154abcf61a411aea3c232d58104ef39a50f8aaff534.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": {
@@ -48796,7 +48796,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "7eeec3dd2bbda52e5b4dc6f329293bc1fd1adabc4a2427331a4e1e4fe8a46cc5.zip",
+          "S3Key": "3bf73d07c5e1a0bd778e16496f53f9802a317e45f13f6366315f49d9842104ef.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -49108,7 +49108,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "9d6ad85b84ac4981fd40d8a5c8d316149ef0351370a7270d736b7790a63f7aef.zip",
+          "S3Key": "06baeab70999632a4e3cc409b8cd2be5f792718c5b87c4b6e7c2a3e62f8dea5d.zip",
         },
         "Description": "Manually re-stage a package version",
         "Environment": {
@@ -49317,7 +49317,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8513ede87f1f78c8666c55181afd61f8a0bf5550fa2c7602ba1a1e29e51f13ea.zip",
+          "S3Key": "67484159781c7060cc7cdb33b8048e4716cb544b688651a21f3f911d27368f5a.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -49524,7 +49524,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "caf5affd59290949115d9efddec9219f76f903a26d7fcacad6c9347401b76dcc.zip",
+          "S3Key": "63f16dd0b96a26b73688f3466e919fcf23121ea9959b282716c2384846456b71.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -49929,7 +49929,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "14700f3f8dd2f4997b0e6380f2714c17996184ef4a12d7990ce58b009105e158.zip",
+          "S3Key": "e42a736be21cd3134b9bff4e71e3afa99a4cc900ae489e9a7f7025c8d258f9b8.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -49941,7 +49941,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "14700f3f8dd2f4997b0e6380f2714c17996184ef4a12d7990ce58b009105e158.zip",
+          "S3Key": "e42a736be21cd3134b9bff4e71e3afa99a4cc900ae489e9a7f7025c8d258f9b8.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -50008,7 +50008,7 @@ function handler(event) {
           },
         ],
         "SourceObjectKeys": [
-          "cfeb64a21b1bb5d2d1d9f1c76c63615906363b832b15503a5fcdca3ee49bbfa7.zip",
+          "03ff63241c3f1c9d7021041d8625bfb618c4168b528678b2a75bb4fdf5b9e494.zip",
         ],
         "SystemMetadata": {
           "cache-control": "public, max-age=300, must-revalidate, s-maxage=60, proxy-revalidate",
@@ -51035,7 +51035,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "e86d3b422569c60272b31220da71a30ded5f90d2ecc0ca5c58d9c4c9636eda33.zip",
+          "S3Key": "7137b7e7a9a48e520b475aa8e033a5bb06ccc23c444fb43f8bbb929b392856ef.zip",
         },
         "Description": "[ConstructHub/MissingDocumentationWidget] Is a custom CloudWatch widget handler",
         "Environment": {
@@ -51461,7 +51461,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "e231a43a9013f5f24f6a32022c61f09e9cd5fa08fe931e606bb81684040e7368.zip",
+          "S3Key": "6f514377b81eebe35b39ede58c98d89a6844c14c5a52e839071f48f96dad01d7.zip",
         },
         "Description": "[ConstructHub/SQSDLQWidget] Is a custom CloudWatch widget handler",
         "Handler": "index.handler",
@@ -52786,7 +52786,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "14700f3f8dd2f4997b0e6380f2714c17996184ef4a12d7990ce58b009105e158.zip",
+          "S3Key": "e42a736be21cd3134b9bff4e71e3afa99a4cc900ae489e9a7f7025c8d258f9b8.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -53152,7 +53152,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "95c4189864dbf50a528d71bba7983f1c72ecdb4e0a84b258370eb164a2d8b5f1.zip",
+          "S3Key": "ceb8637c8e04b94b162bc128e7a7c24d7ca560b4977e762837487bc934cec374.zip",
         },
         "Description": "backend/deny-list/prune-handler.lambda.ts",
         "Environment": {
@@ -53348,7 +53348,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "70eca9bc2a5f6d903868ff0f1d4b2a68171d2aa8762f79b2e2dceb61071952ee.zip",
+          "S3Key": "0e9bd53c8e4cc8a3d66c0a9c0e289a20644114d9925d5320894badf88f29f57b.zip",
         },
         "Description": "backend/deny-list/prune-queue-handler.lambda.ts",
         "Environment": {
@@ -53629,7 +53629,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "649504c66341123a000af00370bc1425ff679e340cc98fc16a854ffa71be9e87.zip",
+          "S3Key": "e4ab225c7936f2eae3602ace6c2d52ffce6265902becdacba8bfa453a7947993.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -53857,7 +53857,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "a323116d13e8b02fd6df324424f01a89d685b1cdd34085c24fceba637051ebea.zip",
+          "S3Key": "8e156a6d01a8cba082af6b52bf9b3f5d8ff0372fc2bd65db725e9320e703a33c.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": {
@@ -54069,7 +54069,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "14700f3f8dd2f4997b0e6380f2714c17996184ef4a12d7990ce58b009105e158.zip",
+          "S3Key": "e42a736be21cd3134b9bff4e71e3afa99a4cc900ae489e9a7f7025c8d258f9b8.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -54283,7 +54283,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "586a1de4c6dfa1effbf944e236b43ee8e7098f5fe44764b1abf7505aab6eb68b.zip",
+          "S3Key": "21d95dae27beb007008f118941bd01cdc870aa25991c17d5544375f72f926187.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -54461,7 +54461,7 @@ Direct link to the function: /lambda/home#/functions/",
               {
                 "Ref": "ConstructHubPackageDataDC5EF35E",
               },
-              "","Prefix":"data/"}},"Is there more?":{"Type":"Choice","Choices":[{"Variable":"$.response.NextContinuationToken","IsPresent":true,"Next":"Give room for on-demand work"}],"Default":"Process Result"},"S3.ListObjectsV2(NextPage)":{"Next":"Is there more?","Retry":[{"ErrorEquals":["S3.SdkClientException"]}],"Type":"Task","ResultPath":"$.response","Resource":"arn:",
+              "","Prefix":"data/","MaxKeys":900}},"Is there more?":{"Type":"Choice","Choices":[{"Variable":"$.response.NextContinuationToken","IsPresent":true,"Next":"Give room for on-demand work"}],"Default":"Process Result"},"S3.ListObjectsV2(NextPage)":{"Next":"Is there more?","Retry":[{"ErrorEquals":["S3.SdkClientException"]}],"Type":"Task","ResultPath":"$.response","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -54469,7 +54469,7 @@ Direct link to the function: /lambda/home#/functions/",
               {
                 "Ref": "ConstructHubPackageDataDC5EF35E",
               },
-              "","ContinuationToken.$":"$.ContinuationToken","Prefix":"data/"}},"Process Result":{"Type":"Map","ResultPath":null,"End":true,"InputPath":"$.response.Contents[*][?(@.Key =~ /^.*/metadata.json$/)]","Iterator":{"StartAt":"Send for reprocessing","States":{"Send for reprocessing":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["Lambda.TooManyRequestsException"],"IntervalSeconds":60,"MaxAttempts":30,"BackoffRate":1.1}],"Type":"Task","Resource":"arn:",
+              "","ContinuationToken.$":"$.ContinuationToken","Prefix":"data/","MaxKeys":900}},"Process Result":{"Type":"Map","ResultPath":null,"End":true,"InputPath":"$.response.Contents[*][?(@.Key =~ /^.*/metadata.json$/)]","Iterator":{"StartAt":"Send for reprocessing","States":{"Send for reprocessing":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["Lambda.TooManyRequestsException"],"IntervalSeconds":60,"MaxAttempts":30,"BackoffRate":1.1}],"Type":"Task","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -55075,7 +55075,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "3838f09986ecd1cf5f4e98caedec8eb0c845339172bcc8711b519a8987cc56ee.zip",
+          "S3Key": "92ea79a00d10208fdffeff6b1413b88ef1d6d6c927cd6129d66378ed694aad89.zip",
         },
         "Description": "[ConstructHub/Inventory] A canary that periodically inspects the list of indexed packages",
         "Environment": {
@@ -55736,7 +55736,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "14700f3f8dd2f4997b0e6380f2714c17996184ef4a12d7990ce58b009105e158.zip",
+          "S3Key": "e42a736be21cd3134b9bff4e71e3afa99a4cc900ae489e9a7f7025c8d258f9b8.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -56601,7 +56601,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1a89160600b3e2be7ade4a88a50d22e06a082f0fad411e72f7a9e50ea9753d57.zip",
+          "S3Key": "161c86d2d771967ab8aff9dbf517646eab724a16d0857b5a5b23ed8b8acc6d5d.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -56915,7 +56915,7 @@ RUNBOOK: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "aac6c06e2f850f244bd1349125480a92d2b7ddaaecafea7c9549adc1502e4689.zip",
+          "S3Key": "e78ec9ac5931add41bdf700f8036a5a8479040627b91be5ee9dc1939e19ae8fe.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -57262,7 +57262,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "42c84f4df5864e35ab9ea480fe64a7e118525bdc344197a746412f5bbef2bb0d.zip",
+          "S3Key": "1124b946bc8e940fb46cd2c462cdc1b7e54fe418faf9b3c9c5da6dbaab65a845.zip",
         },
         "Description": "[ConstructHub/Orchestration/NeedsCatalogUpdate] Determines whether a package version requires a catalog update",
         "Environment": {
@@ -57417,7 +57417,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "e6d7b8e2302080b4decb9b19e2e42698b613eaedbf8c76eaf3c05707834302e4.zip",
+          "S3Key": "103ed25c76ca9342bd8adde12b324f70d94bdb2e4bd9f323edd939cfe199046b.zip",
         },
         "Description": "[ConstructHub/Redrive] Manually redrives all messages from the backend dead letter queue",
         "Environment": {
@@ -58215,7 +58215,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:bf8b65e8cdcb3defed4173acd317d002bc89d243f6af4ea630944bd9d1588f97",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:ddb9ed165690d6ce66795af95dae2c6b20649748078572102587d317b2db0be7",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -60869,7 +60869,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "3d8d55e227ba16eb24dac3993e02e2fb06ba0ccc82f242a46c657e5e72012203.zip",
+          "S3Key": "fc45da1e5e21ad2d736d1d9043ce17cd8132932a3db40dd86fc17179ed2bd5c0.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -60923,7 +60923,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1eacc73709e81960105bc44d627f04480e4b44efb5efac714992814577bd92c4.zip",
+          "S3Key": "79a486bea9ba022ce3d8f154abcf61a411aea3c232d58104ef39a50f8aaff534.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": {
@@ -61628,7 +61628,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "7eeec3dd2bbda52e5b4dc6f329293bc1fd1adabc4a2427331a4e1e4fe8a46cc5.zip",
+          "S3Key": "3bf73d07c5e1a0bd778e16496f53f9802a317e45f13f6366315f49d9842104ef.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -61940,7 +61940,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "9d6ad85b84ac4981fd40d8a5c8d316149ef0351370a7270d736b7790a63f7aef.zip",
+          "S3Key": "06baeab70999632a4e3cc409b8cd2be5f792718c5b87c4b6e7c2a3e62f8dea5d.zip",
         },
         "Description": "Manually re-stage a package version",
         "Environment": {
@@ -62149,7 +62149,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8513ede87f1f78c8666c55181afd61f8a0bf5550fa2c7602ba1a1e29e51f13ea.zip",
+          "S3Key": "67484159781c7060cc7cdb33b8048e4716cb544b688651a21f3f911d27368f5a.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -65216,7 +65216,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "caf5affd59290949115d9efddec9219f76f903a26d7fcacad6c9347401b76dcc.zip",
+          "S3Key": "63f16dd0b96a26b73688f3466e919fcf23121ea9959b282716c2384846456b71.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -65569,7 +65569,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "14700f3f8dd2f4997b0e6380f2714c17996184ef4a12d7990ce58b009105e158.zip",
+          "S3Key": "e42a736be21cd3134b9bff4e71e3afa99a4cc900ae489e9a7f7025c8d258f9b8.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -65581,7 +65581,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "14700f3f8dd2f4997b0e6380f2714c17996184ef4a12d7990ce58b009105e158.zip",
+          "S3Key": "e42a736be21cd3134b9bff4e71e3afa99a4cc900ae489e9a7f7025c8d258f9b8.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -65648,7 +65648,7 @@ function handler(event) {
           },
         ],
         "SourceObjectKeys": [
-          "cfeb64a21b1bb5d2d1d9f1c76c63615906363b832b15503a5fcdca3ee49bbfa7.zip",
+          "03ff63241c3f1c9d7021041d8625bfb618c4168b528678b2a75bb4fdf5b9e494.zip",
         ],
         "SystemMetadata": {
           "cache-control": "public, max-age=300, must-revalidate, s-maxage=60, proxy-revalidate",
@@ -67034,7 +67034,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "e86d3b422569c60272b31220da71a30ded5f90d2ecc0ca5c58d9c4c9636eda33.zip",
+          "S3Key": "7137b7e7a9a48e520b475aa8e033a5bb06ccc23c444fb43f8bbb929b392856ef.zip",
         },
         "Description": "[ConstructHub/MissingDocumentationWidget] Is a custom CloudWatch widget handler",
         "Environment": {
@@ -67460,7 +67460,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "e231a43a9013f5f24f6a32022c61f09e9cd5fa08fe931e606bb81684040e7368.zip",
+          "S3Key": "6f514377b81eebe35b39ede58c98d89a6844c14c5a52e839071f48f96dad01d7.zip",
         },
         "Description": "[ConstructHub/SQSDLQWidget] Is a custom CloudWatch widget handler",
         "Handler": "index.handler",

--- a/src/__tests__/backend/deny-list/__snapshots__/deny-list.test.ts.snap
+++ b/src/__tests__/backend/deny-list/__snapshots__/deny-list.test.ts.snap
@@ -566,7 +566,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "14700f3f8dd2f4997b0e6380f2714c17996184ef4a12d7990ce58b009105e158.zip",
+          "S3Key": "e42a736be21cd3134b9bff4e71e3afa99a4cc900ae489e9a7f7025c8d258f9b8.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -932,7 +932,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "95c4189864dbf50a528d71bba7983f1c72ecdb4e0a84b258370eb164a2d8b5f1.zip",
+          "S3Key": "ceb8637c8e04b94b162bc128e7a7c24d7ca560b4977e762837487bc934cec374.zip",
         },
         "Description": "backend/deny-list/prune-handler.lambda.ts",
         "Environment": {
@@ -1128,7 +1128,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "70eca9bc2a5f6d903868ff0f1d4b2a68171d2aa8762f79b2e2dceb61071952ee.zip",
+          "S3Key": "0e9bd53c8e4cc8a3d66c0a9c0e289a20644114d9925d5320894badf88f29f57b.zip",
         },
         "Description": "backend/deny-list/prune-queue-handler.lambda.ts",
         "Environment": {

--- a/src/__tests__/backend/license-list/__snapshots__/license-list.test.ts.snap
+++ b/src/__tests__/backend/license-list/__snapshots__/license-list.test.ts.snap
@@ -310,7 +310,7 @@ exports[`All licenses 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "14700f3f8dd2f4997b0e6380f2714c17996184ef4a12d7990ce58b009105e158.zip",
+          "S3Key": "e42a736be21cd3134b9bff4e71e3afa99a4cc900ae489e9a7f7025c8d258f9b8.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -839,7 +839,7 @@ exports[`Apache licenses only 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "14700f3f8dd2f4997b0e6380f2714c17996184ef4a12d7990ce58b009105e158.zip",
+          "S3Key": "e42a736be21cd3134b9bff4e71e3afa99a4cc900ae489e9a7f7025c8d258f9b8.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -1368,7 +1368,7 @@ exports[`BSD licenses only 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "14700f3f8dd2f4997b0e6380f2714c17996184ef4a12d7990ce58b009105e158.zip",
+          "S3Key": "e42a736be21cd3134b9bff4e71e3afa99a4cc900ae489e9a7f7025c8d258f9b8.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -1897,7 +1897,7 @@ exports[`MIT licenses only 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "14700f3f8dd2f4997b0e6380f2714c17996184ef4a12d7990ce58b009105e158.zip",
+          "S3Key": "e42a736be21cd3134b9bff4e71e3afa99a4cc900ae489e9a7f7025c8d258f9b8.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -2426,7 +2426,7 @@ exports[`OSI-Approved licenses only 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "14700f3f8dd2f4997b0e6380f2714c17996184ef4a12d7990ce58b009105e158.zip",
+          "S3Key": "e42a736be21cd3134b9bff4e71e3afa99a4cc900ae489e9a7f7025c8d258f9b8.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -2955,7 +2955,7 @@ exports[`empty set 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "14700f3f8dd2f4997b0e6380f2714c17996184ef4a12d7990ce58b009105e158.zip",
+          "S3Key": "e42a736be21cd3134b9bff4e71e3afa99a4cc900ae489e9a7f7025c8d258f9b8.zip",
         },
         "Description": "/opt/awscli/aws",
       },

--- a/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
+++ b/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
@@ -126,7 +126,7 @@ exports[`CodeArtifact repository 1`] = `
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:bf8b65e8cdcb3defed4173acd317d002bc89d243f6af4ea630944bd9d1588f97",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:ddb9ed165690d6ce66795af95dae2c6b20649748078572102587d317b2db0be7",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -2449,7 +2449,7 @@ exports[`VPC Endpoints 1`] = `
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:bf8b65e8cdcb3defed4173acd317d002bc89d243f6af4ea630944bd9d1588f97",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:ddb9ed165690d6ce66795af95dae2c6b20649748078572102587d317b2db0be7",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -4823,7 +4823,7 @@ exports[`VPC Endpoints and CodeArtifact repository 1`] = `
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:bf8b65e8cdcb3defed4173acd317d002bc89d243f6af4ea630944bd9d1588f97",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:ddb9ed165690d6ce66795af95dae2c6b20649748078572102587d317b2db0be7",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -7142,7 +7142,7 @@ exports[`basic use 1`] = `
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:bf8b65e8cdcb3defed4173acd317d002bc89d243f6af4ea630944bd9d1588f97",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:ddb9ed165690d6ce66795af95dae2c6b20649748078572102587d317b2db0be7",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -1595,7 +1595,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "14700f3f8dd2f4997b0e6380f2714c17996184ef4a12d7990ce58b009105e158.zip",
+          "S3Key": "e42a736be21cd3134b9bff4e71e3afa99a4cc900ae489e9a7f7025c8d258f9b8.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -1961,7 +1961,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "95c4189864dbf50a528d71bba7983f1c72ecdb4e0a84b258370eb164a2d8b5f1.zip",
+          "S3Key": "ceb8637c8e04b94b162bc128e7a7c24d7ca560b4977e762837487bc934cec374.zip",
         },
         "Description": "backend/deny-list/prune-handler.lambda.ts",
         "Environment": {
@@ -2157,7 +2157,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "70eca9bc2a5f6d903868ff0f1d4b2a68171d2aa8762f79b2e2dceb61071952ee.zip",
+          "S3Key": "0e9bd53c8e4cc8a3d66c0a9c0e289a20644114d9925d5320894badf88f29f57b.zip",
         },
         "Description": "backend/deny-list/prune-queue-handler.lambda.ts",
         "Environment": {
@@ -2435,7 +2435,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "649504c66341123a000af00370bc1425ff679e340cc98fc16a854ffa71be9e87.zip",
+          "S3Key": "e4ab225c7936f2eae3602ace6c2d52ffce6265902becdacba8bfa453a7947993.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -2665,7 +2665,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "a323116d13e8b02fd6df324424f01a89d685b1cdd34085c24fceba637051ebea.zip",
+          "S3Key": "8e156a6d01a8cba082af6b52bf9b3f5d8ff0372fc2bd65db725e9320e703a33c.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": {
@@ -2898,7 +2898,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "14700f3f8dd2f4997b0e6380f2714c17996184ef4a12d7990ce58b009105e158.zip",
+          "S3Key": "e42a736be21cd3134b9bff4e71e3afa99a4cc900ae489e9a7f7025c8d258f9b8.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -3109,7 +3109,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "586a1de4c6dfa1effbf944e236b43ee8e7098f5fe44764b1abf7505aab6eb68b.zip",
+          "S3Key": "21d95dae27beb007008f118941bd01cdc870aa25991c17d5544375f72f926187.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -3287,7 +3287,7 @@ Direct link to the function: /lambda/home#/functions/",
               {
                 "Ref": "ConstructHubPackageDataDC5EF35E",
               },
-              "","Prefix":"data/"}},"Is there more?":{"Type":"Choice","Choices":[{"Variable":"$.response.NextContinuationToken","IsPresent":true,"Next":"Give room for on-demand work"}],"Default":"Process Result"},"S3.ListObjectsV2(NextPage)":{"Next":"Is there more?","Retry":[{"ErrorEquals":["S3.SdkClientException"]}],"Type":"Task","ResultPath":"$.response","Resource":"arn:",
+              "","Prefix":"data/","MaxKeys":900}},"Is there more?":{"Type":"Choice","Choices":[{"Variable":"$.response.NextContinuationToken","IsPresent":true,"Next":"Give room for on-demand work"}],"Default":"Process Result"},"S3.ListObjectsV2(NextPage)":{"Next":"Is there more?","Retry":[{"ErrorEquals":["S3.SdkClientException"]}],"Type":"Task","ResultPath":"$.response","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -3295,7 +3295,7 @@ Direct link to the function: /lambda/home#/functions/",
               {
                 "Ref": "ConstructHubPackageDataDC5EF35E",
               },
-              "","ContinuationToken.$":"$.ContinuationToken","Prefix":"data/"}},"Process Result":{"Type":"Map","ResultPath":null,"End":true,"InputPath":"$.response.Contents[*][?(@.Key =~ /^.*/metadata.json$/)]","Iterator":{"StartAt":"Send for reprocessing","States":{"Send for reprocessing":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["Lambda.TooManyRequestsException"],"IntervalSeconds":60,"MaxAttempts":30,"BackoffRate":1.1}],"Type":"Task","Resource":"arn:",
+              "","ContinuationToken.$":"$.ContinuationToken","Prefix":"data/","MaxKeys":900}},"Process Result":{"Type":"Map","ResultPath":null,"End":true,"InputPath":"$.response.Contents[*][?(@.Key =~ /^.*/metadata.json$/)]","Iterator":{"StartAt":"Send for reprocessing","States":{"Send for reprocessing":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["Lambda.TooManyRequestsException"],"IntervalSeconds":60,"MaxAttempts":30,"BackoffRate":1.1}],"Type":"Task","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },
@@ -3868,7 +3868,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "3838f09986ecd1cf5f4e98caedec8eb0c845339172bcc8711b519a8987cc56ee.zip",
+          "S3Key": "92ea79a00d10208fdffeff6b1413b88ef1d6d6c927cd6129d66378ed694aad89.zip",
         },
         "Description": "[ConstructHub/Inventory] A canary that periodically inspects the list of indexed packages",
         "Environment": {
@@ -4552,7 +4552,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "14700f3f8dd2f4997b0e6380f2714c17996184ef4a12d7990ce58b009105e158.zip",
+          "S3Key": "e42a736be21cd3134b9bff4e71e3afa99a4cc900ae489e9a7f7025c8d258f9b8.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -5408,7 +5408,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1a89160600b3e2be7ade4a88a50d22e06a082f0fad411e72f7a9e50ea9753d57.zip",
+          "S3Key": "161c86d2d771967ab8aff9dbf517646eab724a16d0857b5a5b23ed8b8acc6d5d.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -5719,7 +5719,7 @@ RUNBOOK: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "aac6c06e2f850f244bd1349125480a92d2b7ddaaecafea7c9549adc1502e4689.zip",
+          "S3Key": "e78ec9ac5931add41bdf700f8036a5a8479040627b91be5ee9dc1939e19ae8fe.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -6079,7 +6079,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "42c84f4df5864e35ab9ea480fe64a7e118525bdc344197a746412f5bbef2bb0d.zip",
+          "S3Key": "1124b946bc8e940fb46cd2c462cdc1b7e54fe418faf9b3c9c5da6dbaab65a845.zip",
         },
         "Description": "[ConstructHub/Orchestration/NeedsCatalogUpdate] Determines whether a package version requires a catalog update",
         "Environment": {
@@ -6231,7 +6231,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "e6d7b8e2302080b4decb9b19e2e42698b613eaedbf8c76eaf3c05707834302e4.zip",
+          "S3Key": "103ed25c76ca9342bd8adde12b324f70d94bdb2e4bd9f323edd939cfe199046b.zip",
         },
         "Description": "[ConstructHub/Redrive] Manually redrives all messages from the backend dead letter queue",
         "Environment": {
@@ -7080,7 +7080,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:bf8b65e8cdcb3defed4173acd317d002bc89d243f6af4ea630944bd9d1588f97",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:ddb9ed165690d6ce66795af95dae2c6b20649748078572102587d317b2db0be7",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -9683,7 +9683,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "0eec6ebdaab13fec98850923d42d8641dd1a3f6c12dc56cd8edc7c8da4a00096.zip",
+          "S3Key": "baf4e859ba7b9ec44dc6440155228dc5d6261879d9ec4af13a637f0f2d779507.zip",
         },
         "Description": "ReleaseNotes generator",
         "Environment": {
@@ -9834,7 +9834,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "eea6fce263e4f8e6cf8515daea7525e18aea4c871a0b45eea5f9abf2a4e7a997.zip",
+          "S3Key": "1a164d349299af67e79377cfb6c9cf7055da68b51072979e5fe01ef4a6a4a761.zip",
         },
         "Description": "ReleaseNotes get message from the worker queue",
         "Environment": {
@@ -10105,7 +10105,7 @@ RunBook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "a97f540ce2d3b73b541fd5585544931c8731e8d54944b6be1e909415cf7d7a00.zip",
+          "S3Key": "09641fa91889e1a7902749782b6fd277ac18109fd93bf85548219982bc7551fa.zip",
         },
         "Description": "backend/release-notes/release-notes-trigger.lambda.ts",
         "Environment": {
@@ -10688,7 +10688,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "3d8d55e227ba16eb24dac3993e02e2fb06ba0ccc82f242a46c657e5e72012203.zip",
+          "S3Key": "fc45da1e5e21ad2d736d1d9043ce17cd8132932a3db40dd86fc17179ed2bd5c0.zip",
         },
         "Description": "[dev/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -10742,7 +10742,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1eacc73709e81960105bc44d627f04480e4b44efb5efac714992814577bd92c4.zip",
+          "S3Key": "79a486bea9ba022ce3d8f154abcf61a411aea3c232d58104ef39a50f8aaff534.zip",
         },
         "Description": "[dev/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": {
@@ -11441,7 +11441,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "7eeec3dd2bbda52e5b4dc6f329293bc1fd1adabc4a2427331a4e1e4fe8a46cc5.zip",
+          "S3Key": "3bf73d07c5e1a0bd778e16496f53f9802a317e45f13f6366315f49d9842104ef.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -11753,7 +11753,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "9d6ad85b84ac4981fd40d8a5c8d316149ef0351370a7270d736b7790a63f7aef.zip",
+          "S3Key": "06baeab70999632a4e3cc409b8cd2be5f792718c5b87c4b6e7c2a3e62f8dea5d.zip",
         },
         "Description": "Manually re-stage a package version",
         "Environment": {
@@ -11962,7 +11962,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8513ede87f1f78c8666c55181afd61f8a0bf5550fa2c7602ba1a1e29e51f13ea.zip",
+          "S3Key": "67484159781c7060cc7cdb33b8048e4716cb544b688651a21f3f911d27368f5a.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -15160,7 +15160,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "caf5affd59290949115d9efddec9219f76f903a26d7fcacad6c9347401b76dcc.zip",
+          "S3Key": "63f16dd0b96a26b73688f3466e919fcf23121ea9959b282716c2384846456b71.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -15513,7 +15513,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "14700f3f8dd2f4997b0e6380f2714c17996184ef4a12d7990ce58b009105e158.zip",
+          "S3Key": "e42a736be21cd3134b9bff4e71e3afa99a4cc900ae489e9a7f7025c8d258f9b8.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -15525,7 +15525,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "14700f3f8dd2f4997b0e6380f2714c17996184ef4a12d7990ce58b009105e158.zip",
+          "S3Key": "e42a736be21cd3134b9bff4e71e3afa99a4cc900ae489e9a7f7025c8d258f9b8.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -15592,7 +15592,7 @@ function handler(event) {
           },
         ],
         "SourceObjectKeys": [
-          "cfeb64a21b1bb5d2d1d9f1c76c63615906363b832b15503a5fcdca3ee49bbfa7.zip",
+          "03ff63241c3f1c9d7021041d8625bfb618c4168b528678b2a75bb4fdf5b9e494.zip",
         ],
         "SystemMetadata": {
           "cache-control": "public, max-age=300, must-revalidate, s-maxage=60, proxy-revalidate",
@@ -16421,7 +16421,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "e86d3b422569c60272b31220da71a30ded5f90d2ecc0ca5c58d9c4c9636eda33.zip",
+          "S3Key": "7137b7e7a9a48e520b475aa8e033a5bb06ccc23c444fb43f8bbb929b392856ef.zip",
         },
         "Description": "[ConstructHub/MissingDocumentationWidget] Is a custom CloudWatch widget handler",
         "Environment": {
@@ -16847,7 +16847,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "e231a43a9013f5f24f6a32022c61f09e9cd5fa08fe931e606bb81684040e7368.zip",
+          "S3Key": "6f514377b81eebe35b39ede58c98d89a6844c14c5a52e839071f48f96dad01d7.zip",
         },
         "Description": "[ConstructHub/SQSDLQWidget] Is a custom CloudWatch widget handler",
         "Handler": "index.handler",

--- a/src/__tests__/package-sources/__snapshots__/code-artifact.test.ts.snap
+++ b/src/__tests__/package-sources/__snapshots__/code-artifact.test.ts.snap
@@ -243,7 +243,7 @@ exports[`default configuration 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "a5124a534075d17441705498c550134057c78ee2ebc2bad3afda9923e97ac8e0.zip",
+          "S3Key": "794a5b8ed50ada5d750ec90fd023241166fa3f10ee335f0069cdc72eaf4683e5.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -727,7 +727,7 @@ exports[`user-provided staging bucket 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "a5124a534075d17441705498c550134057c78ee2ebc2bad3afda9923e97ac8e0.zip",
+          "S3Key": "794a5b8ed50ada5d750ec90fd023241166fa3f10ee335f0069cdc72eaf4683e5.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {


### PR DESCRIPTION
StepFunctions has a limit on input or output size for a task, state, or execution of 256 KiB of data as a UTF-8 encoded string.

In the case of the reprocess workflow, if the output of `ListObjectsV2` exceeds this limit, the state machine execution fails, which interrupts the chain. As a result, only a subset of packages is reprocessed.

Reduce the number of requested keys in each `ListObjectsV2` from 1000 to 900, to reduce the risk of this happening. With the data we have at the moment, outputs don't exceed 200 KiB.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*