### PR TITLE
fix: consolidate messages for unpublished packages

### DIFF
--- a/src/package-sources/npmjs/npm-js-follower.lambda.ts
+++ b/src/package-sources/npmjs/npm-js-follower.lambda.ts
@@ -527,6 +527,7 @@ function getRelevantVersionInfos(
       Unit.Count
     );
 
+    const unpublishedVersions: string[] = [];
     for (const [version, modified] of packageVersionUpdates) {
       const knownKey = `${change.doc.name}@${version}`;
       const known = knownVersions.get(knownKey);
@@ -534,9 +535,7 @@ function getRelevantVersionInfos(
         const infos = change.doc.versions[version];
         if (infos == null) {
           // Could be the version in question was un-published.
-          console.log(
-            `[${change.seq}] Could not find info for "${change.doc.name}@${version}". Was it un-published?`
-          );
+          unpublishedVersions.push(knownKey);
         } else if (isConstructLibrary(infos)) {
           // skip if this package is denied
           const denied = denyList.lookup(infos.name, infos.version);
@@ -576,6 +575,12 @@ function getRelevantVersionInfos(
         }
         // Else this is not a construct library, so we'll just ignore it...
       }
+    }
+
+    for (const version of unpublishedVersions) {
+      console.log(
+        `[${change.seq}] Could not find info for "${version}". Was it un-published?`
+      );
     }
   }
   return result;


### PR DESCRIPTION
We currently send a message per unpublished version. However, a package that has many versions unpublished will pollute the logs with many messages. This PR consolidates those messages into one message that can be collapsed so that the logs are much easier to parse.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*