### PR TITLE
fix: follower processes only 100 changes every 5min

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -9691,7 +9691,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d94afe985351e4da0deac7c248b803e2eb67786a9f8c5d83dcf69c50c1879e95.zip",
+          "S3Key": "1d68ada74ab3e8fea53cda618d787ef0d607b5d5f11586f14f3db65e5087887e.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -23281,7 +23281,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d94afe985351e4da0deac7c248b803e2eb67786a9f8c5d83dcf69c50c1879e95.zip",
+          "S3Key": "1d68ada74ab3e8fea53cda618d787ef0d607b5d5f11586f14f3db65e5087887e.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -36443,7 +36443,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d94afe985351e4da0deac7c248b803e2eb67786a9f8c5d83dcf69c50c1879e95.zip",
+          "S3Key": "1d68ada74ab3e8fea53cda618d787ef0d607b5d5f11586f14f3db65e5087887e.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -49754,7 +49754,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d94afe985351e4da0deac7c248b803e2eb67786a9f8c5d83dcf69c50c1879e95.zip",
+          "S3Key": "1d68ada74ab3e8fea53cda618d787ef0d607b5d5f11586f14f3db65e5087887e.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -63046,7 +63046,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d94afe985351e4da0deac7c248b803e2eb67786a9f8c5d83dcf69c50c1879e95.zip",
+          "S3Key": "1d68ada74ab3e8fea53cda618d787ef0d607b5d5f11586f14f3db65e5087887e.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -10973,7 +10973,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d94afe985351e4da0deac7c248b803e2eb67786a9f8c5d83dcf69c50c1879e95.zip",
+          "S3Key": "1d68ada74ab3e8fea53cda618d787ef0d607b5d5f11586f14f3db65e5087887e.zip",
         },
         "Description": "[dev/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {

--- a/src/package-sources/npmjs/couch-changes.lambda-shared.ts
+++ b/src/package-sources/npmjs/couch-changes.lambda-shared.ts
@@ -42,7 +42,7 @@ export class CouchChanges extends EventEmitter {
   }
 
   /**
-   * @returns summary informations about the database.
+   * @returns summary information about the database.
    */
   public async info(): Promise<DatabaseInfos> {
     return (await this.https('get', this.baseUrl)) as any;
@@ -73,7 +73,8 @@ export class CouchChanges extends EventEmitter {
 
     return {
       last_seq,
-      results,
+      actionableResults: results,
+      totalCount: result.results.length,
     };
   }
 
@@ -250,15 +251,16 @@ export interface DatabaseChanges {
   readonly last_seq: string | number;
 
   /**
-   * The amount of pending changes from the server. This value is not always
-   * returned by the servers.
+   * The actionable changes that are part of this batch.
+   * This has deleted and unreachable packages removed.
    */
-  readonly pending?: number;
+  readonly actionableResults: readonly DatabaseChange[];
 
   /**
-   * The changes that are part of this batch.
+   * The total count of changes in this batch. This includes unprocessable changes.
+   * 0 indicates we are up to date with "now".
    */
-  readonly results: readonly DatabaseChange[];
+  readonly totalCount: number;
 }
 
 export interface DatabaseChange {

--- a/src/package-sources/npmjs/npm-js-follower.lambda.ts
+++ b/src/package-sources/npmjs/npm-js-follower.lambda.ts
@@ -120,7 +120,7 @@ export async function handler(event: ScheduledEvent, context: Context) {
       const startTime = Date.now();
 
       try {
-        const batch = changes.results as readonly Change[];
+        const batch = changes.actionableResults as readonly Change[];
 
         // The most recent "modified" timestamp observed in the batch.
         let lastModified: Date | undefined;
@@ -146,7 +146,7 @@ export async function handler(event: ScheduledEvent, context: Context) {
           console.log(
             `Skipping batch as the latest modification is ${lastModified}, which is pre-Constructs`
           );
-        } else if (batch.length === 0) {
+        } else if (changes.totalCount === 0) {
           console.log('Received 0 changes, caught up to "now", exiting...');
           shouldContinue = false;
         } else {


### PR DESCRIPTION
The follower has a mechanism to stop processing when it reaches the end of the replication log. It determines this by looking at the number of changes received and if that's zero, we must be up-to-date.

Due to a code bug, this check was only considering actionable changes. I.e. changes that are not deleted and have metadata. A lot of the changes at the beginning of the log are not actionable. It is therefore extremely common that a batch does not contain any actionable changes. Which than leads the follower to incorrectly believe it has caught up and bail out of processing.

Instead we use the total number of changes as a metric to decide if we are at the end of the log.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*