### PR TITLE
fix: npm follower lambda fails on 404 errors

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -1225,7 +1225,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
+          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -1591,7 +1591,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "f1b7885b673d9f17e1bf0939a3d3ba7a76f17efbbe7c9109b1f8baac1d283d91.zip",
+          "S3Key": "713e019f1505ec8b74e02da59325f8cc0dc1df8633a97946360eef71e4961a86.zip",
         },
         "Description": "backend/deny-list/prune-handler.lambda.ts",
         "Environment": {
@@ -1787,7 +1787,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1f67115da31f072e113b82a616fb1d9ff799f7594c86204bbcbd17de8e954114.zip",
+          "S3Key": "74af847789269e2455d893cf01da26dde664a80ddcbee32c23be027a42addbe9.zip",
         },
         "Description": "backend/deny-list/prune-queue-handler.lambda.ts",
         "Environment": {
@@ -2068,7 +2068,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "029be6a866f5acc5e6f68e18d64475729ab929d61665d8ea58e95ec1cb29c329.zip",
+          "S3Key": "dfc30b6cad945b9a1a8cd74979e7f6046600193846b31fe5faa0e64c2b0d95d7.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -2296,7 +2296,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "f64738290f58bcaa5b6f160f509f5debf06bcae60508f7252a3919f3572a7f78.zip",
+          "S3Key": "a8b68670eb455b177b2b85c9be2df672d28dc9470d41fba4c2b6af036086f1cc.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": {
@@ -2508,7 +2508,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
+          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -2722,7 +2722,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "bcc24517c2bca472ae9747fa039eb1b27336953867061a6dccf3b2ec0a7e5bde.zip",
+          "S3Key": "2d59ba9b7faee1e49a10d111c65af9374c92161329789225db8087a72b141f59.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -3568,7 +3568,7 @@ Direct link to the state machine: /states/home#/statemachines/view/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "02fe7c310c92dd2243de516b7df3e2b7a3170dacc073c48f9fb0806d5d1d8ae7.zip",
+          "S3Key": "b0cac3fe91cf84792dfa53eae18cf51c18867750fd9f296209aabfffa86654aa.zip",
         },
         "Description": "[ConstructHub/Inventory] A canary that periodically inspects the list of indexed packages",
         "Environment": {
@@ -4229,7 +4229,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
+          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -4333,7 +4333,7 @@ Direct link to function: /lambda/home#/functions/",
           },
         ],
         "SourceObjectKeys": [
-          "ee57c3c2c87eefd3a5a6cbcd848e46c0b37f428afd7bcd5a2fdc0f3e9e9da430.zip",
+          "ba2c42b4614a88c72a0a91a75f389fb962da98b479ae5c6b4009169243cf15c0.zip",
         ],
       },
       "Type": "Custom::CDKBucketDeployment",
@@ -5065,7 +5065,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2794517da6217c62d8bb1ae55c2da57e1aa50688975f5839d0ce27ddf5988183.zip",
+          "S3Key": "10f38587378f0b968c1c297a4c392fc45abe5bf3cb14c70decbcf5afc7feb5c5.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -5379,7 +5379,7 @@ RUNBOOK: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "14dc62e437c50fbe51d6ea4c1d91cab10fb0dcbc50da9c0244d2a434a6d3589f.zip",
+          "S3Key": "2f86b7b78231bb11344f469948742a5194ce60097096cdcd28eacc2f2278cd28.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -6133,7 +6133,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "704d493e53a189fedc3896a767512e90558a3022baf76547259001a0db9c4fa5.zip",
+          "S3Key": "7ebde867f806867923269ca6515d489220ccbb48ad5f36d9a753b5dd32957070.zip",
         },
         "Description": "[ConstructHub/Orchestration/NeedsCatalogUpdate] Determines whether a package version requires a catalog update",
         "Environment": {
@@ -6288,7 +6288,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2699566d438b6ee00f3d6873a03cdff236a4fa6f8ee888926c52d120b616702c.zip",
+          "S3Key": "549800a3ebabbfe87937d3d5096cca1a3dec3c65180664a6e700adc7d9164e0e.zip",
         },
         "Description": "[ConstructHub/Redrive] Manually redrives all messages from the backend dead letter queue",
         "Environment": {
@@ -7080,7 +7080,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:095c19b98bab5c46bc4ada3eda593e04b6aba138ec6ba55fa526455d9f30bfc7",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:57a005a0e45aff09fb971c1088738dfcb85d2eb7bb472f196ea15fc597005f8b",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -9672,7 +9672,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1c2b4f991997e567cf8ba9bcfb5269b85e8a6bfb75c1ef547a544bd1f4c9dd33.zip",
+          "S3Key": "7fa31ee1e3852ab3d4ce6d91769f7718a0018845a99d05660484b4a959f36a52.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -9726,7 +9726,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2b526416a9b103a908e003be965218caaa62eae5c88e40a362adbe606942a8d5.zip",
+          "S3Key": "05d03095804959fdfe06e6474ab2b2126ebbef4dec3d7ffd9fabc83751062588.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": {
@@ -10431,7 +10431,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "16de0048ae11d17617e1b32d95c735af13c5b7df555e8affe6753579be7c0a55.zip",
+          "S3Key": "cdbbef158557618f513eea3e6bfe07e833446c71e395196842115e3cf8196160.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -10743,7 +10743,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "feac1a4abd7146259f0edaa6b3a69887ceae3df0572194b0cc1cc84b14d587ef.zip",
+          "S3Key": "cea83a576c76778c5499f70f0d318f4659cd8732622ef80a45306afd87561e2d.zip",
         },
         "Description": "Manually re-stage a package version",
         "Environment": {
@@ -10952,7 +10952,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "f67ec2116e51356d70db86909d2ce8273a58315c1aa36e358eeee77bd9a084d1.zip",
+          "S3Key": "877f8e3751a6a996c80c87df24ab3d5e377bb21b85bdb5cf3483bc912f40ca3e.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -11159,7 +11159,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "cf03d7055d3a91856642c2c2a6850fe5d90964e4e8df7a8b4e782d1a1ede2456.zip",
+          "S3Key": "3ceeaa8de639399c8fd450f5814155deb0aa17f94254552f0d7bb5687d13bee6.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -11512,7 +11512,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
+          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -11524,7 +11524,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
+          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -11591,7 +11591,7 @@ function handler(event) {
           },
         ],
         "SourceObjectKeys": [
-          "cfeb64a21b1bb5d2d1d9f1c76c63615906363b832b15503a5fcdca3ee49bbfa7.zip",
+          "409bb9e6490bb6580ea7992c2ebffc2ed63a4cae97fd1ed71d2b686ab5f6a371.zip",
         ],
         "SystemMetadata": {
           "cache-control": "public, max-age=300, must-revalidate, s-maxage=60, proxy-revalidate",
@@ -12564,7 +12564,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "0d58dbfcc6337b6f02aa7e374a503ef65a4ab53a3ffee57dde581805b629c2e0.zip",
+          "S3Key": "c6ed9052929702bc5c6622a7319d4eaab656d3934f6f2193d3824fbe790bf84b.zip",
         },
         "Description": "[ConstructHub/MissingDocumentationWidget] Is a custom CloudWatch widget handler",
         "Environment": {
@@ -12990,7 +12990,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "6dc2c91d8c8e3bc88ffe8925a64fd8268505d3e3d165e22f18a8486917ba7a16.zip",
+          "S3Key": "368f5caa69ead30ac3efd5fa5b76573d2370207979e58a33d2d59d7e45c39120.zip",
         },
         "Description": "[ConstructHub/SQSDLQWidget] Is a custom CloudWatch widget handler",
         "Handler": "index.handler",
@@ -14581,7 +14581,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
+          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -14947,7 +14947,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "f1b7885b673d9f17e1bf0939a3d3ba7a76f17efbbe7c9109b1f8baac1d283d91.zip",
+          "S3Key": "713e019f1505ec8b74e02da59325f8cc0dc1df8633a97946360eef71e4961a86.zip",
         },
         "Description": "backend/deny-list/prune-handler.lambda.ts",
         "Environment": {
@@ -15143,7 +15143,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1f67115da31f072e113b82a616fb1d9ff799f7594c86204bbcbd17de8e954114.zip",
+          "S3Key": "74af847789269e2455d893cf01da26dde664a80ddcbee32c23be027a42addbe9.zip",
         },
         "Description": "backend/deny-list/prune-queue-handler.lambda.ts",
         "Environment": {
@@ -15424,7 +15424,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "029be6a866f5acc5e6f68e18d64475729ab929d61665d8ea58e95ec1cb29c329.zip",
+          "S3Key": "dfc30b6cad945b9a1a8cd74979e7f6046600193846b31fe5faa0e64c2b0d95d7.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -15652,7 +15652,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "f64738290f58bcaa5b6f160f509f5debf06bcae60508f7252a3919f3572a7f78.zip",
+          "S3Key": "a8b68670eb455b177b2b85c9be2df672d28dc9470d41fba4c2b6af036086f1cc.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": {
@@ -15882,7 +15882,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
+          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -16096,7 +16096,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "bcc24517c2bca472ae9747fa039eb1b27336953867061a6dccf3b2ec0a7e5bde.zip",
+          "S3Key": "2d59ba9b7faee1e49a10d111c65af9374c92161329789225db8087a72b141f59.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -17022,7 +17022,7 @@ Direct link to the state machine: /states/home#/statemachines/view/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "02fe7c310c92dd2243de516b7df3e2b7a3170dacc073c48f9fb0806d5d1d8ae7.zip",
+          "S3Key": "b0cac3fe91cf84792dfa53eae18cf51c18867750fd9f296209aabfffa86654aa.zip",
         },
         "Description": "[ConstructHub/Inventory] A canary that periodically inspects the list of indexed packages",
         "Environment": {
@@ -17683,7 +17683,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
+          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -17787,7 +17787,7 @@ Direct link to function: /lambda/home#/functions/",
           },
         ],
         "SourceObjectKeys": [
-          "ee57c3c2c87eefd3a5a6cbcd848e46c0b37f428afd7bcd5a2fdc0f3e9e9da430.zip",
+          "ba2c42b4614a88c72a0a91a75f389fb962da98b479ae5c6b4009169243cf15c0.zip",
         ],
       },
       "Type": "Custom::CDKBucketDeployment",
@@ -18519,7 +18519,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2794517da6217c62d8bb1ae55c2da57e1aa50688975f5839d0ce27ddf5988183.zip",
+          "S3Key": "10f38587378f0b968c1c297a4c392fc45abe5bf3cb14c70decbcf5afc7feb5c5.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -18833,7 +18833,7 @@ RUNBOOK: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "14dc62e437c50fbe51d6ea4c1d91cab10fb0dcbc50da9c0244d2a434a6d3589f.zip",
+          "S3Key": "2f86b7b78231bb11344f469948742a5194ce60097096cdcd28eacc2f2278cd28.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -19587,7 +19587,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "704d493e53a189fedc3896a767512e90558a3022baf76547259001a0db9c4fa5.zip",
+          "S3Key": "7ebde867f806867923269ca6515d489220ccbb48ad5f36d9a753b5dd32957070.zip",
         },
         "Description": "[ConstructHub/Orchestration/NeedsCatalogUpdate] Determines whether a package version requires a catalog update",
         "Environment": {
@@ -19742,7 +19742,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2699566d438b6ee00f3d6873a03cdff236a4fa6f8ee888926c52d120b616702c.zip",
+          "S3Key": "549800a3ebabbfe87937d3d5096cca1a3dec3c65180664a6e700adc7d9164e0e.zip",
         },
         "Description": "[ConstructHub/Redrive] Manually redrives all messages from the backend dead letter queue",
         "Environment": {
@@ -20561,7 +20561,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:095c19b98bab5c46bc4ada3eda593e04b6aba138ec6ba55fa526455d9f30bfc7",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:57a005a0e45aff09fb971c1088738dfcb85d2eb7bb472f196ea15fc597005f8b",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -23199,7 +23199,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1c2b4f991997e567cf8ba9bcfb5269b85e8a6bfb75c1ef547a544bd1f4c9dd33.zip",
+          "S3Key": "7fa31ee1e3852ab3d4ce6d91769f7718a0018845a99d05660484b4a959f36a52.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -23253,7 +23253,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2b526416a9b103a908e003be965218caaa62eae5c88e40a362adbe606942a8d5.zip",
+          "S3Key": "05d03095804959fdfe06e6474ab2b2126ebbef4dec3d7ffd9fabc83751062588.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": {
@@ -23958,7 +23958,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "16de0048ae11d17617e1b32d95c735af13c5b7df555e8affe6753579be7c0a55.zip",
+          "S3Key": "cdbbef158557618f513eea3e6bfe07e833446c71e395196842115e3cf8196160.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -24270,7 +24270,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "feac1a4abd7146259f0edaa6b3a69887ceae3df0572194b0cc1cc84b14d587ef.zip",
+          "S3Key": "cea83a576c76778c5499f70f0d318f4659cd8732622ef80a45306afd87561e2d.zip",
         },
         "Description": "Manually re-stage a package version",
         "Environment": {
@@ -24479,7 +24479,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "f67ec2116e51356d70db86909d2ce8273a58315c1aa36e358eeee77bd9a084d1.zip",
+          "S3Key": "877f8e3751a6a996c80c87df24ab3d5e377bb21b85bdb5cf3483bc912f40ca3e.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -24686,7 +24686,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "cf03d7055d3a91856642c2c2a6850fe5d90964e4e8df7a8b4e782d1a1ede2456.zip",
+          "S3Key": "3ceeaa8de639399c8fd450f5814155deb0aa17f94254552f0d7bb5687d13bee6.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -25039,7 +25039,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
+          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -25051,7 +25051,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
+          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -25118,7 +25118,7 @@ function handler(event) {
           },
         ],
         "SourceObjectKeys": [
-          "cfeb64a21b1bb5d2d1d9f1c76c63615906363b832b15503a5fcdca3ee49bbfa7.zip",
+          "409bb9e6490bb6580ea7992c2ebffc2ed63a4cae97fd1ed71d2b686ab5f6a371.zip",
         ],
         "SystemMetadata": {
           "cache-control": "public, max-age=300, must-revalidate, s-maxage=60, proxy-revalidate",
@@ -26091,7 +26091,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "0d58dbfcc6337b6f02aa7e374a503ef65a4ab53a3ffee57dde581805b629c2e0.zip",
+          "S3Key": "c6ed9052929702bc5c6622a7319d4eaab656d3934f6f2193d3824fbe790bf84b.zip",
         },
         "Description": "[ConstructHub/MissingDocumentationWidget] Is a custom CloudWatch widget handler",
         "Environment": {
@@ -26517,7 +26517,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "6dc2c91d8c8e3bc88ffe8925a64fd8268505d3e3d165e22f18a8486917ba7a16.zip",
+          "S3Key": "368f5caa69ead30ac3efd5fa5b76573d2370207979e58a33d2d59d7e45c39120.zip",
         },
         "Description": "[ConstructHub/SQSDLQWidget] Is a custom CloudWatch widget handler",
         "Handler": "index.handler",
@@ -27851,7 +27851,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
+          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -28217,7 +28217,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "f1b7885b673d9f17e1bf0939a3d3ba7a76f17efbbe7c9109b1f8baac1d283d91.zip",
+          "S3Key": "713e019f1505ec8b74e02da59325f8cc0dc1df8633a97946360eef71e4961a86.zip",
         },
         "Description": "backend/deny-list/prune-handler.lambda.ts",
         "Environment": {
@@ -28413,7 +28413,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1f67115da31f072e113b82a616fb1d9ff799f7594c86204bbcbd17de8e954114.zip",
+          "S3Key": "74af847789269e2455d893cf01da26dde664a80ddcbee32c23be027a42addbe9.zip",
         },
         "Description": "backend/deny-list/prune-queue-handler.lambda.ts",
         "Environment": {
@@ -28694,7 +28694,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "029be6a866f5acc5e6f68e18d64475729ab929d61665d8ea58e95ec1cb29c329.zip",
+          "S3Key": "dfc30b6cad945b9a1a8cd74979e7f6046600193846b31fe5faa0e64c2b0d95d7.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -28922,7 +28922,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "f64738290f58bcaa5b6f160f509f5debf06bcae60508f7252a3919f3572a7f78.zip",
+          "S3Key": "a8b68670eb455b177b2b85c9be2df672d28dc9470d41fba4c2b6af036086f1cc.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": {
@@ -29134,7 +29134,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
+          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -29348,7 +29348,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "bcc24517c2bca472ae9747fa039eb1b27336953867061a6dccf3b2ec0a7e5bde.zip",
+          "S3Key": "2d59ba9b7faee1e49a10d111c65af9374c92161329789225db8087a72b141f59.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -30194,7 +30194,7 @@ Direct link to the state machine: /states/home#/statemachines/view/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "02fe7c310c92dd2243de516b7df3e2b7a3170dacc073c48f9fb0806d5d1d8ae7.zip",
+          "S3Key": "b0cac3fe91cf84792dfa53eae18cf51c18867750fd9f296209aabfffa86654aa.zip",
         },
         "Description": "[ConstructHub/Inventory] A canary that periodically inspects the list of indexed packages",
         "Environment": {
@@ -30855,7 +30855,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
+          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -30959,7 +30959,7 @@ Direct link to function: /lambda/home#/functions/",
           },
         ],
         "SourceObjectKeys": [
-          "ee57c3c2c87eefd3a5a6cbcd848e46c0b37f428afd7bcd5a2fdc0f3e9e9da430.zip",
+          "ba2c42b4614a88c72a0a91a75f389fb962da98b479ae5c6b4009169243cf15c0.zip",
         ],
       },
       "Type": "Custom::CDKBucketDeployment",
@@ -31691,7 +31691,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2794517da6217c62d8bb1ae55c2da57e1aa50688975f5839d0ce27ddf5988183.zip",
+          "S3Key": "10f38587378f0b968c1c297a4c392fc45abe5bf3cb14c70decbcf5afc7feb5c5.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -32005,7 +32005,7 @@ RUNBOOK: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "14dc62e437c50fbe51d6ea4c1d91cab10fb0dcbc50da9c0244d2a434a6d3589f.zip",
+          "S3Key": "2f86b7b78231bb11344f469948742a5194ce60097096cdcd28eacc2f2278cd28.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -32759,7 +32759,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "704d493e53a189fedc3896a767512e90558a3022baf76547259001a0db9c4fa5.zip",
+          "S3Key": "7ebde867f806867923269ca6515d489220ccbb48ad5f36d9a753b5dd32957070.zip",
         },
         "Description": "[ConstructHub/Orchestration/NeedsCatalogUpdate] Determines whether a package version requires a catalog update",
         "Environment": {
@@ -32914,7 +32914,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2699566d438b6ee00f3d6873a03cdff236a4fa6f8ee888926c52d120b616702c.zip",
+          "S3Key": "549800a3ebabbfe87937d3d5096cca1a3dec3c65180664a6e700adc7d9164e0e.zip",
         },
         "Description": "[ConstructHub/Redrive] Manually redrives all messages from the backend dead letter queue",
         "Environment": {
@@ -33706,7 +33706,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:095c19b98bab5c46bc4ada3eda593e04b6aba138ec6ba55fa526455d9f30bfc7",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:57a005a0e45aff09fb971c1088738dfcb85d2eb7bb472f196ea15fc597005f8b",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -36298,7 +36298,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1c2b4f991997e567cf8ba9bcfb5269b85e8a6bfb75c1ef547a544bd1f4c9dd33.zip",
+          "S3Key": "7fa31ee1e3852ab3d4ce6d91769f7718a0018845a99d05660484b4a959f36a52.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -36352,7 +36352,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2b526416a9b103a908e003be965218caaa62eae5c88e40a362adbe606942a8d5.zip",
+          "S3Key": "05d03095804959fdfe06e6474ab2b2126ebbef4dec3d7ffd9fabc83751062588.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": {
@@ -37057,7 +37057,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "16de0048ae11d17617e1b32d95c735af13c5b7df555e8affe6753579be7c0a55.zip",
+          "S3Key": "cdbbef158557618f513eea3e6bfe07e833446c71e395196842115e3cf8196160.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -37369,7 +37369,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "feac1a4abd7146259f0edaa6b3a69887ceae3df0572194b0cc1cc84b14d587ef.zip",
+          "S3Key": "cea83a576c76778c5499f70f0d318f4659cd8732622ef80a45306afd87561e2d.zip",
         },
         "Description": "Manually re-stage a package version",
         "Environment": {
@@ -37578,7 +37578,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "f67ec2116e51356d70db86909d2ce8273a58315c1aa36e358eeee77bd9a084d1.zip",
+          "S3Key": "877f8e3751a6a996c80c87df24ab3d5e377bb21b85bdb5cf3483bc912f40ca3e.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -37785,7 +37785,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "cf03d7055d3a91856642c2c2a6850fe5d90964e4e8df7a8b4e782d1a1ede2456.zip",
+          "S3Key": "3ceeaa8de639399c8fd450f5814155deb0aa17f94254552f0d7bb5687d13bee6.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -38138,7 +38138,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
+          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -38150,7 +38150,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
+          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -38217,7 +38217,7 @@ function handler(event) {
           },
         ],
         "SourceObjectKeys": [
-          "cfeb64a21b1bb5d2d1d9f1c76c63615906363b832b15503a5fcdca3ee49bbfa7.zip",
+          "409bb9e6490bb6580ea7992c2ebffc2ed63a4cae97fd1ed71d2b686ab5f6a371.zip",
         ],
         "SystemMetadata": {
           "cache-control": "public, max-age=300, must-revalidate, s-maxage=60, proxy-revalidate",
@@ -39190,7 +39190,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "0d58dbfcc6337b6f02aa7e374a503ef65a4ab53a3ffee57dde581805b629c2e0.zip",
+          "S3Key": "c6ed9052929702bc5c6622a7319d4eaab656d3934f6f2193d3824fbe790bf84b.zip",
         },
         "Description": "[ConstructHub/MissingDocumentationWidget] Is a custom CloudWatch widget handler",
         "Environment": {
@@ -39616,7 +39616,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "6dc2c91d8c8e3bc88ffe8925a64fd8268505d3e3d165e22f18a8486917ba7a16.zip",
+          "S3Key": "368f5caa69ead30ac3efd5fa5b76573d2370207979e58a33d2d59d7e45c39120.zip",
         },
         "Description": "[ConstructHub/SQSDLQWidget] Is a custom CloudWatch widget handler",
         "Handler": "index.handler",
@@ -41090,7 +41090,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
+          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -41456,7 +41456,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "f1b7885b673d9f17e1bf0939a3d3ba7a76f17efbbe7c9109b1f8baac1d283d91.zip",
+          "S3Key": "713e019f1505ec8b74e02da59325f8cc0dc1df8633a97946360eef71e4961a86.zip",
         },
         "Description": "backend/deny-list/prune-handler.lambda.ts",
         "Environment": {
@@ -41652,7 +41652,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1f67115da31f072e113b82a616fb1d9ff799f7594c86204bbcbd17de8e954114.zip",
+          "S3Key": "74af847789269e2455d893cf01da26dde664a80ddcbee32c23be027a42addbe9.zip",
         },
         "Description": "backend/deny-list/prune-queue-handler.lambda.ts",
         "Environment": {
@@ -41933,7 +41933,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "029be6a866f5acc5e6f68e18d64475729ab929d61665d8ea58e95ec1cb29c329.zip",
+          "S3Key": "dfc30b6cad945b9a1a8cd74979e7f6046600193846b31fe5faa0e64c2b0d95d7.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -42148,7 +42148,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "f64738290f58bcaa5b6f160f509f5debf06bcae60508f7252a3919f3572a7f78.zip",
+          "S3Key": "a8b68670eb455b177b2b85c9be2df672d28dc9470d41fba4c2b6af036086f1cc.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": {
@@ -42360,7 +42360,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
+          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -42574,7 +42574,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "bcc24517c2bca472ae9747fa039eb1b27336953867061a6dccf3b2ec0a7e5bde.zip",
+          "S3Key": "2d59ba9b7faee1e49a10d111c65af9374c92161329789225db8087a72b141f59.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -43420,7 +43420,7 @@ Direct link to the state machine: /states/home#/statemachines/view/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "02fe7c310c92dd2243de516b7df3e2b7a3170dacc073c48f9fb0806d5d1d8ae7.zip",
+          "S3Key": "b0cac3fe91cf84792dfa53eae18cf51c18867750fd9f296209aabfffa86654aa.zip",
         },
         "Description": "[ConstructHub/Inventory] A canary that periodically inspects the list of indexed packages",
         "Environment": {
@@ -44081,7 +44081,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
+          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -44185,7 +44185,7 @@ Direct link to function: /lambda/home#/functions/",
           },
         ],
         "SourceObjectKeys": [
-          "ee57c3c2c87eefd3a5a6cbcd848e46c0b37f428afd7bcd5a2fdc0f3e9e9da430.zip",
+          "ba2c42b4614a88c72a0a91a75f389fb962da98b479ae5c6b4009169243cf15c0.zip",
         ],
       },
       "Type": "Custom::CDKBucketDeployment",
@@ -44939,7 +44939,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2794517da6217c62d8bb1ae55c2da57e1aa50688975f5839d0ce27ddf5988183.zip",
+          "S3Key": "10f38587378f0b968c1c297a4c392fc45abe5bf3cb14c70decbcf5afc7feb5c5.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -45253,7 +45253,7 @@ RUNBOOK: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "14dc62e437c50fbe51d6ea4c1d91cab10fb0dcbc50da9c0244d2a434a6d3589f.zip",
+          "S3Key": "2f86b7b78231bb11344f469948742a5194ce60097096cdcd28eacc2f2278cd28.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -46007,7 +46007,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "704d493e53a189fedc3896a767512e90558a3022baf76547259001a0db9c4fa5.zip",
+          "S3Key": "7ebde867f806867923269ca6515d489220ccbb48ad5f36d9a753b5dd32957070.zip",
         },
         "Description": "[ConstructHub/Orchestration/NeedsCatalogUpdate] Determines whether a package version requires a catalog update",
         "Environment": {
@@ -46162,7 +46162,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2699566d438b6ee00f3d6873a03cdff236a4fa6f8ee888926c52d120b616702c.zip",
+          "S3Key": "549800a3ebabbfe87937d3d5096cca1a3dec3c65180664a6e700adc7d9164e0e.zip",
         },
         "Description": "[ConstructHub/Redrive] Manually redrives all messages from the backend dead letter queue",
         "Environment": {
@@ -46954,7 +46954,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:095c19b98bab5c46bc4ada3eda593e04b6aba138ec6ba55fa526455d9f30bfc7",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:57a005a0e45aff09fb971c1088738dfcb85d2eb7bb472f196ea15fc597005f8b",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -49546,7 +49546,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1c2b4f991997e567cf8ba9bcfb5269b85e8a6bfb75c1ef547a544bd1f4c9dd33.zip",
+          "S3Key": "7fa31ee1e3852ab3d4ce6d91769f7718a0018845a99d05660484b4a959f36a52.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -49600,7 +49600,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2b526416a9b103a908e003be965218caaa62eae5c88e40a362adbe606942a8d5.zip",
+          "S3Key": "05d03095804959fdfe06e6474ab2b2126ebbef4dec3d7ffd9fabc83751062588.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": {
@@ -50292,7 +50292,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "16de0048ae11d17617e1b32d95c735af13c5b7df555e8affe6753579be7c0a55.zip",
+          "S3Key": "cdbbef158557618f513eea3e6bfe07e833446c71e395196842115e3cf8196160.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -50604,7 +50604,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "feac1a4abd7146259f0edaa6b3a69887ceae3df0572194b0cc1cc84b14d587ef.zip",
+          "S3Key": "cea83a576c76778c5499f70f0d318f4659cd8732622ef80a45306afd87561e2d.zip",
         },
         "Description": "Manually re-stage a package version",
         "Environment": {
@@ -50813,7 +50813,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "f67ec2116e51356d70db86909d2ce8273a58315c1aa36e358eeee77bd9a084d1.zip",
+          "S3Key": "877f8e3751a6a996c80c87df24ab3d5e377bb21b85bdb5cf3483bc912f40ca3e.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -51020,7 +51020,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "cf03d7055d3a91856642c2c2a6850fe5d90964e4e8df7a8b4e782d1a1ede2456.zip",
+          "S3Key": "3ceeaa8de639399c8fd450f5814155deb0aa17f94254552f0d7bb5687d13bee6.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -51425,7 +51425,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
+          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -51437,7 +51437,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
+          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -51504,7 +51504,7 @@ function handler(event) {
           },
         ],
         "SourceObjectKeys": [
-          "cfeb64a21b1bb5d2d1d9f1c76c63615906363b832b15503a5fcdca3ee49bbfa7.zip",
+          "409bb9e6490bb6580ea7992c2ebffc2ed63a4cae97fd1ed71d2b686ab5f6a371.zip",
         ],
         "SystemMetadata": {
           "cache-control": "public, max-age=300, must-revalidate, s-maxage=60, proxy-revalidate",
@@ -52675,7 +52675,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "0d58dbfcc6337b6f02aa7e374a503ef65a4ab53a3ffee57dde581805b629c2e0.zip",
+          "S3Key": "c6ed9052929702bc5c6622a7319d4eaab656d3934f6f2193d3824fbe790bf84b.zip",
         },
         "Description": "[ConstructHub/MissingDocumentationWidget] Is a custom CloudWatch widget handler",
         "Environment": {
@@ -53101,7 +53101,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "6dc2c91d8c8e3bc88ffe8925a64fd8268505d3e3d165e22f18a8486917ba7a16.zip",
+          "S3Key": "368f5caa69ead30ac3efd5fa5b76573d2370207979e58a33d2d59d7e45c39120.zip",
         },
         "Description": "[ConstructHub/SQSDLQWidget] Is a custom CloudWatch widget handler",
         "Handler": "index.handler",
@@ -54512,7 +54512,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
+          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -54878,7 +54878,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "f1b7885b673d9f17e1bf0939a3d3ba7a76f17efbbe7c9109b1f8baac1d283d91.zip",
+          "S3Key": "713e019f1505ec8b74e02da59325f8cc0dc1df8633a97946360eef71e4961a86.zip",
         },
         "Description": "backend/deny-list/prune-handler.lambda.ts",
         "Environment": {
@@ -55074,7 +55074,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1f67115da31f072e113b82a616fb1d9ff799f7594c86204bbcbd17de8e954114.zip",
+          "S3Key": "74af847789269e2455d893cf01da26dde664a80ddcbee32c23be027a42addbe9.zip",
         },
         "Description": "backend/deny-list/prune-queue-handler.lambda.ts",
         "Environment": {
@@ -55355,7 +55355,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "029be6a866f5acc5e6f68e18d64475729ab929d61665d8ea58e95ec1cb29c329.zip",
+          "S3Key": "dfc30b6cad945b9a1a8cd74979e7f6046600193846b31fe5faa0e64c2b0d95d7.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -55583,7 +55583,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "f64738290f58bcaa5b6f160f509f5debf06bcae60508f7252a3919f3572a7f78.zip",
+          "S3Key": "a8b68670eb455b177b2b85c9be2df672d28dc9470d41fba4c2b6af036086f1cc.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": {
@@ -55795,7 +55795,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
+          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -56009,7 +56009,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "bcc24517c2bca472ae9747fa039eb1b27336953867061a6dccf3b2ec0a7e5bde.zip",
+          "S3Key": "2d59ba9b7faee1e49a10d111c65af9374c92161329789225db8087a72b141f59.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -56981,7 +56981,7 @@ Direct link to the state machine: /states/home#/statemachines/view/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "02fe7c310c92dd2243de516b7df3e2b7a3170dacc073c48f9fb0806d5d1d8ae7.zip",
+          "S3Key": "b0cac3fe91cf84792dfa53eae18cf51c18867750fd9f296209aabfffa86654aa.zip",
         },
         "Description": "[ConstructHub/Inventory] A canary that periodically inspects the list of indexed packages",
         "Environment": {
@@ -57642,7 +57642,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
+          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -57746,7 +57746,7 @@ Direct link to function: /lambda/home#/functions/",
           },
         ],
         "SourceObjectKeys": [
-          "ee57c3c2c87eefd3a5a6cbcd848e46c0b37f428afd7bcd5a2fdc0f3e9e9da430.zip",
+          "ba2c42b4614a88c72a0a91a75f389fb962da98b479ae5c6b4009169243cf15c0.zip",
         ],
       },
       "Type": "Custom::CDKBucketDeployment",
@@ -58507,7 +58507,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2794517da6217c62d8bb1ae55c2da57e1aa50688975f5839d0ce27ddf5988183.zip",
+          "S3Key": "10f38587378f0b968c1c297a4c392fc45abe5bf3cb14c70decbcf5afc7feb5c5.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -58821,7 +58821,7 @@ RUNBOOK: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "14dc62e437c50fbe51d6ea4c1d91cab10fb0dcbc50da9c0244d2a434a6d3589f.zip",
+          "S3Key": "2f86b7b78231bb11344f469948742a5194ce60097096cdcd28eacc2f2278cd28.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -59168,7 +59168,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "704d493e53a189fedc3896a767512e90558a3022baf76547259001a0db9c4fa5.zip",
+          "S3Key": "7ebde867f806867923269ca6515d489220ccbb48ad5f36d9a753b5dd32957070.zip",
         },
         "Description": "[ConstructHub/Orchestration/NeedsCatalogUpdate] Determines whether a package version requires a catalog update",
         "Environment": {
@@ -59323,7 +59323,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2699566d438b6ee00f3d6873a03cdff236a4fa6f8ee888926c52d120b616702c.zip",
+          "S3Key": "549800a3ebabbfe87937d3d5096cca1a3dec3c65180664a6e700adc7d9164e0e.zip",
         },
         "Description": "[ConstructHub/Redrive] Manually redrives all messages from the backend dead letter queue",
         "Environment": {
@@ -60121,7 +60121,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:095c19b98bab5c46bc4ada3eda593e04b6aba138ec6ba55fa526455d9f30bfc7",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:57a005a0e45aff09fb971c1088738dfcb85d2eb7bb472f196ea15fc597005f8b",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -62775,7 +62775,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1c2b4f991997e567cf8ba9bcfb5269b85e8a6bfb75c1ef547a544bd1f4c9dd33.zip",
+          "S3Key": "7fa31ee1e3852ab3d4ce6d91769f7718a0018845a99d05660484b4a959f36a52.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -62829,7 +62829,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2b526416a9b103a908e003be965218caaa62eae5c88e40a362adbe606942a8d5.zip",
+          "S3Key": "05d03095804959fdfe06e6474ab2b2126ebbef4dec3d7ffd9fabc83751062588.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": {
@@ -63534,7 +63534,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "16de0048ae11d17617e1b32d95c735af13c5b7df555e8affe6753579be7c0a55.zip",
+          "S3Key": "cdbbef158557618f513eea3e6bfe07e833446c71e395196842115e3cf8196160.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -63846,7 +63846,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "feac1a4abd7146259f0edaa6b3a69887ceae3df0572194b0cc1cc84b14d587ef.zip",
+          "S3Key": "cea83a576c76778c5499f70f0d318f4659cd8732622ef80a45306afd87561e2d.zip",
         },
         "Description": "Manually re-stage a package version",
         "Environment": {
@@ -64055,7 +64055,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "f67ec2116e51356d70db86909d2ce8273a58315c1aa36e358eeee77bd9a084d1.zip",
+          "S3Key": "877f8e3751a6a996c80c87df24ab3d5e377bb21b85bdb5cf3483bc912f40ca3e.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -67122,7 +67122,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "cf03d7055d3a91856642c2c2a6850fe5d90964e4e8df7a8b4e782d1a1ede2456.zip",
+          "S3Key": "3ceeaa8de639399c8fd450f5814155deb0aa17f94254552f0d7bb5687d13bee6.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -67475,7 +67475,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
+          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -67487,7 +67487,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
+          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -67554,7 +67554,7 @@ function handler(event) {
           },
         ],
         "SourceObjectKeys": [
-          "cfeb64a21b1bb5d2d1d9f1c76c63615906363b832b15503a5fcdca3ee49bbfa7.zip",
+          "409bb9e6490bb6580ea7992c2ebffc2ed63a4cae97fd1ed71d2b686ab5f6a371.zip",
         ],
         "SystemMetadata": {
           "cache-control": "public, max-age=300, must-revalidate, s-maxage=60, proxy-revalidate",
@@ -69084,7 +69084,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "0d58dbfcc6337b6f02aa7e374a503ef65a4ab53a3ffee57dde581805b629c2e0.zip",
+          "S3Key": "c6ed9052929702bc5c6622a7319d4eaab656d3934f6f2193d3824fbe790bf84b.zip",
         },
         "Description": "[ConstructHub/MissingDocumentationWidget] Is a custom CloudWatch widget handler",
         "Environment": {
@@ -69510,7 +69510,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "6dc2c91d8c8e3bc88ffe8925a64fd8268505d3e3d165e22f18a8486917ba7a16.zip",
+          "S3Key": "368f5caa69ead30ac3efd5fa5b76573d2370207979e58a33d2d59d7e45c39120.zip",
         },
         "Description": "[ConstructHub/SQSDLQWidget] Is a custom CloudWatch widget handler",
         "Handler": "index.handler",

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -1225,7 +1225,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
+          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -1591,7 +1591,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "713e019f1505ec8b74e02da59325f8cc0dc1df8633a97946360eef71e4961a86.zip",
+          "S3Key": "f1b7885b673d9f17e1bf0939a3d3ba7a76f17efbbe7c9109b1f8baac1d283d91.zip",
         },
         "Description": "backend/deny-list/prune-handler.lambda.ts",
         "Environment": {
@@ -1787,7 +1787,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "74af847789269e2455d893cf01da26dde664a80ddcbee32c23be027a42addbe9.zip",
+          "S3Key": "1f67115da31f072e113b82a616fb1d9ff799f7594c86204bbcbd17de8e954114.zip",
         },
         "Description": "backend/deny-list/prune-queue-handler.lambda.ts",
         "Environment": {
@@ -2068,7 +2068,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "dfc30b6cad945b9a1a8cd74979e7f6046600193846b31fe5faa0e64c2b0d95d7.zip",
+          "S3Key": "029be6a866f5acc5e6f68e18d64475729ab929d61665d8ea58e95ec1cb29c329.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -2296,7 +2296,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "a8b68670eb455b177b2b85c9be2df672d28dc9470d41fba4c2b6af036086f1cc.zip",
+          "S3Key": "f64738290f58bcaa5b6f160f509f5debf06bcae60508f7252a3919f3572a7f78.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": {
@@ -2508,7 +2508,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
+          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -2722,7 +2722,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2d59ba9b7faee1e49a10d111c65af9374c92161329789225db8087a72b141f59.zip",
+          "S3Key": "bcc24517c2bca472ae9747fa039eb1b27336953867061a6dccf3b2ec0a7e5bde.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -3568,7 +3568,7 @@ Direct link to the state machine: /states/home#/statemachines/view/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b0cac3fe91cf84792dfa53eae18cf51c18867750fd9f296209aabfffa86654aa.zip",
+          "S3Key": "02fe7c310c92dd2243de516b7df3e2b7a3170dacc073c48f9fb0806d5d1d8ae7.zip",
         },
         "Description": "[ConstructHub/Inventory] A canary that periodically inspects the list of indexed packages",
         "Environment": {
@@ -4229,7 +4229,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
+          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -4333,7 +4333,7 @@ Direct link to function: /lambda/home#/functions/",
           },
         ],
         "SourceObjectKeys": [
-          "ba2c42b4614a88c72a0a91a75f389fb962da98b479ae5c6b4009169243cf15c0.zip",
+          "ee57c3c2c87eefd3a5a6cbcd848e46c0b37f428afd7bcd5a2fdc0f3e9e9da430.zip",
         ],
       },
       "Type": "Custom::CDKBucketDeployment",
@@ -5065,7 +5065,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "10f38587378f0b968c1c297a4c392fc45abe5bf3cb14c70decbcf5afc7feb5c5.zip",
+          "S3Key": "2794517da6217c62d8bb1ae55c2da57e1aa50688975f5839d0ce27ddf5988183.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -5379,7 +5379,7 @@ RUNBOOK: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2f86b7b78231bb11344f469948742a5194ce60097096cdcd28eacc2f2278cd28.zip",
+          "S3Key": "14dc62e437c50fbe51d6ea4c1d91cab10fb0dcbc50da9c0244d2a434a6d3589f.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -6133,7 +6133,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "7ebde867f806867923269ca6515d489220ccbb48ad5f36d9a753b5dd32957070.zip",
+          "S3Key": "704d493e53a189fedc3896a767512e90558a3022baf76547259001a0db9c4fa5.zip",
         },
         "Description": "[ConstructHub/Orchestration/NeedsCatalogUpdate] Determines whether a package version requires a catalog update",
         "Environment": {
@@ -6288,7 +6288,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "549800a3ebabbfe87937d3d5096cca1a3dec3c65180664a6e700adc7d9164e0e.zip",
+          "S3Key": "2699566d438b6ee00f3d6873a03cdff236a4fa6f8ee888926c52d120b616702c.zip",
         },
         "Description": "[ConstructHub/Redrive] Manually redrives all messages from the backend dead letter queue",
         "Environment": {
@@ -7080,7 +7080,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:57a005a0e45aff09fb971c1088738dfcb85d2eb7bb472f196ea15fc597005f8b",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:095c19b98bab5c46bc4ada3eda593e04b6aba138ec6ba55fa526455d9f30bfc7",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -9672,7 +9672,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "c86be1d83b833a8f5e51a98f93c6203097919e33548dc173647bb10f3d84b208.zip",
+          "S3Key": "1c2b4f991997e567cf8ba9bcfb5269b85e8a6bfb75c1ef547a544bd1f4c9dd33.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -9726,7 +9726,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "05d03095804959fdfe06e6474ab2b2126ebbef4dec3d7ffd9fabc83751062588.zip",
+          "S3Key": "2b526416a9b103a908e003be965218caaa62eae5c88e40a362adbe606942a8d5.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": {
@@ -10431,7 +10431,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "cdbbef158557618f513eea3e6bfe07e833446c71e395196842115e3cf8196160.zip",
+          "S3Key": "16de0048ae11d17617e1b32d95c735af13c5b7df555e8affe6753579be7c0a55.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -10743,7 +10743,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "cea83a576c76778c5499f70f0d318f4659cd8732622ef80a45306afd87561e2d.zip",
+          "S3Key": "feac1a4abd7146259f0edaa6b3a69887ceae3df0572194b0cc1cc84b14d587ef.zip",
         },
         "Description": "Manually re-stage a package version",
         "Environment": {
@@ -10952,7 +10952,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "877f8e3751a6a996c80c87df24ab3d5e377bb21b85bdb5cf3483bc912f40ca3e.zip",
+          "S3Key": "f67ec2116e51356d70db86909d2ce8273a58315c1aa36e358eeee77bd9a084d1.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -11159,7 +11159,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "3ceeaa8de639399c8fd450f5814155deb0aa17f94254552f0d7bb5687d13bee6.zip",
+          "S3Key": "cf03d7055d3a91856642c2c2a6850fe5d90964e4e8df7a8b4e782d1a1ede2456.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -11512,7 +11512,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
+          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -11524,7 +11524,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
+          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -11591,7 +11591,7 @@ function handler(event) {
           },
         ],
         "SourceObjectKeys": [
-          "409bb9e6490bb6580ea7992c2ebffc2ed63a4cae97fd1ed71d2b686ab5f6a371.zip",
+          "cfeb64a21b1bb5d2d1d9f1c76c63615906363b832b15503a5fcdca3ee49bbfa7.zip",
         ],
         "SystemMetadata": {
           "cache-control": "public, max-age=300, must-revalidate, s-maxage=60, proxy-revalidate",
@@ -12564,7 +12564,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "c6ed9052929702bc5c6622a7319d4eaab656d3934f6f2193d3824fbe790bf84b.zip",
+          "S3Key": "0d58dbfcc6337b6f02aa7e374a503ef65a4ab53a3ffee57dde581805b629c2e0.zip",
         },
         "Description": "[ConstructHub/MissingDocumentationWidget] Is a custom CloudWatch widget handler",
         "Environment": {
@@ -12990,7 +12990,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "368f5caa69ead30ac3efd5fa5b76573d2370207979e58a33d2d59d7e45c39120.zip",
+          "S3Key": "6dc2c91d8c8e3bc88ffe8925a64fd8268505d3e3d165e22f18a8486917ba7a16.zip",
         },
         "Description": "[ConstructHub/SQSDLQWidget] Is a custom CloudWatch widget handler",
         "Handler": "index.handler",
@@ -14581,7 +14581,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
+          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -14947,7 +14947,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "713e019f1505ec8b74e02da59325f8cc0dc1df8633a97946360eef71e4961a86.zip",
+          "S3Key": "f1b7885b673d9f17e1bf0939a3d3ba7a76f17efbbe7c9109b1f8baac1d283d91.zip",
         },
         "Description": "backend/deny-list/prune-handler.lambda.ts",
         "Environment": {
@@ -15143,7 +15143,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "74af847789269e2455d893cf01da26dde664a80ddcbee32c23be027a42addbe9.zip",
+          "S3Key": "1f67115da31f072e113b82a616fb1d9ff799f7594c86204bbcbd17de8e954114.zip",
         },
         "Description": "backend/deny-list/prune-queue-handler.lambda.ts",
         "Environment": {
@@ -15424,7 +15424,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "dfc30b6cad945b9a1a8cd74979e7f6046600193846b31fe5faa0e64c2b0d95d7.zip",
+          "S3Key": "029be6a866f5acc5e6f68e18d64475729ab929d61665d8ea58e95ec1cb29c329.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -15652,7 +15652,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "a8b68670eb455b177b2b85c9be2df672d28dc9470d41fba4c2b6af036086f1cc.zip",
+          "S3Key": "f64738290f58bcaa5b6f160f509f5debf06bcae60508f7252a3919f3572a7f78.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": {
@@ -15882,7 +15882,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
+          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -16096,7 +16096,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2d59ba9b7faee1e49a10d111c65af9374c92161329789225db8087a72b141f59.zip",
+          "S3Key": "bcc24517c2bca472ae9747fa039eb1b27336953867061a6dccf3b2ec0a7e5bde.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -17022,7 +17022,7 @@ Direct link to the state machine: /states/home#/statemachines/view/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b0cac3fe91cf84792dfa53eae18cf51c18867750fd9f296209aabfffa86654aa.zip",
+          "S3Key": "02fe7c310c92dd2243de516b7df3e2b7a3170dacc073c48f9fb0806d5d1d8ae7.zip",
         },
         "Description": "[ConstructHub/Inventory] A canary that periodically inspects the list of indexed packages",
         "Environment": {
@@ -17683,7 +17683,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
+          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -17787,7 +17787,7 @@ Direct link to function: /lambda/home#/functions/",
           },
         ],
         "SourceObjectKeys": [
-          "ba2c42b4614a88c72a0a91a75f389fb962da98b479ae5c6b4009169243cf15c0.zip",
+          "ee57c3c2c87eefd3a5a6cbcd848e46c0b37f428afd7bcd5a2fdc0f3e9e9da430.zip",
         ],
       },
       "Type": "Custom::CDKBucketDeployment",
@@ -18519,7 +18519,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "10f38587378f0b968c1c297a4c392fc45abe5bf3cb14c70decbcf5afc7feb5c5.zip",
+          "S3Key": "2794517da6217c62d8bb1ae55c2da57e1aa50688975f5839d0ce27ddf5988183.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -18833,7 +18833,7 @@ RUNBOOK: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2f86b7b78231bb11344f469948742a5194ce60097096cdcd28eacc2f2278cd28.zip",
+          "S3Key": "14dc62e437c50fbe51d6ea4c1d91cab10fb0dcbc50da9c0244d2a434a6d3589f.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -19587,7 +19587,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "7ebde867f806867923269ca6515d489220ccbb48ad5f36d9a753b5dd32957070.zip",
+          "S3Key": "704d493e53a189fedc3896a767512e90558a3022baf76547259001a0db9c4fa5.zip",
         },
         "Description": "[ConstructHub/Orchestration/NeedsCatalogUpdate] Determines whether a package version requires a catalog update",
         "Environment": {
@@ -19742,7 +19742,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "549800a3ebabbfe87937d3d5096cca1a3dec3c65180664a6e700adc7d9164e0e.zip",
+          "S3Key": "2699566d438b6ee00f3d6873a03cdff236a4fa6f8ee888926c52d120b616702c.zip",
         },
         "Description": "[ConstructHub/Redrive] Manually redrives all messages from the backend dead letter queue",
         "Environment": {
@@ -20561,7 +20561,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:57a005a0e45aff09fb971c1088738dfcb85d2eb7bb472f196ea15fc597005f8b",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:095c19b98bab5c46bc4ada3eda593e04b6aba138ec6ba55fa526455d9f30bfc7",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -23199,7 +23199,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "c86be1d83b833a8f5e51a98f93c6203097919e33548dc173647bb10f3d84b208.zip",
+          "S3Key": "1c2b4f991997e567cf8ba9bcfb5269b85e8a6bfb75c1ef547a544bd1f4c9dd33.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -23253,7 +23253,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "05d03095804959fdfe06e6474ab2b2126ebbef4dec3d7ffd9fabc83751062588.zip",
+          "S3Key": "2b526416a9b103a908e003be965218caaa62eae5c88e40a362adbe606942a8d5.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": {
@@ -23958,7 +23958,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "cdbbef158557618f513eea3e6bfe07e833446c71e395196842115e3cf8196160.zip",
+          "S3Key": "16de0048ae11d17617e1b32d95c735af13c5b7df555e8affe6753579be7c0a55.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -24270,7 +24270,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "cea83a576c76778c5499f70f0d318f4659cd8732622ef80a45306afd87561e2d.zip",
+          "S3Key": "feac1a4abd7146259f0edaa6b3a69887ceae3df0572194b0cc1cc84b14d587ef.zip",
         },
         "Description": "Manually re-stage a package version",
         "Environment": {
@@ -24479,7 +24479,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "877f8e3751a6a996c80c87df24ab3d5e377bb21b85bdb5cf3483bc912f40ca3e.zip",
+          "S3Key": "f67ec2116e51356d70db86909d2ce8273a58315c1aa36e358eeee77bd9a084d1.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -24686,7 +24686,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "3ceeaa8de639399c8fd450f5814155deb0aa17f94254552f0d7bb5687d13bee6.zip",
+          "S3Key": "cf03d7055d3a91856642c2c2a6850fe5d90964e4e8df7a8b4e782d1a1ede2456.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -25039,7 +25039,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
+          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -25051,7 +25051,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
+          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -25118,7 +25118,7 @@ function handler(event) {
           },
         ],
         "SourceObjectKeys": [
-          "409bb9e6490bb6580ea7992c2ebffc2ed63a4cae97fd1ed71d2b686ab5f6a371.zip",
+          "cfeb64a21b1bb5d2d1d9f1c76c63615906363b832b15503a5fcdca3ee49bbfa7.zip",
         ],
         "SystemMetadata": {
           "cache-control": "public, max-age=300, must-revalidate, s-maxage=60, proxy-revalidate",
@@ -26091,7 +26091,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "c6ed9052929702bc5c6622a7319d4eaab656d3934f6f2193d3824fbe790bf84b.zip",
+          "S3Key": "0d58dbfcc6337b6f02aa7e374a503ef65a4ab53a3ffee57dde581805b629c2e0.zip",
         },
         "Description": "[ConstructHub/MissingDocumentationWidget] Is a custom CloudWatch widget handler",
         "Environment": {
@@ -26517,7 +26517,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "368f5caa69ead30ac3efd5fa5b76573d2370207979e58a33d2d59d7e45c39120.zip",
+          "S3Key": "6dc2c91d8c8e3bc88ffe8925a64fd8268505d3e3d165e22f18a8486917ba7a16.zip",
         },
         "Description": "[ConstructHub/SQSDLQWidget] Is a custom CloudWatch widget handler",
         "Handler": "index.handler",
@@ -27851,7 +27851,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
+          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -28217,7 +28217,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "713e019f1505ec8b74e02da59325f8cc0dc1df8633a97946360eef71e4961a86.zip",
+          "S3Key": "f1b7885b673d9f17e1bf0939a3d3ba7a76f17efbbe7c9109b1f8baac1d283d91.zip",
         },
         "Description": "backend/deny-list/prune-handler.lambda.ts",
         "Environment": {
@@ -28413,7 +28413,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "74af847789269e2455d893cf01da26dde664a80ddcbee32c23be027a42addbe9.zip",
+          "S3Key": "1f67115da31f072e113b82a616fb1d9ff799f7594c86204bbcbd17de8e954114.zip",
         },
         "Description": "backend/deny-list/prune-queue-handler.lambda.ts",
         "Environment": {
@@ -28694,7 +28694,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "dfc30b6cad945b9a1a8cd74979e7f6046600193846b31fe5faa0e64c2b0d95d7.zip",
+          "S3Key": "029be6a866f5acc5e6f68e18d64475729ab929d61665d8ea58e95ec1cb29c329.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -28922,7 +28922,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "a8b68670eb455b177b2b85c9be2df672d28dc9470d41fba4c2b6af036086f1cc.zip",
+          "S3Key": "f64738290f58bcaa5b6f160f509f5debf06bcae60508f7252a3919f3572a7f78.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": {
@@ -29134,7 +29134,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
+          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -29348,7 +29348,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2d59ba9b7faee1e49a10d111c65af9374c92161329789225db8087a72b141f59.zip",
+          "S3Key": "bcc24517c2bca472ae9747fa039eb1b27336953867061a6dccf3b2ec0a7e5bde.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -30194,7 +30194,7 @@ Direct link to the state machine: /states/home#/statemachines/view/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b0cac3fe91cf84792dfa53eae18cf51c18867750fd9f296209aabfffa86654aa.zip",
+          "S3Key": "02fe7c310c92dd2243de516b7df3e2b7a3170dacc073c48f9fb0806d5d1d8ae7.zip",
         },
         "Description": "[ConstructHub/Inventory] A canary that periodically inspects the list of indexed packages",
         "Environment": {
@@ -30855,7 +30855,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
+          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -30959,7 +30959,7 @@ Direct link to function: /lambda/home#/functions/",
           },
         ],
         "SourceObjectKeys": [
-          "ba2c42b4614a88c72a0a91a75f389fb962da98b479ae5c6b4009169243cf15c0.zip",
+          "ee57c3c2c87eefd3a5a6cbcd848e46c0b37f428afd7bcd5a2fdc0f3e9e9da430.zip",
         ],
       },
       "Type": "Custom::CDKBucketDeployment",
@@ -31691,7 +31691,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "10f38587378f0b968c1c297a4c392fc45abe5bf3cb14c70decbcf5afc7feb5c5.zip",
+          "S3Key": "2794517da6217c62d8bb1ae55c2da57e1aa50688975f5839d0ce27ddf5988183.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -32005,7 +32005,7 @@ RUNBOOK: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2f86b7b78231bb11344f469948742a5194ce60097096cdcd28eacc2f2278cd28.zip",
+          "S3Key": "14dc62e437c50fbe51d6ea4c1d91cab10fb0dcbc50da9c0244d2a434a6d3589f.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -32759,7 +32759,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "7ebde867f806867923269ca6515d489220ccbb48ad5f36d9a753b5dd32957070.zip",
+          "S3Key": "704d493e53a189fedc3896a767512e90558a3022baf76547259001a0db9c4fa5.zip",
         },
         "Description": "[ConstructHub/Orchestration/NeedsCatalogUpdate] Determines whether a package version requires a catalog update",
         "Environment": {
@@ -32914,7 +32914,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "549800a3ebabbfe87937d3d5096cca1a3dec3c65180664a6e700adc7d9164e0e.zip",
+          "S3Key": "2699566d438b6ee00f3d6873a03cdff236a4fa6f8ee888926c52d120b616702c.zip",
         },
         "Description": "[ConstructHub/Redrive] Manually redrives all messages from the backend dead letter queue",
         "Environment": {
@@ -33706,7 +33706,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:57a005a0e45aff09fb971c1088738dfcb85d2eb7bb472f196ea15fc597005f8b",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:095c19b98bab5c46bc4ada3eda593e04b6aba138ec6ba55fa526455d9f30bfc7",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -36298,7 +36298,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "c86be1d83b833a8f5e51a98f93c6203097919e33548dc173647bb10f3d84b208.zip",
+          "S3Key": "1c2b4f991997e567cf8ba9bcfb5269b85e8a6bfb75c1ef547a544bd1f4c9dd33.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -36352,7 +36352,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "05d03095804959fdfe06e6474ab2b2126ebbef4dec3d7ffd9fabc83751062588.zip",
+          "S3Key": "2b526416a9b103a908e003be965218caaa62eae5c88e40a362adbe606942a8d5.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": {
@@ -37057,7 +37057,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "cdbbef158557618f513eea3e6bfe07e833446c71e395196842115e3cf8196160.zip",
+          "S3Key": "16de0048ae11d17617e1b32d95c735af13c5b7df555e8affe6753579be7c0a55.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -37369,7 +37369,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "cea83a576c76778c5499f70f0d318f4659cd8732622ef80a45306afd87561e2d.zip",
+          "S3Key": "feac1a4abd7146259f0edaa6b3a69887ceae3df0572194b0cc1cc84b14d587ef.zip",
         },
         "Description": "Manually re-stage a package version",
         "Environment": {
@@ -37578,7 +37578,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "877f8e3751a6a996c80c87df24ab3d5e377bb21b85bdb5cf3483bc912f40ca3e.zip",
+          "S3Key": "f67ec2116e51356d70db86909d2ce8273a58315c1aa36e358eeee77bd9a084d1.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -37785,7 +37785,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "3ceeaa8de639399c8fd450f5814155deb0aa17f94254552f0d7bb5687d13bee6.zip",
+          "S3Key": "cf03d7055d3a91856642c2c2a6850fe5d90964e4e8df7a8b4e782d1a1ede2456.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -38138,7 +38138,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
+          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -38150,7 +38150,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
+          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -38217,7 +38217,7 @@ function handler(event) {
           },
         ],
         "SourceObjectKeys": [
-          "409bb9e6490bb6580ea7992c2ebffc2ed63a4cae97fd1ed71d2b686ab5f6a371.zip",
+          "cfeb64a21b1bb5d2d1d9f1c76c63615906363b832b15503a5fcdca3ee49bbfa7.zip",
         ],
         "SystemMetadata": {
           "cache-control": "public, max-age=300, must-revalidate, s-maxage=60, proxy-revalidate",
@@ -39190,7 +39190,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "c6ed9052929702bc5c6622a7319d4eaab656d3934f6f2193d3824fbe790bf84b.zip",
+          "S3Key": "0d58dbfcc6337b6f02aa7e374a503ef65a4ab53a3ffee57dde581805b629c2e0.zip",
         },
         "Description": "[ConstructHub/MissingDocumentationWidget] Is a custom CloudWatch widget handler",
         "Environment": {
@@ -39616,7 +39616,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "368f5caa69ead30ac3efd5fa5b76573d2370207979e58a33d2d59d7e45c39120.zip",
+          "S3Key": "6dc2c91d8c8e3bc88ffe8925a64fd8268505d3e3d165e22f18a8486917ba7a16.zip",
         },
         "Description": "[ConstructHub/SQSDLQWidget] Is a custom CloudWatch widget handler",
         "Handler": "index.handler",
@@ -41090,7 +41090,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
+          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -41456,7 +41456,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "713e019f1505ec8b74e02da59325f8cc0dc1df8633a97946360eef71e4961a86.zip",
+          "S3Key": "f1b7885b673d9f17e1bf0939a3d3ba7a76f17efbbe7c9109b1f8baac1d283d91.zip",
         },
         "Description": "backend/deny-list/prune-handler.lambda.ts",
         "Environment": {
@@ -41652,7 +41652,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "74af847789269e2455d893cf01da26dde664a80ddcbee32c23be027a42addbe9.zip",
+          "S3Key": "1f67115da31f072e113b82a616fb1d9ff799f7594c86204bbcbd17de8e954114.zip",
         },
         "Description": "backend/deny-list/prune-queue-handler.lambda.ts",
         "Environment": {
@@ -41933,7 +41933,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "dfc30b6cad945b9a1a8cd74979e7f6046600193846b31fe5faa0e64c2b0d95d7.zip",
+          "S3Key": "029be6a866f5acc5e6f68e18d64475729ab929d61665d8ea58e95ec1cb29c329.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -42148,7 +42148,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "a8b68670eb455b177b2b85c9be2df672d28dc9470d41fba4c2b6af036086f1cc.zip",
+          "S3Key": "f64738290f58bcaa5b6f160f509f5debf06bcae60508f7252a3919f3572a7f78.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": {
@@ -42360,7 +42360,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
+          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -42574,7 +42574,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2d59ba9b7faee1e49a10d111c65af9374c92161329789225db8087a72b141f59.zip",
+          "S3Key": "bcc24517c2bca472ae9747fa039eb1b27336953867061a6dccf3b2ec0a7e5bde.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -43420,7 +43420,7 @@ Direct link to the state machine: /states/home#/statemachines/view/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b0cac3fe91cf84792dfa53eae18cf51c18867750fd9f296209aabfffa86654aa.zip",
+          "S3Key": "02fe7c310c92dd2243de516b7df3e2b7a3170dacc073c48f9fb0806d5d1d8ae7.zip",
         },
         "Description": "[ConstructHub/Inventory] A canary that periodically inspects the list of indexed packages",
         "Environment": {
@@ -44081,7 +44081,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
+          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -44185,7 +44185,7 @@ Direct link to function: /lambda/home#/functions/",
           },
         ],
         "SourceObjectKeys": [
-          "ba2c42b4614a88c72a0a91a75f389fb962da98b479ae5c6b4009169243cf15c0.zip",
+          "ee57c3c2c87eefd3a5a6cbcd848e46c0b37f428afd7bcd5a2fdc0f3e9e9da430.zip",
         ],
       },
       "Type": "Custom::CDKBucketDeployment",
@@ -44939,7 +44939,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "10f38587378f0b968c1c297a4c392fc45abe5bf3cb14c70decbcf5afc7feb5c5.zip",
+          "S3Key": "2794517da6217c62d8bb1ae55c2da57e1aa50688975f5839d0ce27ddf5988183.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -45253,7 +45253,7 @@ RUNBOOK: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2f86b7b78231bb11344f469948742a5194ce60097096cdcd28eacc2f2278cd28.zip",
+          "S3Key": "14dc62e437c50fbe51d6ea4c1d91cab10fb0dcbc50da9c0244d2a434a6d3589f.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -46007,7 +46007,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "7ebde867f806867923269ca6515d489220ccbb48ad5f36d9a753b5dd32957070.zip",
+          "S3Key": "704d493e53a189fedc3896a767512e90558a3022baf76547259001a0db9c4fa5.zip",
         },
         "Description": "[ConstructHub/Orchestration/NeedsCatalogUpdate] Determines whether a package version requires a catalog update",
         "Environment": {
@@ -46162,7 +46162,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "549800a3ebabbfe87937d3d5096cca1a3dec3c65180664a6e700adc7d9164e0e.zip",
+          "S3Key": "2699566d438b6ee00f3d6873a03cdff236a4fa6f8ee888926c52d120b616702c.zip",
         },
         "Description": "[ConstructHub/Redrive] Manually redrives all messages from the backend dead letter queue",
         "Environment": {
@@ -46954,7 +46954,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:57a005a0e45aff09fb971c1088738dfcb85d2eb7bb472f196ea15fc597005f8b",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:095c19b98bab5c46bc4ada3eda593e04b6aba138ec6ba55fa526455d9f30bfc7",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -49546,7 +49546,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "c86be1d83b833a8f5e51a98f93c6203097919e33548dc173647bb10f3d84b208.zip",
+          "S3Key": "1c2b4f991997e567cf8ba9bcfb5269b85e8a6bfb75c1ef547a544bd1f4c9dd33.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -49600,7 +49600,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "05d03095804959fdfe06e6474ab2b2126ebbef4dec3d7ffd9fabc83751062588.zip",
+          "S3Key": "2b526416a9b103a908e003be965218caaa62eae5c88e40a362adbe606942a8d5.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": {
@@ -50292,7 +50292,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "cdbbef158557618f513eea3e6bfe07e833446c71e395196842115e3cf8196160.zip",
+          "S3Key": "16de0048ae11d17617e1b32d95c735af13c5b7df555e8affe6753579be7c0a55.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -50604,7 +50604,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "cea83a576c76778c5499f70f0d318f4659cd8732622ef80a45306afd87561e2d.zip",
+          "S3Key": "feac1a4abd7146259f0edaa6b3a69887ceae3df0572194b0cc1cc84b14d587ef.zip",
         },
         "Description": "Manually re-stage a package version",
         "Environment": {
@@ -50813,7 +50813,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "877f8e3751a6a996c80c87df24ab3d5e377bb21b85bdb5cf3483bc912f40ca3e.zip",
+          "S3Key": "f67ec2116e51356d70db86909d2ce8273a58315c1aa36e358eeee77bd9a084d1.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -51020,7 +51020,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "3ceeaa8de639399c8fd450f5814155deb0aa17f94254552f0d7bb5687d13bee6.zip",
+          "S3Key": "cf03d7055d3a91856642c2c2a6850fe5d90964e4e8df7a8b4e782d1a1ede2456.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -51425,7 +51425,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
+          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -51437,7 +51437,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
+          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -51504,7 +51504,7 @@ function handler(event) {
           },
         ],
         "SourceObjectKeys": [
-          "409bb9e6490bb6580ea7992c2ebffc2ed63a4cae97fd1ed71d2b686ab5f6a371.zip",
+          "cfeb64a21b1bb5d2d1d9f1c76c63615906363b832b15503a5fcdca3ee49bbfa7.zip",
         ],
         "SystemMetadata": {
           "cache-control": "public, max-age=300, must-revalidate, s-maxage=60, proxy-revalidate",
@@ -52675,7 +52675,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "c6ed9052929702bc5c6622a7319d4eaab656d3934f6f2193d3824fbe790bf84b.zip",
+          "S3Key": "0d58dbfcc6337b6f02aa7e374a503ef65a4ab53a3ffee57dde581805b629c2e0.zip",
         },
         "Description": "[ConstructHub/MissingDocumentationWidget] Is a custom CloudWatch widget handler",
         "Environment": {
@@ -53101,7 +53101,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "368f5caa69ead30ac3efd5fa5b76573d2370207979e58a33d2d59d7e45c39120.zip",
+          "S3Key": "6dc2c91d8c8e3bc88ffe8925a64fd8268505d3e3d165e22f18a8486917ba7a16.zip",
         },
         "Description": "[ConstructHub/SQSDLQWidget] Is a custom CloudWatch widget handler",
         "Handler": "index.handler",
@@ -54512,7 +54512,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
+          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -54878,7 +54878,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "713e019f1505ec8b74e02da59325f8cc0dc1df8633a97946360eef71e4961a86.zip",
+          "S3Key": "f1b7885b673d9f17e1bf0939a3d3ba7a76f17efbbe7c9109b1f8baac1d283d91.zip",
         },
         "Description": "backend/deny-list/prune-handler.lambda.ts",
         "Environment": {
@@ -55074,7 +55074,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "74af847789269e2455d893cf01da26dde664a80ddcbee32c23be027a42addbe9.zip",
+          "S3Key": "1f67115da31f072e113b82a616fb1d9ff799f7594c86204bbcbd17de8e954114.zip",
         },
         "Description": "backend/deny-list/prune-queue-handler.lambda.ts",
         "Environment": {
@@ -55355,7 +55355,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "dfc30b6cad945b9a1a8cd74979e7f6046600193846b31fe5faa0e64c2b0d95d7.zip",
+          "S3Key": "029be6a866f5acc5e6f68e18d64475729ab929d61665d8ea58e95ec1cb29c329.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -55583,7 +55583,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "a8b68670eb455b177b2b85c9be2df672d28dc9470d41fba4c2b6af036086f1cc.zip",
+          "S3Key": "f64738290f58bcaa5b6f160f509f5debf06bcae60508f7252a3919f3572a7f78.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": {
@@ -55795,7 +55795,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
+          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -56009,7 +56009,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2d59ba9b7faee1e49a10d111c65af9374c92161329789225db8087a72b141f59.zip",
+          "S3Key": "bcc24517c2bca472ae9747fa039eb1b27336953867061a6dccf3b2ec0a7e5bde.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -56981,7 +56981,7 @@ Direct link to the state machine: /states/home#/statemachines/view/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b0cac3fe91cf84792dfa53eae18cf51c18867750fd9f296209aabfffa86654aa.zip",
+          "S3Key": "02fe7c310c92dd2243de516b7df3e2b7a3170dacc073c48f9fb0806d5d1d8ae7.zip",
         },
         "Description": "[ConstructHub/Inventory] A canary that periodically inspects the list of indexed packages",
         "Environment": {
@@ -57642,7 +57642,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
+          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -57746,7 +57746,7 @@ Direct link to function: /lambda/home#/functions/",
           },
         ],
         "SourceObjectKeys": [
-          "ba2c42b4614a88c72a0a91a75f389fb962da98b479ae5c6b4009169243cf15c0.zip",
+          "ee57c3c2c87eefd3a5a6cbcd848e46c0b37f428afd7bcd5a2fdc0f3e9e9da430.zip",
         ],
       },
       "Type": "Custom::CDKBucketDeployment",
@@ -58507,7 +58507,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "10f38587378f0b968c1c297a4c392fc45abe5bf3cb14c70decbcf5afc7feb5c5.zip",
+          "S3Key": "2794517da6217c62d8bb1ae55c2da57e1aa50688975f5839d0ce27ddf5988183.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -58821,7 +58821,7 @@ RUNBOOK: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2f86b7b78231bb11344f469948742a5194ce60097096cdcd28eacc2f2278cd28.zip",
+          "S3Key": "14dc62e437c50fbe51d6ea4c1d91cab10fb0dcbc50da9c0244d2a434a6d3589f.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -59168,7 +59168,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "7ebde867f806867923269ca6515d489220ccbb48ad5f36d9a753b5dd32957070.zip",
+          "S3Key": "704d493e53a189fedc3896a767512e90558a3022baf76547259001a0db9c4fa5.zip",
         },
         "Description": "[ConstructHub/Orchestration/NeedsCatalogUpdate] Determines whether a package version requires a catalog update",
         "Environment": {
@@ -59323,7 +59323,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "549800a3ebabbfe87937d3d5096cca1a3dec3c65180664a6e700adc7d9164e0e.zip",
+          "S3Key": "2699566d438b6ee00f3d6873a03cdff236a4fa6f8ee888926c52d120b616702c.zip",
         },
         "Description": "[ConstructHub/Redrive] Manually redrives all messages from the backend dead letter queue",
         "Environment": {
@@ -60121,7 +60121,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:57a005a0e45aff09fb971c1088738dfcb85d2eb7bb472f196ea15fc597005f8b",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:095c19b98bab5c46bc4ada3eda593e04b6aba138ec6ba55fa526455d9f30bfc7",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -62775,7 +62775,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "c86be1d83b833a8f5e51a98f93c6203097919e33548dc173647bb10f3d84b208.zip",
+          "S3Key": "1c2b4f991997e567cf8ba9bcfb5269b85e8a6bfb75c1ef547a544bd1f4c9dd33.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -62829,7 +62829,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "05d03095804959fdfe06e6474ab2b2126ebbef4dec3d7ffd9fabc83751062588.zip",
+          "S3Key": "2b526416a9b103a908e003be965218caaa62eae5c88e40a362adbe606942a8d5.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": {
@@ -63534,7 +63534,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "cdbbef158557618f513eea3e6bfe07e833446c71e395196842115e3cf8196160.zip",
+          "S3Key": "16de0048ae11d17617e1b32d95c735af13c5b7df555e8affe6753579be7c0a55.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -63846,7 +63846,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "cea83a576c76778c5499f70f0d318f4659cd8732622ef80a45306afd87561e2d.zip",
+          "S3Key": "feac1a4abd7146259f0edaa6b3a69887ceae3df0572194b0cc1cc84b14d587ef.zip",
         },
         "Description": "Manually re-stage a package version",
         "Environment": {
@@ -64055,7 +64055,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "877f8e3751a6a996c80c87df24ab3d5e377bb21b85bdb5cf3483bc912f40ca3e.zip",
+          "S3Key": "f67ec2116e51356d70db86909d2ce8273a58315c1aa36e358eeee77bd9a084d1.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -67122,7 +67122,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "3ceeaa8de639399c8fd450f5814155deb0aa17f94254552f0d7bb5687d13bee6.zip",
+          "S3Key": "cf03d7055d3a91856642c2c2a6850fe5d90964e4e8df7a8b4e782d1a1ede2456.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -67475,7 +67475,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
+          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -67487,7 +67487,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
+          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -67554,7 +67554,7 @@ function handler(event) {
           },
         ],
         "SourceObjectKeys": [
-          "409bb9e6490bb6580ea7992c2ebffc2ed63a4cae97fd1ed71d2b686ab5f6a371.zip",
+          "cfeb64a21b1bb5d2d1d9f1c76c63615906363b832b15503a5fcdca3ee49bbfa7.zip",
         ],
         "SystemMetadata": {
           "cache-control": "public, max-age=300, must-revalidate, s-maxage=60, proxy-revalidate",
@@ -69084,7 +69084,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "c6ed9052929702bc5c6622a7319d4eaab656d3934f6f2193d3824fbe790bf84b.zip",
+          "S3Key": "0d58dbfcc6337b6f02aa7e374a503ef65a4ab53a3ffee57dde581805b629c2e0.zip",
         },
         "Description": "[ConstructHub/MissingDocumentationWidget] Is a custom CloudWatch widget handler",
         "Environment": {
@@ -69510,7 +69510,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "368f5caa69ead30ac3efd5fa5b76573d2370207979e58a33d2d59d7e45c39120.zip",
+          "S3Key": "6dc2c91d8c8e3bc88ffe8925a64fd8268505d3e3d165e22f18a8486917ba7a16.zip",
         },
         "Description": "[ConstructHub/SQSDLQWidget] Is a custom CloudWatch widget handler",
         "Handler": "index.handler",

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -1681,7 +1681,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
+          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -2047,7 +2047,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "713e019f1505ec8b74e02da59325f8cc0dc1df8633a97946360eef71e4961a86.zip",
+          "S3Key": "f1b7885b673d9f17e1bf0939a3d3ba7a76f17efbbe7c9109b1f8baac1d283d91.zip",
         },
         "Description": "backend/deny-list/prune-handler.lambda.ts",
         "Environment": {
@@ -2243,7 +2243,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "74af847789269e2455d893cf01da26dde664a80ddcbee32c23be027a42addbe9.zip",
+          "S3Key": "1f67115da31f072e113b82a616fb1d9ff799f7594c86204bbcbd17de8e954114.zip",
         },
         "Description": "backend/deny-list/prune-queue-handler.lambda.ts",
         "Environment": {
@@ -2521,7 +2521,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "dfc30b6cad945b9a1a8cd74979e7f6046600193846b31fe5faa0e64c2b0d95d7.zip",
+          "S3Key": "029be6a866f5acc5e6f68e18d64475729ab929d61665d8ea58e95ec1cb29c329.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -2751,7 +2751,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "a8b68670eb455b177b2b85c9be2df672d28dc9470d41fba4c2b6af036086f1cc.zip",
+          "S3Key": "f64738290f58bcaa5b6f160f509f5debf06bcae60508f7252a3919f3572a7f78.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": {
@@ -2984,7 +2984,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
+          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -3195,7 +3195,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2d59ba9b7faee1e49a10d111c65af9374c92161329789225db8087a72b141f59.zip",
+          "S3Key": "bcc24517c2bca472ae9747fa039eb1b27336953867061a6dccf3b2ec0a7e5bde.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -4134,7 +4134,7 @@ Direct link to the state machine: /states/home#/statemachines/view/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b0cac3fe91cf84792dfa53eae18cf51c18867750fd9f296209aabfffa86654aa.zip",
+          "S3Key": "02fe7c310c92dd2243de516b7df3e2b7a3170dacc073c48f9fb0806d5d1d8ae7.zip",
         },
         "Description": "[ConstructHub/Inventory] A canary that periodically inspects the list of indexed packages",
         "Environment": {
@@ -4818,7 +4818,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
+          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -4922,7 +4922,7 @@ Direct link to function: /lambda/home#/functions/",
           },
         ],
         "SourceObjectKeys": [
-          "ba2c42b4614a88c72a0a91a75f389fb962da98b479ae5c6b4009169243cf15c0.zip",
+          "ee57c3c2c87eefd3a5a6cbcd848e46c0b37f428afd7bcd5a2fdc0f3e9e9da430.zip",
         ],
       },
       "Type": "Custom::CDKBucketDeployment",
@@ -5674,7 +5674,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "10f38587378f0b968c1c297a4c392fc45abe5bf3cb14c70decbcf5afc7feb5c5.zip",
+          "S3Key": "2794517da6217c62d8bb1ae55c2da57e1aa50688975f5839d0ce27ddf5988183.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -5985,7 +5985,7 @@ RUNBOOK: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2f86b7b78231bb11344f469948742a5194ce60097096cdcd28eacc2f2278cd28.zip",
+          "S3Key": "14dc62e437c50fbe51d6ea4c1d91cab10fb0dcbc50da9c0244d2a434a6d3589f.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -6345,7 +6345,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "7ebde867f806867923269ca6515d489220ccbb48ad5f36d9a753b5dd32957070.zip",
+          "S3Key": "704d493e53a189fedc3896a767512e90558a3022baf76547259001a0db9c4fa5.zip",
         },
         "Description": "[ConstructHub/Orchestration/NeedsCatalogUpdate] Determines whether a package version requires a catalog update",
         "Environment": {
@@ -6497,7 +6497,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "549800a3ebabbfe87937d3d5096cca1a3dec3c65180664a6e700adc7d9164e0e.zip",
+          "S3Key": "2699566d438b6ee00f3d6873a03cdff236a4fa6f8ee888926c52d120b616702c.zip",
         },
         "Description": "[ConstructHub/Redrive] Manually redrives all messages from the backend dead letter queue",
         "Environment": {
@@ -7346,7 +7346,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:57a005a0e45aff09fb971c1088738dfcb85d2eb7bb472f196ea15fc597005f8b",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:095c19b98bab5c46bc4ada3eda593e04b6aba138ec6ba55fa526455d9f30bfc7",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -9949,7 +9949,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "462dc2212e31f4895deb72abc98c1e8828ade0a0e619f931788e45f8001068af.zip",
+          "S3Key": "ccdeae615059cc300aa03ca059e86a0017b211b6cf19e3ac9d0a62fab168cf28.zip",
         },
         "Description": "ReleaseNotes generator",
         "Environment": {
@@ -10100,7 +10100,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "ebf550a623e56e1e7708874608e700384a91ae851cc300e439f11883a9d59f37.zip",
+          "S3Key": "18edf070daf97137cc276e99390c935375660f09ba13809dd5d4b864c07c0117.zip",
         },
         "Description": "ReleaseNotes get message from the worker queue",
         "Environment": {
@@ -10371,7 +10371,7 @@ RunBook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d0a2c3d05077cc91d213fbe67e615cf8b4d342c11585ca8accf575a5da6911b1.zip",
+          "S3Key": "cac631d792aa08f415c3c43f0b35cb62af8e8e0fc249fa0ad292d1057532fdd4.zip",
         },
         "Description": "backend/release-notes/release-notes-trigger.lambda.ts",
         "Environment": {
@@ -10954,7 +10954,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "c86be1d83b833a8f5e51a98f93c6203097919e33548dc173647bb10f3d84b208.zip",
+          "S3Key": "1c2b4f991997e567cf8ba9bcfb5269b85e8a6bfb75c1ef547a544bd1f4c9dd33.zip",
         },
         "Description": "[dev/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -11008,7 +11008,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "05d03095804959fdfe06e6474ab2b2126ebbef4dec3d7ffd9fabc83751062588.zip",
+          "S3Key": "2b526416a9b103a908e003be965218caaa62eae5c88e40a362adbe606942a8d5.zip",
         },
         "Description": "[dev/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": {
@@ -11707,7 +11707,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "cdbbef158557618f513eea3e6bfe07e833446c71e395196842115e3cf8196160.zip",
+          "S3Key": "16de0048ae11d17617e1b32d95c735af13c5b7df555e8affe6753579be7c0a55.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -12019,7 +12019,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "cea83a576c76778c5499f70f0d318f4659cd8732622ef80a45306afd87561e2d.zip",
+          "S3Key": "feac1a4abd7146259f0edaa6b3a69887ceae3df0572194b0cc1cc84b14d587ef.zip",
         },
         "Description": "Manually re-stage a package version",
         "Environment": {
@@ -12228,7 +12228,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "877f8e3751a6a996c80c87df24ab3d5e377bb21b85bdb5cf3483bc912f40ca3e.zip",
+          "S3Key": "f67ec2116e51356d70db86909d2ce8273a58315c1aa36e358eeee77bd9a084d1.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -15426,7 +15426,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "3ceeaa8de639399c8fd450f5814155deb0aa17f94254552f0d7bb5687d13bee6.zip",
+          "S3Key": "cf03d7055d3a91856642c2c2a6850fe5d90964e4e8df7a8b4e782d1a1ede2456.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -15779,7 +15779,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
+          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -15791,7 +15791,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
+          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -15858,7 +15858,7 @@ function handler(event) {
           },
         ],
         "SourceObjectKeys": [
-          "409bb9e6490bb6580ea7992c2ebffc2ed63a4cae97fd1ed71d2b686ab5f6a371.zip",
+          "cfeb64a21b1bb5d2d1d9f1c76c63615906363b832b15503a5fcdca3ee49bbfa7.zip",
         ],
         "SystemMetadata": {
           "cache-control": "public, max-age=300, must-revalidate, s-maxage=60, proxy-revalidate",
@@ -16831,7 +16831,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "c6ed9052929702bc5c6622a7319d4eaab656d3934f6f2193d3824fbe790bf84b.zip",
+          "S3Key": "0d58dbfcc6337b6f02aa7e374a503ef65a4ab53a3ffee57dde581805b629c2e0.zip",
         },
         "Description": "[ConstructHub/MissingDocumentationWidget] Is a custom CloudWatch widget handler",
         "Environment": {
@@ -17257,7 +17257,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "368f5caa69ead30ac3efd5fa5b76573d2370207979e58a33d2d59d7e45c39120.zip",
+          "S3Key": "6dc2c91d8c8e3bc88ffe8925a64fd8268505d3e3d165e22f18a8486917ba7a16.zip",
         },
         "Description": "[ConstructHub/SQSDLQWidget] Is a custom CloudWatch widget handler",
         "Handler": "index.handler",

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -1681,7 +1681,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
+          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -2047,7 +2047,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "f1b7885b673d9f17e1bf0939a3d3ba7a76f17efbbe7c9109b1f8baac1d283d91.zip",
+          "S3Key": "713e019f1505ec8b74e02da59325f8cc0dc1df8633a97946360eef71e4961a86.zip",
         },
         "Description": "backend/deny-list/prune-handler.lambda.ts",
         "Environment": {
@@ -2243,7 +2243,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1f67115da31f072e113b82a616fb1d9ff799f7594c86204bbcbd17de8e954114.zip",
+          "S3Key": "74af847789269e2455d893cf01da26dde664a80ddcbee32c23be027a42addbe9.zip",
         },
         "Description": "backend/deny-list/prune-queue-handler.lambda.ts",
         "Environment": {
@@ -2521,7 +2521,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "029be6a866f5acc5e6f68e18d64475729ab929d61665d8ea58e95ec1cb29c329.zip",
+          "S3Key": "dfc30b6cad945b9a1a8cd74979e7f6046600193846b31fe5faa0e64c2b0d95d7.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -2751,7 +2751,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "f64738290f58bcaa5b6f160f509f5debf06bcae60508f7252a3919f3572a7f78.zip",
+          "S3Key": "a8b68670eb455b177b2b85c9be2df672d28dc9470d41fba4c2b6af036086f1cc.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": {
@@ -2984,7 +2984,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
+          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -3195,7 +3195,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "bcc24517c2bca472ae9747fa039eb1b27336953867061a6dccf3b2ec0a7e5bde.zip",
+          "S3Key": "2d59ba9b7faee1e49a10d111c65af9374c92161329789225db8087a72b141f59.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -4134,7 +4134,7 @@ Direct link to the state machine: /states/home#/statemachines/view/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "02fe7c310c92dd2243de516b7df3e2b7a3170dacc073c48f9fb0806d5d1d8ae7.zip",
+          "S3Key": "b0cac3fe91cf84792dfa53eae18cf51c18867750fd9f296209aabfffa86654aa.zip",
         },
         "Description": "[ConstructHub/Inventory] A canary that periodically inspects the list of indexed packages",
         "Environment": {
@@ -4818,7 +4818,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
+          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -4922,7 +4922,7 @@ Direct link to function: /lambda/home#/functions/",
           },
         ],
         "SourceObjectKeys": [
-          "ee57c3c2c87eefd3a5a6cbcd848e46c0b37f428afd7bcd5a2fdc0f3e9e9da430.zip",
+          "ba2c42b4614a88c72a0a91a75f389fb962da98b479ae5c6b4009169243cf15c0.zip",
         ],
       },
       "Type": "Custom::CDKBucketDeployment",
@@ -5674,7 +5674,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2794517da6217c62d8bb1ae55c2da57e1aa50688975f5839d0ce27ddf5988183.zip",
+          "S3Key": "10f38587378f0b968c1c297a4c392fc45abe5bf3cb14c70decbcf5afc7feb5c5.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -5985,7 +5985,7 @@ RUNBOOK: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "14dc62e437c50fbe51d6ea4c1d91cab10fb0dcbc50da9c0244d2a434a6d3589f.zip",
+          "S3Key": "2f86b7b78231bb11344f469948742a5194ce60097096cdcd28eacc2f2278cd28.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -6345,7 +6345,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "704d493e53a189fedc3896a767512e90558a3022baf76547259001a0db9c4fa5.zip",
+          "S3Key": "7ebde867f806867923269ca6515d489220ccbb48ad5f36d9a753b5dd32957070.zip",
         },
         "Description": "[ConstructHub/Orchestration/NeedsCatalogUpdate] Determines whether a package version requires a catalog update",
         "Environment": {
@@ -6497,7 +6497,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2699566d438b6ee00f3d6873a03cdff236a4fa6f8ee888926c52d120b616702c.zip",
+          "S3Key": "549800a3ebabbfe87937d3d5096cca1a3dec3c65180664a6e700adc7d9164e0e.zip",
         },
         "Description": "[ConstructHub/Redrive] Manually redrives all messages from the backend dead letter queue",
         "Environment": {
@@ -7346,7 +7346,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:095c19b98bab5c46bc4ada3eda593e04b6aba138ec6ba55fa526455d9f30bfc7",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:57a005a0e45aff09fb971c1088738dfcb85d2eb7bb472f196ea15fc597005f8b",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -9949,7 +9949,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "ccdeae615059cc300aa03ca059e86a0017b211b6cf19e3ac9d0a62fab168cf28.zip",
+          "S3Key": "462dc2212e31f4895deb72abc98c1e8828ade0a0e619f931788e45f8001068af.zip",
         },
         "Description": "ReleaseNotes generator",
         "Environment": {
@@ -10100,7 +10100,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "18edf070daf97137cc276e99390c935375660f09ba13809dd5d4b864c07c0117.zip",
+          "S3Key": "ebf550a623e56e1e7708874608e700384a91ae851cc300e439f11883a9d59f37.zip",
         },
         "Description": "ReleaseNotes get message from the worker queue",
         "Environment": {
@@ -10371,7 +10371,7 @@ RunBook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "cac631d792aa08f415c3c43f0b35cb62af8e8e0fc249fa0ad292d1057532fdd4.zip",
+          "S3Key": "d0a2c3d05077cc91d213fbe67e615cf8b4d342c11585ca8accf575a5da6911b1.zip",
         },
         "Description": "backend/release-notes/release-notes-trigger.lambda.ts",
         "Environment": {
@@ -10954,7 +10954,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "1c2b4f991997e567cf8ba9bcfb5269b85e8a6bfb75c1ef547a544bd1f4c9dd33.zip",
+          "S3Key": "7fa31ee1e3852ab3d4ce6d91769f7718a0018845a99d05660484b4a959f36a52.zip",
         },
         "Description": "[dev/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -11008,7 +11008,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2b526416a9b103a908e003be965218caaa62eae5c88e40a362adbe606942a8d5.zip",
+          "S3Key": "05d03095804959fdfe06e6474ab2b2126ebbef4dec3d7ffd9fabc83751062588.zip",
         },
         "Description": "[dev/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": {
@@ -11707,7 +11707,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "16de0048ae11d17617e1b32d95c735af13c5b7df555e8affe6753579be7c0a55.zip",
+          "S3Key": "cdbbef158557618f513eea3e6bfe07e833446c71e395196842115e3cf8196160.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -12019,7 +12019,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "feac1a4abd7146259f0edaa6b3a69887ceae3df0572194b0cc1cc84b14d587ef.zip",
+          "S3Key": "cea83a576c76778c5499f70f0d318f4659cd8732622ef80a45306afd87561e2d.zip",
         },
         "Description": "Manually re-stage a package version",
         "Environment": {
@@ -12228,7 +12228,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "f67ec2116e51356d70db86909d2ce8273a58315c1aa36e358eeee77bd9a084d1.zip",
+          "S3Key": "877f8e3751a6a996c80c87df24ab3d5e377bb21b85bdb5cf3483bc912f40ca3e.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -15426,7 +15426,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "cf03d7055d3a91856642c2c2a6850fe5d90964e4e8df7a8b4e782d1a1ede2456.zip",
+          "S3Key": "3ceeaa8de639399c8fd450f5814155deb0aa17f94254552f0d7bb5687d13bee6.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -15779,7 +15779,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
+          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -15791,7 +15791,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "566e8d9f8eaa36ffa4f62af3b2cb2abfe3a5e01497f47d6232038964297e694d.zip",
+          "S3Key": "8341cb239e4e1842be4d85a62c1b0a519b37f6f3b0e6acc9758db8a98f518fa3.zip",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -15858,7 +15858,7 @@ function handler(event) {
           },
         ],
         "SourceObjectKeys": [
-          "cfeb64a21b1bb5d2d1d9f1c76c63615906363b832b15503a5fcdca3ee49bbfa7.zip",
+          "409bb9e6490bb6580ea7992c2ebffc2ed63a4cae97fd1ed71d2b686ab5f6a371.zip",
         ],
         "SystemMetadata": {
           "cache-control": "public, max-age=300, must-revalidate, s-maxage=60, proxy-revalidate",
@@ -16831,7 +16831,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "0d58dbfcc6337b6f02aa7e374a503ef65a4ab53a3ffee57dde581805b629c2e0.zip",
+          "S3Key": "c6ed9052929702bc5c6622a7319d4eaab656d3934f6f2193d3824fbe790bf84b.zip",
         },
         "Description": "[ConstructHub/MissingDocumentationWidget] Is a custom CloudWatch widget handler",
         "Environment": {
@@ -17257,7 +17257,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "6dc2c91d8c8e3bc88ffe8925a64fd8268505d3e3d165e22f18a8486917ba7a16.zip",
+          "S3Key": "368f5caa69ead30ac3efd5fa5b76573d2370207979e58a33d2d59d7e45c39120.zip",
         },
         "Description": "[ConstructHub/SQSDLQWidget] Is a custom CloudWatch widget handler",
         "Handler": "index.handler",


### PR DESCRIPTION
the npm follower now makes a GET request for every package it finds. occasionally, that results in a 404 error. we shouldn't fail the entire lambda on these, and instead log and move on.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*