### PR TITLE
feat: add lifecycle rule to npm source bucket

### DIFF
--- a/src/package-sources/npmjs.ts
+++ b/src/package-sources/npmjs.ts
@@ -127,6 +127,9 @@ export class NpmJs implements IPackageSource {
             prefix: S3KeyPrefix.STAGED_KEY_PREFIX,
             expiration: Duration.days(30),
           },
+          {
+            noncurrentVersionExpiration: Duration.days(30),
+          },
         ],
       });
     bucket.grantRead(ingestion);


### PR DESCRIPTION
we recently versioned this bucket to store backups of the npm replica state. this is a 16MB file that gets updated every 5 minutes. therefore we should add a lifecycle rule on the non-current versions and only save the state from the past 30 days. that should be enough to grab a backup if needed.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*