### PR TITLE
fix: orchestration dlq alarm is too sensitive

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -6017,7 +6017,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
         },
         "AlarmName": "Test/ConstructHub/Orchestration/DLQ/NotEmpty",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
-        "EvaluationPeriods": 1,
+        "EvaluationPeriods": 5,
         "Metrics": [
           {
             "Expression": "m1 + m2",
@@ -19567,7 +19567,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
         },
         "AlarmName": "Test/ConstructHub/Orchestration/DLQ/NotEmpty",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
-        "EvaluationPeriods": 1,
+        "EvaluationPeriods": 5,
         "Metrics": [
           {
             "Expression": "m1 + m2",
@@ -32827,7 +32827,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
         },
         "AlarmName": "Test/ConstructHub/Orchestration/DLQ/NotEmpty",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
-        "EvaluationPeriods": 1,
+        "EvaluationPeriods": 5,
         "Metrics": [
           {
             "Expression": "m1 + m2",
@@ -46171,7 +46171,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
         },
         "AlarmName": "Test/ConstructHub/Orchestration/DLQ/NotEmpty",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
-        "EvaluationPeriods": 1,
+        "EvaluationPeriods": 5,
         "Metrics": [
           {
             "Expression": "m1 + m2",
@@ -59444,7 +59444,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
         },
         "AlarmName": "Test/ConstructHub/Orchestration/DLQ/NotEmpty",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
-        "EvaluationPeriods": 1,
+        "EvaluationPeriods": 5,
         "Metrics": [
           {
             "Expression": "m1 + m2",

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -6239,7 +6239,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
         },
         "AlarmName": "dev/ConstructHub/Orchestration/DLQ/NotEmpty",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
-        "EvaluationPeriods": 1,
+        "EvaluationPeriods": 5,
         "Metrics": [
           {
             "Expression": "m1 + m2",

--- a/src/backend/orchestration/index.ts
+++ b/src/backend/orchestration/index.ts
@@ -244,7 +244,7 @@ export class Orchestration extends Construct {
         ].join('\n'),
         comparisonOperator:
           ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
-        evaluationPeriods: 1,
+        evaluationPeriods: 5,
         threshold: 1,
       })
     );
@@ -468,9 +468,8 @@ export class Orchestration extends Construct {
       this.stateMachine
         .metricFailed()
         .createAlarm(this, 'OrchestrationFailed', {
-          alarmName: `${this.stateMachine.node.path}/${
-            this.stateMachine.metricFailed().metricName
-          }`,
+          alarmName: `${this.stateMachine.node.path}/${this.stateMachine.metricFailed().metricName
+            }`,
           alarmDescription: [
             'Backend orchestration failed!',
             '',


### PR DESCRIPTION
We are observing sporadic occurrences where the size of the DLQ is reported as 1 for a very short period of time (less than a minute). This triggers an alarm which is quickly auto resolved. 

Its not entirely clear why this happens. There is no auto/human re-drive when it happens. I am now attributing it to SQS eventual consistency and deeming the alarm to sensitive. 

Increase the evaluation periods to 2. This will now be consistent with our [ingestion dlq alarm](https://github.com/cdklabs/construct-hub/blob/main/src/backend/ingestion/index.ts#L311), which already uses 2 evaluation periods. 

> Also see https://github.com/cdklabs/construct-hub/pull/1402

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*