### PR TITLE
fix: resetting the npm follower cache deletes all known versions

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -9672,7 +9672,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "9550ece866309fd65100bd0efcd7c5b8ce998463d46ffa3df2bd01579957ec62.zip",
+          "S3Key": "d86bd57dfa95987c5dfeedfa7eb14bf56371f286c2c3b0c3ad7ea0514b5b806f.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -23199,7 +23199,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "9550ece866309fd65100bd0efcd7c5b8ce998463d46ffa3df2bd01579957ec62.zip",
+          "S3Key": "d86bd57dfa95987c5dfeedfa7eb14bf56371f286c2c3b0c3ad7ea0514b5b806f.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -36298,7 +36298,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "9550ece866309fd65100bd0efcd7c5b8ce998463d46ffa3df2bd01579957ec62.zip",
+          "S3Key": "d86bd57dfa95987c5dfeedfa7eb14bf56371f286c2c3b0c3ad7ea0514b5b806f.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -49546,7 +49546,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "9550ece866309fd65100bd0efcd7c5b8ce998463d46ffa3df2bd01579957ec62.zip",
+          "S3Key": "d86bd57dfa95987c5dfeedfa7eb14bf56371f286c2c3b0c3ad7ea0514b5b806f.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -62775,7 +62775,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "9550ece866309fd65100bd0efcd7c5b8ce998463d46ffa3df2bd01579957ec62.zip",
+          "S3Key": "d86bd57dfa95987c5dfeedfa7eb14bf56371f286c2c3b0c3ad7ea0514b5b806f.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -10954,7 +10954,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "9550ece866309fd65100bd0efcd7c5b8ce998463d46ffa3df2bd01579957ec62.zip",
+          "S3Key": "d86bd57dfa95987c5dfeedfa7eb14bf56371f286c2c3b0c3ad7ea0514b5b806f.zip",
         },
         "Description": "[dev/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {

--- a/src/package-sources/npmjs/npm-js-follower.lambda.ts
+++ b/src/package-sources/npmjs/npm-js-follower.lambda.ts
@@ -277,7 +277,7 @@ async function loadLastTransactionMarker(
       console.warn(
         `Current DB update_seq (${dbUpdateSeq}) is lower than marker (CouchDB instance was likely replaced), resetting to 0!`
       );
-      return { marker: '0', knownVersions: data.knownVersion };
+      return { marker: '0', knownVersions: data.knownVersions };
     }
 
     return data;


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*