### PR TITLE
feat: allow registering medium severity alarms

### DIFF
--- a/API.md
+++ b/API.md
@@ -94,6 +94,7 @@ Any object.
 | <code><a href="#construct-hub.ConstructHub.property.highSeverityAlarms">highSeverityAlarms</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarm[]</code> | Returns a list of all high-severity alarms from this ConstructHub instance. |
 | <code><a href="#construct-hub.ConstructHub.property.ingestionQueue">ingestionQueue</a></code> | <code>aws-cdk-lib.aws_sqs.IQueue</code> | *No description.* |
 | <code><a href="#construct-hub.ConstructHub.property.lowSeverityAlarms">lowSeverityAlarms</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarm[]</code> | Returns a list of all low-severity alarms from this ConstructHub instance. |
+| <code><a href="#construct-hub.ConstructHub.property.mediumSeverityAlarms">mediumSeverityAlarms</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarm[]</code> | Returns a list of all low-severity alarms from this ConstructHub instance. |
 | <code><a href="#construct-hub.ConstructHub.property.regenerateAllDocumentationPerPackage">regenerateAllDocumentationPerPackage</a></code> | <code>aws-cdk-lib.aws_stepfunctions.IStateMachine</code> | The function operators can use to reprocess a specific package version through the backend data pipeline. |
 
 ---
@@ -163,6 +164,22 @@ public readonly ingestionQueue: IQueue;
 
 ```typescript
 public readonly lowSeverityAlarms: IAlarm[];
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarm[]
+
+Returns a list of all low-severity alarms from this ConstructHub instance.
+
+These do not necessitate immediate attention, as they do not have direct
+customer-visible impact, or handling is not time-sensitive. They indicate
+that something unusual (not necessarily bad) is happening.
+
+---
+
+##### `mediumSeverityAlarms`<sup>Required</sup> <a name="mediumSeverityAlarms" id="construct-hub.ConstructHub.property.mediumSeverityAlarms"></a>
+
+```typescript
+public readonly mediumSeverityAlarms: IAlarm[];
 ```
 
 - *Type:* aws-cdk-lib.aws_cloudwatch.IAlarm[]
@@ -327,6 +344,8 @@ const alarmActions: AlarmActions = { ... }
 | --- | --- | --- |
 | <code><a href="#construct-hub.AlarmActions.property.highSeverity">highSeverity</a></code> | <code>string</code> | The ARN of the CloudWatch alarm action to take for alarms of high-severity alarms. |
 | <code><a href="#construct-hub.AlarmActions.property.highSeverityAction">highSeverityAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The CloudWatch alarm action to take for alarms of high-severity alarms. |
+| <code><a href="#construct-hub.AlarmActions.property.mediumSeverity">mediumSeverity</a></code> | <code>string</code> | The ARN of the CloudWatch alarm action to take for alarms of medium-severity alarms. |
+| <code><a href="#construct-hub.AlarmActions.property.mediumSeverityAction">mediumSeverityAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The CloudWatch alarm action to take for alarms of medium-severity alarms. |
 | <code><a href="#construct-hub.AlarmActions.property.normalSeverity">normalSeverity</a></code> | <code>string</code> | The ARN of the CloudWatch alarm action to take for alarms of normal severity. |
 | <code><a href="#construct-hub.AlarmActions.property.normalSeverityAction">normalSeverityAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The CloudWatch alarm action to take for alarms of normal severity. |
 
@@ -357,6 +376,38 @@ public readonly highSeverityAction: IAlarmAction;
 - *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
 
 The CloudWatch alarm action to take for alarms of high-severity alarms.
+
+This must be an ARN that can be used with CloudWatch alarms.
+
+> [https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarms-and-actions](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarms-and-actions)
+
+---
+
+##### `mediumSeverity`<sup>Optional</sup> <a name="mediumSeverity" id="construct-hub.AlarmActions.property.mediumSeverity"></a>
+
+```typescript
+public readonly mediumSeverity: string;
+```
+
+- *Type:* string
+
+The ARN of the CloudWatch alarm action to take for alarms of medium-severity alarms.
+
+This must be an ARN that can be used with CloudWatch alarms.
+
+> [https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarms-and-actions](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarms-and-actions)
+
+---
+
+##### `mediumSeverityAction`<sup>Optional</sup> <a name="mediumSeverityAction" id="construct-hub.AlarmActions.property.mediumSeverityAction"></a>
+
+```typescript
+public readonly mediumSeverityAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+
+The CloudWatch alarm action to take for alarms of medium-severity alarms.
 
 This must be an ARN that can be used with CloudWatch alarms.
 
@@ -13679,6 +13730,7 @@ ConstructHub monitoring features exposed to extension points.
 | --- | --- |
 | <code><a href="#construct-hub.IMonitoring.addHighSeverityAlarm">addHighSeverityAlarm</a></code> | Adds a high-severity alarm. |
 | <code><a href="#construct-hub.IMonitoring.addLowSeverityAlarm">addLowSeverityAlarm</a></code> | Adds a low-severity alarm. |
+| <code><a href="#construct-hub.IMonitoring.addMediumSeverityAlarm">addMediumSeverityAlarm</a></code> | Adds a medium-severity alarm. |
 
 ---
 
@@ -13729,6 +13781,33 @@ a user-friendly title for the alarm (not currently used).
 ---
 
 ###### `alarm`<sup>Required</sup> <a name="alarm" id="construct-hub.IMonitoring.addLowSeverityAlarm.parameter.alarm"></a>
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.AlarmBase
+
+the alarm to be added.
+
+---
+
+##### `addMediumSeverityAlarm` <a name="addMediumSeverityAlarm" id="construct-hub.IMonitoring.addMediumSeverityAlarm"></a>
+
+```typescript
+public addMediumSeverityAlarm(title: string, alarm: AlarmBase): void
+```
+
+Adds a medium-severity alarm.
+
+If this alarm goes off, the action specified in
+`mediumSeverityAlarmAction` is triggered.
+
+###### `title`<sup>Required</sup> <a name="title" id="construct-hub.IMonitoring.addMediumSeverityAlarm.parameter.title"></a>
+
+- *Type:* string
+
+a user-friendly title for the alarm (not currently used).
+
+---
+
+###### `alarm`<sup>Required</sup> <a name="alarm" id="construct-hub.IMonitoring.addMediumSeverityAlarm.parameter.alarm"></a>
 
 - *Type:* aws-cdk-lib.aws_cloudwatch.AlarmBase
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -58,6 +58,23 @@ export interface AlarmActions {
   readonly highSeverityAction?: IAlarmAction;
 
   /**
+   * The ARN of the CloudWatch alarm action to take for alarms of medium-severity
+   * alarms.
+   *
+   * This must be an ARN that can be used with CloudWatch alarms.
+   * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarms-and-actions
+   */
+  readonly mediumSeverity?: string;
+
+  /**
+   * The CloudWatch alarm action to take for alarms of medium-severity alarms.
+   *
+   * This must be an ARN that can be used with CloudWatch alarms.
+   * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarms-and-actions
+   */
+  readonly mediumSeverityAction?: IAlarmAction;
+
+  /**
    * The ARN of the CloudWatch alarm action to take for alarms of normal
    * severity.
    *

--- a/src/construct-hub.ts
+++ b/src/construct-hub.ts
@@ -350,13 +350,13 @@ export class ConstructHub extends Construct implements iam.IGrantable {
     // Create an internal CodeArtifact repository if we run in network-controlled mode, or if a domain is provided.
     const codeArtifact =
       isolation === Isolation.NO_INTERNET_ACCESS ||
-      props.codeArtifactDomain != null
+        props.codeArtifactDomain != null
         ? new Repository(this, 'CodeArtifact', {
-            description: 'Proxy to npmjs.com for ConstructHub',
-            domainName: props.codeArtifactDomain?.name,
-            domainExists: props.codeArtifactDomain != null,
-            upstreams: props.codeArtifactDomain?.upstreams,
-          })
+          description: 'Proxy to npmjs.com for ConstructHub',
+          domainName: props.codeArtifactDomain?.name,
+          domainExists: props.codeArtifactDomain != null,
+          upstreams: props.codeArtifactDomain?.upstreams,
+        })
         : undefined;
     const { vpc, vpcEndpoints, vpcSubnets, vpcSecurityGroups } = this.createVpc(
       isolation,
@@ -563,6 +563,17 @@ export class ConstructHub extends Construct implements iam.IGrantable {
    * customer-visible impact, or handling is not time-sensitive. They indicate
    * that something unusual (not necessarily bad) is happening.
    */
+  public get mediumSeverityAlarms(): cw.IAlarm[] {
+    // Note: the array is already returned by-copy by Monitoring, so not copying again.
+    return this.monitoring.mediumSeverityAlarms;
+  }
+
+  /**
+   * Returns a list of all low-severity alarms from this ConstructHub instance.
+   * These do not necessitate immediate attention, as they do not have direct
+   * customer-visible impact, or handling is not time-sensitive. They indicate
+   * that something unusual (not necessarily bad) is happening.
+   */
   public get lowSeverityAlarms(): cw.IAlarm[] {
     // Note: the array is already returned by-copy by Monitoring, so not copying again.
     return this.monitoring.lowSeverityAlarms;
@@ -572,7 +583,7 @@ export class ConstructHub extends Construct implements iam.IGrantable {
    * Returns a list of all alarms configured by this ConstructHub instance.
    */
   public get allAlarms(): cw.IAlarm[] {
-    return [...this.highSeverityAlarms, ...this.lowSeverityAlarms];
+    return [...this.highSeverityAlarms, ...this.lowSeverityAlarms, ...this.mediumSeverityAlarms];
   }
 
   public get grantPrincipal(): iam.IPrincipal {

--- a/src/monitoring/api.ts
+++ b/src/monitoring/api.ts
@@ -15,6 +15,15 @@ export interface IMonitoring {
   addHighSeverityAlarm(title: string, alarm: AlarmBase): void;
 
   /**
+   * Adds a medium-severity alarm. If this alarm goes off, the action specified in
+   * `mediumSeverityAlarmAction` is triggered.
+   *
+   * @param title a user-friendly title for the alarm (not currently used).
+   * @param alarm the alarm to be added.
+   */
+  addMediumSeverityAlarm(title: string, alarm: AlarmBase): void;
+
+  /**
    * Adds a low-severity alarm. If this alarm goes off, the action specified in
    * `normalAlarmAction` is triggered.
    *

--- a/src/monitoring/index.ts
+++ b/src/monitoring/index.ts
@@ -27,6 +27,7 @@ export interface MonitoringProps {
 export class Monitoring extends Construct implements IMonitoring {
   private alarmActions?: AlarmActions;
   private _highSeverityAlarms: cw.AlarmBase[];
+  private _mediumSeverityAlarms: cw.AlarmBase[];
   private _lowSeverityAlarms: cw.AlarmBase[];
 
   /**
@@ -55,6 +56,7 @@ export class Monitoring extends Construct implements IMonitoring {
 
     this._highSeverityAlarms = [];
     this._lowSeverityAlarms = [];
+    this._mediumSeverityAlarms = [];
 
     this.highSeverityDashboard = new cw.Dashboard(
       this,
@@ -103,8 +105,26 @@ export class Monitoring extends Construct implements IMonitoring {
     this._lowSeverityAlarms.push(alarm);
   }
 
+  public addMediumSeverityAlarm(_title: string, alarm: cw.AlarmBase) {
+    const actionArn = this.alarmActions?.mediumSeverity;
+    if (actionArn) {
+      alarm.addAlarmAction({
+        bind: () => ({ alarmActionArn: actionArn }),
+      });
+    }
+    const action = this.alarmActions?.mediumSeverityAction;
+    if (action) {
+      alarm.addAlarmAction(action);
+    }
+    this._mediumSeverityAlarms.push(alarm);
+  }
+
   public get highSeverityAlarms() {
     return [...this._highSeverityAlarms];
+  }
+
+  public get mediumSeverityAlarms() {
+    return [...this._mediumSeverityAlarms];
   }
 
   public get lowSeverityAlarms() {

--- a/test/integ.transliterator.ecstask.ts
+++ b/test/integ.transliterator.ecstask.ts
@@ -24,6 +24,7 @@ const transliterator = new Transliterator(stack, 'Transliterator', {
   bucket,
   monitoring: {
     addHighSeverityAlarm: () => {},
+    addMediumSeverityAlarm: () => {},
     addLowSeverityAlarm: () => {},
   },
 });


### PR DESCRIPTION
We identified a need for another severity level other than "high" and "normal". With this change, we can have the following conceptual categorization:

- **High**: Requires immediate action
- **Medium**: Requires action but can wait for working hours
- **Normal**: Requires action but can wait for operator discretion. 

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*