### PR TITLE
feat: lambda insights on web app deployment lambda

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -7080,7 +7080,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:095c19b98bab5c46bc4ada3eda593e04b6aba138ec6ba55fa526455d9f30bfc7",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:83330cc512e0f6b6dd13d446d94cc603af4b10599b24c760aeb7388ab9a6c1fa",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -12014,6 +12014,15 @@ function handler(event) {
           {
             "Ref": "ConstructHubWebAppDeployWebsiteAwsCliLayer23CFFBC1",
           },
+          {
+            "Fn::FindInMap": [
+              "CloudwatchlambdainsightsversionMap",
+              {
+                "Ref": "AWS::Region",
+              },
+              "1x0x229x0xx86x64",
+            ],
+          },
         ],
         "MemorySize": 512,
         "Role": {
@@ -12051,6 +12060,18 @@ function handler(event) {
                   "Ref": "AWS::Partition",
                 },
                 ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/CloudWatchLambdaInsightsExecutionRolePolicy",
               ],
             ],
           },
@@ -12182,15 +12203,6 @@ function handler(event) {
           {
             "Ref": "ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA",
           },
-          {
-            "Fn::FindInMap": [
-              "CloudwatchlambdainsightsversionMap",
-              {
-                "Ref": "AWS::Region",
-              },
-              "1x0x229x0xx86x64",
-            ],
-          },
         ],
         "Role": {
           "Fn::GetAtt": [
@@ -12227,18 +12239,6 @@ function handler(event) {
                   "Ref": "AWS::Partition",
                 },
                 ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/CloudWatchLambdaInsightsExecutionRolePolicy",
               ],
             ],
           },
@@ -20561,7 +20561,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:095c19b98bab5c46bc4ada3eda593e04b6aba138ec6ba55fa526455d9f30bfc7",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:83330cc512e0f6b6dd13d446d94cc603af4b10599b24c760aeb7388ab9a6c1fa",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -25541,6 +25541,15 @@ function handler(event) {
           {
             "Ref": "ConstructHubWebAppDeployWebsiteAwsCliLayer23CFFBC1",
           },
+          {
+            "Fn::FindInMap": [
+              "CloudwatchlambdainsightsversionMap",
+              {
+                "Ref": "AWS::Region",
+              },
+              "1x0x229x0xx86x64",
+            ],
+          },
         ],
         "MemorySize": 512,
         "Role": {
@@ -25578,6 +25587,18 @@ function handler(event) {
                   "Ref": "AWS::Partition",
                 },
                 ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/CloudWatchLambdaInsightsExecutionRolePolicy",
               ],
             ],
           },
@@ -25709,15 +25730,6 @@ function handler(event) {
           {
             "Ref": "ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA",
           },
-          {
-            "Fn::FindInMap": [
-              "CloudwatchlambdainsightsversionMap",
-              {
-                "Ref": "AWS::Region",
-              },
-              "1x0x229x0xx86x64",
-            ],
-          },
         ],
         "Role": {
           "Fn::GetAtt": [
@@ -25754,18 +25766,6 @@ function handler(event) {
                   "Ref": "AWS::Partition",
                 },
                 ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/CloudWatchLambdaInsightsExecutionRolePolicy",
               ],
             ],
           },
@@ -33706,7 +33706,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:095c19b98bab5c46bc4ada3eda593e04b6aba138ec6ba55fa526455d9f30bfc7",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:83330cc512e0f6b6dd13d446d94cc603af4b10599b24c760aeb7388ab9a6c1fa",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -38640,6 +38640,15 @@ function handler(event) {
           {
             "Ref": "ConstructHubWebAppDeployWebsiteAwsCliLayer23CFFBC1",
           },
+          {
+            "Fn::FindInMap": [
+              "CloudwatchlambdainsightsversionMap",
+              {
+                "Ref": "AWS::Region",
+              },
+              "1x0x229x0xx86x64",
+            ],
+          },
         ],
         "MemorySize": 512,
         "Role": {
@@ -38677,6 +38686,18 @@ function handler(event) {
                   "Ref": "AWS::Partition",
                 },
                 ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/CloudWatchLambdaInsightsExecutionRolePolicy",
               ],
             ],
           },
@@ -38808,15 +38829,6 @@ function handler(event) {
           {
             "Ref": "ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA",
           },
-          {
-            "Fn::FindInMap": [
-              "CloudwatchlambdainsightsversionMap",
-              {
-                "Ref": "AWS::Region",
-              },
-              "1x0x229x0xx86x64",
-            ],
-          },
         ],
         "Role": {
           "Fn::GetAtt": [
@@ -38853,18 +38865,6 @@ function handler(event) {
                   "Ref": "AWS::Partition",
                 },
                 ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/CloudWatchLambdaInsightsExecutionRolePolicy",
               ],
             ],
           },
@@ -46954,7 +46954,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:095c19b98bab5c46bc4ada3eda593e04b6aba138ec6ba55fa526455d9f30bfc7",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:83330cc512e0f6b6dd13d446d94cc603af4b10599b24c760aeb7388ab9a6c1fa",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -52125,6 +52125,15 @@ function handler(event) {
           {
             "Ref": "ConstructHubWebAppDeployWebsiteAwsCliLayer23CFFBC1",
           },
+          {
+            "Fn::FindInMap": [
+              "CloudwatchlambdainsightsversionMap",
+              {
+                "Ref": "AWS::Region",
+              },
+              "1x0x229x0xx86x64",
+            ],
+          },
         ],
         "MemorySize": 512,
         "Role": {
@@ -52162,6 +52171,18 @@ function handler(event) {
                   "Ref": "AWS::Partition",
                 },
                 ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/CloudWatchLambdaInsightsExecutionRolePolicy",
               ],
             ],
           },
@@ -52293,15 +52314,6 @@ function handler(event) {
           {
             "Ref": "ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA",
           },
-          {
-            "Fn::FindInMap": [
-              "CloudwatchlambdainsightsversionMap",
-              {
-                "Ref": "AWS::Region",
-              },
-              "1x0x229x0xx86x64",
-            ],
-          },
         ],
         "Role": {
           "Fn::GetAtt": [
@@ -52338,18 +52350,6 @@ function handler(event) {
                   "Ref": "AWS::Partition",
                 },
                 ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/CloudWatchLambdaInsightsExecutionRolePolicy",
               ],
             ],
           },
@@ -60121,7 +60121,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:095c19b98bab5c46bc4ada3eda593e04b6aba138ec6ba55fa526455d9f30bfc7",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:83330cc512e0f6b6dd13d446d94cc603af4b10599b24c760aeb7388ab9a6c1fa",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -68534,6 +68534,15 @@ function handler(event) {
           {
             "Ref": "ConstructHubWebAppDeployWebsiteAwsCliLayer23CFFBC1",
           },
+          {
+            "Fn::FindInMap": [
+              "CloudwatchlambdainsightsversionMap",
+              {
+                "Ref": "AWS::Region",
+              },
+              "1x0x229x0xx86x64",
+            ],
+          },
         ],
         "MemorySize": 512,
         "Role": {
@@ -68571,6 +68580,18 @@ function handler(event) {
                   "Ref": "AWS::Partition",
                 },
                 ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/CloudWatchLambdaInsightsExecutionRolePolicy",
               ],
             ],
           },
@@ -68702,15 +68723,6 @@ function handler(event) {
           {
             "Ref": "ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA",
           },
-          {
-            "Fn::FindInMap": [
-              "CloudwatchlambdainsightsversionMap",
-              {
-                "Ref": "AWS::Region",
-              },
-              "1x0x229x0xx86x64",
-            ],
-          },
         ],
         "Role": {
           "Fn::GetAtt": [
@@ -68747,18 +68759,6 @@ function handler(event) {
                   "Ref": "AWS::Partition",
                 },
                 ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/CloudWatchLambdaInsightsExecutionRolePolicy",
               ],
             ],
           },

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -3,6 +3,92 @@
 exports[`minimal usage 1`] = `
 {
   "Mappings": {
+    "CloudwatchlambdainsightsversionMap": {
+      "af-south-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:af-south-1:012438385374:layer:LambdaInsightsExtension:28",
+      },
+      "ap-east-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-east-1:519774774795:layer:LambdaInsightsExtension:28",
+      },
+      "ap-northeast-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-northeast-1:580247275435:layer:LambdaInsightsExtension:60",
+      },
+      "ap-northeast-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-northeast-2:580247275435:layer:LambdaInsightsExtension:37",
+      },
+      "ap-northeast-3": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-northeast-3:194566237122:layer:LambdaInsightsExtension:19",
+      },
+      "ap-south-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-south-1:580247275435:layer:LambdaInsightsExtension:36",
+      },
+      "ap-south-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-south-2:891564319516:layer:LambdaInsightsExtension:10",
+      },
+      "ap-southeast-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-southeast-1:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "ap-southeast-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-southeast-2:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "ap-southeast-3": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-southeast-3:439286490199:layer:LambdaInsightsExtension:14",
+      },
+      "ca-central-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ca-central-1:580247275435:layer:LambdaInsightsExtension:37",
+      },
+      "cn-north-1": {
+        "1x0x229x0xx86x64": "arn:aws-cn:lambda:cn-north-1:488211338238:layer:LambdaInsightsExtension:29",
+      },
+      "cn-northwest-1": {
+        "1x0x229x0xx86x64": "arn:aws-cn:lambda:cn-northwest-1:488211338238:layer:LambdaInsightsExtension:29",
+      },
+      "eu-central-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-central-1:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "eu-central-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-central-2:033019950311:layer:LambdaInsightsExtension:11",
+      },
+      "eu-north-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-north-1:580247275435:layer:LambdaInsightsExtension:35",
+      },
+      "eu-south-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-south-1:339249233099:layer:LambdaInsightsExtension:28",
+      },
+      "eu-south-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-south-2:352183217350:layer:LambdaInsightsExtension:12",
+      },
+      "eu-west-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-west-1:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "eu-west-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-west-2:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "eu-west-3": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-west-3:580247275435:layer:LambdaInsightsExtension:37",
+      },
+      "me-central-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:me-central-1:732604637566:layer:LambdaInsightsExtension:11",
+      },
+      "me-south-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:me-south-1:285320876703:layer:LambdaInsightsExtension:28",
+      },
+      "sa-east-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:sa-east-1:580247275435:layer:LambdaInsightsExtension:37",
+      },
+      "us-east-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:us-east-1:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "us-east-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:us-east-2:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "us-west-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:us-west-1:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "us-west-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:us-west-2:580247275435:layer:LambdaInsightsExtension:38",
+      },
+    },
     "ServiceprincipalMap": {
       "af-south-1": {
         "states": "states.af-south-1.amazonaws.com",
@@ -6994,7 +7080,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:83330cc512e0f6b6dd13d446d94cc603af4b10599b24c760aeb7388ab9a6c1fa",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:095c19b98bab5c46bc4ada3eda593e04b6aba138ec6ba55fa526455d9f30bfc7",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -11928,6 +12014,15 @@ function handler(event) {
           {
             "Ref": "ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA",
           },
+          {
+            "Fn::FindInMap": [
+              "CloudwatchlambdainsightsversionMap",
+              {
+                "Ref": "AWS::Region",
+              },
+              "1x0x229x0xx86x64",
+            ],
+          },
         ],
         "Role": {
           "Fn::GetAtt": [
@@ -11964,6 +12059,18 @@ function handler(event) {
                   "Ref": "AWS::Partition",
                 },
                 ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/CloudWatchLambdaInsightsExecutionRolePolicy",
               ],
             ],
           },
@@ -12872,6 +12979,92 @@ function handler(event) {
 exports[`piggy-backing on an existing CodeArtifact domain 1`] = `
 {
   "Mappings": {
+    "CloudwatchlambdainsightsversionMap": {
+      "af-south-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:af-south-1:012438385374:layer:LambdaInsightsExtension:28",
+      },
+      "ap-east-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-east-1:519774774795:layer:LambdaInsightsExtension:28",
+      },
+      "ap-northeast-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-northeast-1:580247275435:layer:LambdaInsightsExtension:60",
+      },
+      "ap-northeast-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-northeast-2:580247275435:layer:LambdaInsightsExtension:37",
+      },
+      "ap-northeast-3": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-northeast-3:194566237122:layer:LambdaInsightsExtension:19",
+      },
+      "ap-south-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-south-1:580247275435:layer:LambdaInsightsExtension:36",
+      },
+      "ap-south-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-south-2:891564319516:layer:LambdaInsightsExtension:10",
+      },
+      "ap-southeast-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-southeast-1:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "ap-southeast-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-southeast-2:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "ap-southeast-3": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-southeast-3:439286490199:layer:LambdaInsightsExtension:14",
+      },
+      "ca-central-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ca-central-1:580247275435:layer:LambdaInsightsExtension:37",
+      },
+      "cn-north-1": {
+        "1x0x229x0xx86x64": "arn:aws-cn:lambda:cn-north-1:488211338238:layer:LambdaInsightsExtension:29",
+      },
+      "cn-northwest-1": {
+        "1x0x229x0xx86x64": "arn:aws-cn:lambda:cn-northwest-1:488211338238:layer:LambdaInsightsExtension:29",
+      },
+      "eu-central-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-central-1:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "eu-central-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-central-2:033019950311:layer:LambdaInsightsExtension:11",
+      },
+      "eu-north-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-north-1:580247275435:layer:LambdaInsightsExtension:35",
+      },
+      "eu-south-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-south-1:339249233099:layer:LambdaInsightsExtension:28",
+      },
+      "eu-south-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-south-2:352183217350:layer:LambdaInsightsExtension:12",
+      },
+      "eu-west-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-west-1:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "eu-west-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-west-2:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "eu-west-3": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-west-3:580247275435:layer:LambdaInsightsExtension:37",
+      },
+      "me-central-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:me-central-1:732604637566:layer:LambdaInsightsExtension:11",
+      },
+      "me-south-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:me-south-1:285320876703:layer:LambdaInsightsExtension:28",
+      },
+      "sa-east-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:sa-east-1:580247275435:layer:LambdaInsightsExtension:37",
+      },
+      "us-east-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:us-east-1:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "us-east-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:us-east-2:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "us-west-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:us-west-1:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "us-west-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:us-west-2:580247275435:layer:LambdaInsightsExtension:38",
+      },
+    },
     "ServiceprincipalMap": {
       "af-south-1": {
         "states": "states.af-south-1.amazonaws.com",
@@ -20245,7 +20438,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:83330cc512e0f6b6dd13d446d94cc603af4b10599b24c760aeb7388ab9a6c1fa",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:095c19b98bab5c46bc4ada3eda593e04b6aba138ec6ba55fa526455d9f30bfc7",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -25225,6 +25418,15 @@ function handler(event) {
           {
             "Ref": "ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA",
           },
+          {
+            "Fn::FindInMap": [
+              "CloudwatchlambdainsightsversionMap",
+              {
+                "Ref": "AWS::Region",
+              },
+              "1x0x229x0xx86x64",
+            ],
+          },
         ],
         "Role": {
           "Fn::GetAtt": [
@@ -25261,6 +25463,18 @@ function handler(event) {
                   "Ref": "AWS::Partition",
                 },
                 ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/CloudWatchLambdaInsightsExecutionRolePolicy",
               ],
             ],
           },
@@ -26169,6 +26383,92 @@ function handler(event) {
 exports[`with all internet access 1`] = `
 {
   "Mappings": {
+    "CloudwatchlambdainsightsversionMap": {
+      "af-south-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:af-south-1:012438385374:layer:LambdaInsightsExtension:28",
+      },
+      "ap-east-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-east-1:519774774795:layer:LambdaInsightsExtension:28",
+      },
+      "ap-northeast-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-northeast-1:580247275435:layer:LambdaInsightsExtension:60",
+      },
+      "ap-northeast-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-northeast-2:580247275435:layer:LambdaInsightsExtension:37",
+      },
+      "ap-northeast-3": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-northeast-3:194566237122:layer:LambdaInsightsExtension:19",
+      },
+      "ap-south-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-south-1:580247275435:layer:LambdaInsightsExtension:36",
+      },
+      "ap-south-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-south-2:891564319516:layer:LambdaInsightsExtension:10",
+      },
+      "ap-southeast-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-southeast-1:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "ap-southeast-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-southeast-2:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "ap-southeast-3": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-southeast-3:439286490199:layer:LambdaInsightsExtension:14",
+      },
+      "ca-central-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ca-central-1:580247275435:layer:LambdaInsightsExtension:37",
+      },
+      "cn-north-1": {
+        "1x0x229x0xx86x64": "arn:aws-cn:lambda:cn-north-1:488211338238:layer:LambdaInsightsExtension:29",
+      },
+      "cn-northwest-1": {
+        "1x0x229x0xx86x64": "arn:aws-cn:lambda:cn-northwest-1:488211338238:layer:LambdaInsightsExtension:29",
+      },
+      "eu-central-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-central-1:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "eu-central-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-central-2:033019950311:layer:LambdaInsightsExtension:11",
+      },
+      "eu-north-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-north-1:580247275435:layer:LambdaInsightsExtension:35",
+      },
+      "eu-south-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-south-1:339249233099:layer:LambdaInsightsExtension:28",
+      },
+      "eu-south-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-south-2:352183217350:layer:LambdaInsightsExtension:12",
+      },
+      "eu-west-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-west-1:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "eu-west-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-west-2:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "eu-west-3": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-west-3:580247275435:layer:LambdaInsightsExtension:37",
+      },
+      "me-central-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:me-central-1:732604637566:layer:LambdaInsightsExtension:11",
+      },
+      "me-south-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:me-south-1:285320876703:layer:LambdaInsightsExtension:28",
+      },
+      "sa-east-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:sa-east-1:580247275435:layer:LambdaInsightsExtension:37",
+      },
+      "us-east-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:us-east-1:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "us-east-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:us-east-2:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "us-west-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:us-west-1:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "us-west-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:us-west-2:580247275435:layer:LambdaInsightsExtension:38",
+      },
+    },
     "ServiceprincipalMap": {
       "af-south-1": {
         "states": "states.af-south-1.amazonaws.com",
@@ -33160,7 +33460,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:83330cc512e0f6b6dd13d446d94cc603af4b10599b24c760aeb7388ab9a6c1fa",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:095c19b98bab5c46bc4ada3eda593e04b6aba138ec6ba55fa526455d9f30bfc7",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -38094,6 +38394,15 @@ function handler(event) {
           {
             "Ref": "ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA",
           },
+          {
+            "Fn::FindInMap": [
+              "CloudwatchlambdainsightsversionMap",
+              {
+                "Ref": "AWS::Region",
+              },
+              "1x0x229x0xx86x64",
+            ],
+          },
         ],
         "Role": {
           "Fn::GetAtt": [
@@ -38130,6 +38439,18 @@ function handler(event) {
                   "Ref": "AWS::Partition",
                 },
                 ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/CloudWatchLambdaInsightsExecutionRolePolicy",
               ],
             ],
           },
@@ -39044,6 +39365,92 @@ exports[`with domain 1`] = `
       },
       "aws-cn": {
         "zoneId": "Z3RFFRIM2A3IF5",
+      },
+    },
+    "CloudwatchlambdainsightsversionMap": {
+      "af-south-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:af-south-1:012438385374:layer:LambdaInsightsExtension:28",
+      },
+      "ap-east-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-east-1:519774774795:layer:LambdaInsightsExtension:28",
+      },
+      "ap-northeast-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-northeast-1:580247275435:layer:LambdaInsightsExtension:60",
+      },
+      "ap-northeast-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-northeast-2:580247275435:layer:LambdaInsightsExtension:37",
+      },
+      "ap-northeast-3": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-northeast-3:194566237122:layer:LambdaInsightsExtension:19",
+      },
+      "ap-south-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-south-1:580247275435:layer:LambdaInsightsExtension:36",
+      },
+      "ap-south-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-south-2:891564319516:layer:LambdaInsightsExtension:10",
+      },
+      "ap-southeast-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-southeast-1:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "ap-southeast-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-southeast-2:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "ap-southeast-3": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-southeast-3:439286490199:layer:LambdaInsightsExtension:14",
+      },
+      "ca-central-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ca-central-1:580247275435:layer:LambdaInsightsExtension:37",
+      },
+      "cn-north-1": {
+        "1x0x229x0xx86x64": "arn:aws-cn:lambda:cn-north-1:488211338238:layer:LambdaInsightsExtension:29",
+      },
+      "cn-northwest-1": {
+        "1x0x229x0xx86x64": "arn:aws-cn:lambda:cn-northwest-1:488211338238:layer:LambdaInsightsExtension:29",
+      },
+      "eu-central-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-central-1:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "eu-central-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-central-2:033019950311:layer:LambdaInsightsExtension:11",
+      },
+      "eu-north-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-north-1:580247275435:layer:LambdaInsightsExtension:35",
+      },
+      "eu-south-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-south-1:339249233099:layer:LambdaInsightsExtension:28",
+      },
+      "eu-south-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-south-2:352183217350:layer:LambdaInsightsExtension:12",
+      },
+      "eu-west-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-west-1:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "eu-west-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-west-2:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "eu-west-3": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-west-3:580247275435:layer:LambdaInsightsExtension:37",
+      },
+      "me-central-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:me-central-1:732604637566:layer:LambdaInsightsExtension:11",
+      },
+      "me-south-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:me-south-1:285320876703:layer:LambdaInsightsExtension:28",
+      },
+      "sa-east-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:sa-east-1:580247275435:layer:LambdaInsightsExtension:37",
+      },
+      "us-east-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:us-east-1:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "us-east-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:us-east-2:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "us-west-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:us-west-1:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "us-west-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:us-west-2:580247275435:layer:LambdaInsightsExtension:38",
       },
     },
     "ServiceprincipalMap": {
@@ -46178,7 +46585,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:83330cc512e0f6b6dd13d446d94cc603af4b10599b24c760aeb7388ab9a6c1fa",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:095c19b98bab5c46bc4ada3eda593e04b6aba138ec6ba55fa526455d9f30bfc7",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -51349,6 +51756,15 @@ function handler(event) {
           {
             "Ref": "ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA",
           },
+          {
+            "Fn::FindInMap": [
+              "CloudwatchlambdainsightsversionMap",
+              {
+                "Ref": "AWS::Region",
+              },
+              "1x0x229x0xx86x64",
+            ],
+          },
         ],
         "Role": {
           "Fn::GetAtt": [
@@ -51385,6 +51801,18 @@ function handler(event) {
                   "Ref": "AWS::Partition",
                 },
                 ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/CloudWatchLambdaInsightsExecutionRolePolicy",
               ],
             ],
           },
@@ -52293,6 +52721,92 @@ function handler(event) {
 exports[`with limited internet access 1`] = `
 {
   "Mappings": {
+    "CloudwatchlambdainsightsversionMap": {
+      "af-south-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:af-south-1:012438385374:layer:LambdaInsightsExtension:28",
+      },
+      "ap-east-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-east-1:519774774795:layer:LambdaInsightsExtension:28",
+      },
+      "ap-northeast-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-northeast-1:580247275435:layer:LambdaInsightsExtension:60",
+      },
+      "ap-northeast-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-northeast-2:580247275435:layer:LambdaInsightsExtension:37",
+      },
+      "ap-northeast-3": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-northeast-3:194566237122:layer:LambdaInsightsExtension:19",
+      },
+      "ap-south-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-south-1:580247275435:layer:LambdaInsightsExtension:36",
+      },
+      "ap-south-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-south-2:891564319516:layer:LambdaInsightsExtension:10",
+      },
+      "ap-southeast-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-southeast-1:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "ap-southeast-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-southeast-2:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "ap-southeast-3": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-southeast-3:439286490199:layer:LambdaInsightsExtension:14",
+      },
+      "ca-central-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ca-central-1:580247275435:layer:LambdaInsightsExtension:37",
+      },
+      "cn-north-1": {
+        "1x0x229x0xx86x64": "arn:aws-cn:lambda:cn-north-1:488211338238:layer:LambdaInsightsExtension:29",
+      },
+      "cn-northwest-1": {
+        "1x0x229x0xx86x64": "arn:aws-cn:lambda:cn-northwest-1:488211338238:layer:LambdaInsightsExtension:29",
+      },
+      "eu-central-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-central-1:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "eu-central-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-central-2:033019950311:layer:LambdaInsightsExtension:11",
+      },
+      "eu-north-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-north-1:580247275435:layer:LambdaInsightsExtension:35",
+      },
+      "eu-south-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-south-1:339249233099:layer:LambdaInsightsExtension:28",
+      },
+      "eu-south-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-south-2:352183217350:layer:LambdaInsightsExtension:12",
+      },
+      "eu-west-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-west-1:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "eu-west-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-west-2:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "eu-west-3": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-west-3:580247275435:layer:LambdaInsightsExtension:37",
+      },
+      "me-central-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:me-central-1:732604637566:layer:LambdaInsightsExtension:11",
+      },
+      "me-south-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:me-south-1:285320876703:layer:LambdaInsightsExtension:28",
+      },
+      "sa-east-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:sa-east-1:580247275435:layer:LambdaInsightsExtension:37",
+      },
+      "us-east-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:us-east-1:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "us-east-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:us-east-2:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "us-west-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:us-west-1:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "us-west-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:us-west-2:580247275435:layer:LambdaInsightsExtension:38",
+      },
+    },
     "ServiceprincipalMap": {
       "af-south-1": {
         "states": "states.af-south-1.amazonaws.com",
@@ -59115,7 +59629,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:83330cc512e0f6b6dd13d446d94cc603af4b10599b24c760aeb7388ab9a6c1fa",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:095c19b98bab5c46bc4ada3eda593e04b6aba138ec6ba55fa526455d9f30bfc7",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -67528,6 +68042,15 @@ function handler(event) {
           {
             "Ref": "ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA",
           },
+          {
+            "Fn::FindInMap": [
+              "CloudwatchlambdainsightsversionMap",
+              {
+                "Ref": "AWS::Region",
+              },
+              "1x0x229x0xx86x64",
+            ],
+          },
         ],
         "Role": {
           "Fn::GetAtt": [
@@ -67564,6 +68087,18 @@ function handler(event) {
                   "Ref": "AWS::Partition",
                 },
                 ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/CloudWatchLambdaInsightsExecutionRolePolicy",
               ],
             ],
           },

--- a/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
+++ b/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
@@ -126,7 +126,7 @@ exports[`CodeArtifact repository 1`] = `
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:095c19b98bab5c46bc4ada3eda593e04b6aba138ec6ba55fa526455d9f30bfc7",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:83330cc512e0f6b6dd13d446d94cc603af4b10599b24c760aeb7388ab9a6c1fa",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -2449,7 +2449,7 @@ exports[`VPC Endpoints 1`] = `
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:095c19b98bab5c46bc4ada3eda593e04b6aba138ec6ba55fa526455d9f30bfc7",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:83330cc512e0f6b6dd13d446d94cc603af4b10599b24c760aeb7388ab9a6c1fa",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -4823,7 +4823,7 @@ exports[`VPC Endpoints and CodeArtifact repository 1`] = `
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:095c19b98bab5c46bc4ada3eda593e04b6aba138ec6ba55fa526455d9f30bfc7",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:83330cc512e0f6b6dd13d446d94cc603af4b10599b24c760aeb7388ab9a6c1fa",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -7142,7 +7142,7 @@ exports[`basic use 1`] = `
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:095c19b98bab5c46bc4ada3eda593e04b6aba138ec6ba55fa526455d9f30bfc7",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:83330cc512e0f6b6dd13d446d94cc603af4b10599b24c760aeb7388ab9a6c1fa",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",

--- a/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
+++ b/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
@@ -126,7 +126,7 @@ exports[`CodeArtifact repository 1`] = `
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:83330cc512e0f6b6dd13d446d94cc603af4b10599b24c760aeb7388ab9a6c1fa",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:095c19b98bab5c46bc4ada3eda593e04b6aba138ec6ba55fa526455d9f30bfc7",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -2449,7 +2449,7 @@ exports[`VPC Endpoints 1`] = `
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:83330cc512e0f6b6dd13d446d94cc603af4b10599b24c760aeb7388ab9a6c1fa",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:095c19b98bab5c46bc4ada3eda593e04b6aba138ec6ba55fa526455d9f30bfc7",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -4823,7 +4823,7 @@ exports[`VPC Endpoints and CodeArtifact repository 1`] = `
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:83330cc512e0f6b6dd13d446d94cc603af4b10599b24c760aeb7388ab9a6c1fa",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:095c19b98bab5c46bc4ada3eda593e04b6aba138ec6ba55fa526455d9f30bfc7",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -7142,7 +7142,7 @@ exports[`basic use 1`] = `
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:83330cc512e0f6b6dd13d446d94cc603af4b10599b24c760aeb7388ab9a6c1fa",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:095c19b98bab5c46bc4ada3eda593e04b6aba138ec6ba55fa526455d9f30bfc7",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -7346,7 +7346,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:095c19b98bab5c46bc4ada3eda593e04b6aba138ec6ba55fa526455d9f30bfc7",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:83330cc512e0f6b6dd13d446d94cc603af4b10599b24c760aeb7388ab9a6c1fa",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -16281,6 +16281,15 @@ function handler(event) {
           {
             "Ref": "ConstructHubWebAppDeployWebsiteAwsCliLayer23CFFBC1",
           },
+          {
+            "Fn::FindInMap": [
+              "CloudwatchlambdainsightsversionMap",
+              {
+                "Ref": "AWS::Region",
+              },
+              "1x0x229x0xx86x64",
+            ],
+          },
         ],
         "MemorySize": 512,
         "Role": {
@@ -16318,6 +16327,18 @@ function handler(event) {
                   "Ref": "AWS::Partition",
                 },
                 ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/CloudWatchLambdaInsightsExecutionRolePolicy",
               ],
             ],
           },
@@ -16449,15 +16470,6 @@ function handler(event) {
           {
             "Ref": "ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA",
           },
-          {
-            "Fn::FindInMap": [
-              "CloudwatchlambdainsightsversionMap",
-              {
-                "Ref": "AWS::Region",
-              },
-              "1x0x229x0xx86x64",
-            ],
-          },
         ],
         "Role": {
           "Fn::GetAtt": [
@@ -16494,18 +16506,6 @@ function handler(event) {
                   "Ref": "AWS::Partition",
                 },
                 ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/CloudWatchLambdaInsightsExecutionRolePolicy",
               ],
             ],
           },

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -3,6 +3,92 @@
 exports[`golden snapshot 1`] = `
 {
   "Mappings": {
+    "CloudwatchlambdainsightsversionMap": {
+      "af-south-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:af-south-1:012438385374:layer:LambdaInsightsExtension:28",
+      },
+      "ap-east-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-east-1:519774774795:layer:LambdaInsightsExtension:28",
+      },
+      "ap-northeast-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-northeast-1:580247275435:layer:LambdaInsightsExtension:60",
+      },
+      "ap-northeast-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-northeast-2:580247275435:layer:LambdaInsightsExtension:37",
+      },
+      "ap-northeast-3": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-northeast-3:194566237122:layer:LambdaInsightsExtension:19",
+      },
+      "ap-south-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-south-1:580247275435:layer:LambdaInsightsExtension:36",
+      },
+      "ap-south-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-south-2:891564319516:layer:LambdaInsightsExtension:10",
+      },
+      "ap-southeast-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-southeast-1:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "ap-southeast-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-southeast-2:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "ap-southeast-3": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ap-southeast-3:439286490199:layer:LambdaInsightsExtension:14",
+      },
+      "ca-central-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:ca-central-1:580247275435:layer:LambdaInsightsExtension:37",
+      },
+      "cn-north-1": {
+        "1x0x229x0xx86x64": "arn:aws-cn:lambda:cn-north-1:488211338238:layer:LambdaInsightsExtension:29",
+      },
+      "cn-northwest-1": {
+        "1x0x229x0xx86x64": "arn:aws-cn:lambda:cn-northwest-1:488211338238:layer:LambdaInsightsExtension:29",
+      },
+      "eu-central-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-central-1:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "eu-central-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-central-2:033019950311:layer:LambdaInsightsExtension:11",
+      },
+      "eu-north-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-north-1:580247275435:layer:LambdaInsightsExtension:35",
+      },
+      "eu-south-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-south-1:339249233099:layer:LambdaInsightsExtension:28",
+      },
+      "eu-south-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-south-2:352183217350:layer:LambdaInsightsExtension:12",
+      },
+      "eu-west-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-west-1:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "eu-west-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-west-2:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "eu-west-3": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:eu-west-3:580247275435:layer:LambdaInsightsExtension:37",
+      },
+      "me-central-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:me-central-1:732604637566:layer:LambdaInsightsExtension:11",
+      },
+      "me-south-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:me-south-1:285320876703:layer:LambdaInsightsExtension:28",
+      },
+      "sa-east-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:sa-east-1:580247275435:layer:LambdaInsightsExtension:37",
+      },
+      "us-east-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:us-east-1:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "us-east-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:us-east-2:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "us-west-1": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:us-west-1:580247275435:layer:LambdaInsightsExtension:38",
+      },
+      "us-west-2": {
+        "1x0x229x0xx86x64": "arn:aws:lambda:us-west-2:580247275435:layer:LambdaInsightsExtension:38",
+      },
+    },
     "ServiceprincipalMap": {
       "af-south-1": {
         "states": "states.af-south-1.amazonaws.com",
@@ -7260,7 +7346,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:83330cc512e0f6b6dd13d446d94cc603af4b10599b24c760aeb7388ab9a6c1fa",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:095c19b98bab5c46bc4ada3eda593e04b6aba138ec6ba55fa526455d9f30bfc7",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -16195,6 +16281,15 @@ function handler(event) {
           {
             "Ref": "ConstructHubDenyListBucketDeploymentAwsCliLayerEAC3D4DA",
           },
+          {
+            "Fn::FindInMap": [
+              "CloudwatchlambdainsightsversionMap",
+              {
+                "Ref": "AWS::Region",
+              },
+              "1x0x229x0xx86x64",
+            ],
+          },
         ],
         "Role": {
           "Fn::GetAtt": [
@@ -16231,6 +16326,18 @@ function handler(event) {
                   "Ref": "AWS::Partition",
                 },
                 ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/CloudWatchLambdaInsightsExecutionRolePolicy",
               ],
             ],
           },

--- a/src/webapp/index.ts
+++ b/src/webapp/index.ts
@@ -2,6 +2,8 @@ import * as path from 'path';
 import { CfnOutput } from 'aws-cdk-lib';
 import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
 import * as origins from 'aws-cdk-lib/aws-cloudfront-origins';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as r53 from 'aws-cdk-lib/aws-route53';
 import * as r53targets from 'aws-cdk-lib/aws-route53-targets';
 import * as s3 from 'aws-cdk-lib/aws-s3';
@@ -317,7 +319,7 @@ export class WebApp extends Construct {
     // "website" contains the static react app
     const webappDir = path.join(__dirname, '..', '..', 'website');
 
-    new s3deploy.BucketDeployment(this, 'DeployWebsite', {
+    const webAppDeploy = new s3deploy.BucketDeployment(this, 'DeployWebsite', {
       destinationBucket: this.bucket,
       distribution: this.distribution,
       prune: false,
@@ -326,6 +328,26 @@ export class WebApp extends Construct {
         .toArray()
         .map(s3deploy.CacheControl.fromString),
     });
+
+    const lambdaInsightsArn =
+      lambda.LambdaInsightsVersion.VERSION_1_0_229_0.layerVersionArn;
+    const cfnFunction = webAppDeploy.node.findChild(
+      'CustomResourceHandler'
+    ) as lambda.SingletonFunction;
+
+    cfnFunction.addLayers(
+      lambda.LayerVersion.fromLayerVersionArn(
+        this,
+        'LambdaInsights',
+        lambdaInsightsArn
+      )
+    );
+
+    cfnFunction.role!.addManagedPolicy(
+      iam.ManagedPolicy.fromAwsManagedPolicyName(
+        'CloudWatchLambdaInsightsExecutionRolePolicy'
+      )
+    );
 
     // Generate config.json to customize frontend behavior
     const config = new WebappConfig({

--- a/src/webapp/index.ts
+++ b/src/webapp/index.ts
@@ -331,10 +331,13 @@ export class WebApp extends Construct {
 
     const lambdaInsightsArn =
       lambda.LambdaInsightsVersion.VERSION_1_0_229_0.layerVersionArn;
+    
+    // Escape hatch to find the underlying Lambda Function
     const cfnFunction = webAppDeploy.node.findChild(
       'CustomResourceHandler'
     ) as lambda.SingletonFunction;
 
+    // Add Lambda Insights to the Lambda Function
     cfnFunction.addLayers(
       lambda.LayerVersion.fromLayerVersionArn(
         this,
@@ -343,6 +346,9 @@ export class WebApp extends Construct {
       )
     );
 
+    // Add Lambda Insights IAM role permissions
+    // role can only be undefined when the function is imported, which
+    // is not the case here
     cfnFunction.role!.addManagedPolicy(
       iam.ManagedPolicy.fromAwsManagedPolicyName(
         'CloudWatchLambdaInsightsExecutionRolePolicy'


### PR DESCRIPTION
Adds lambda insights to the web app s3 deployment lambda, so that we can track memory usage over time and other metrics.

Testing includes updates to the snapshots and I deployed Construct Hub to my personal account and confirmed that lambda insights was turned on:

<img width="1179" alt="Screenshot 2025-04-03 at 3 06 20 PM" src="https://github.com/user-attachments/assets/4f0f1cbc-4cd4-464e-8427-a690d59898e2" />


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*