### PR TITLE
fix: npmjs package canary can report undefined publish time

### DIFF
--- a/src/package-sources/npmjs/canary/npmjs-package-canary.lambda.ts
+++ b/src/package-sources/npmjs/canary/npmjs-package-canary.lambda.ts
@@ -356,6 +356,10 @@ export class CanaryStateService {
       )
     ).time[version];
 
+    if (publishedAt === undefined) {
+      throw new Error(`Latest version of ${packageName} is ${version} but publish time has not been reported.`);
+    }
+
     console.log(
       `Package: ${packageName} | Version : ${version} | Published At: ${publishedAt}`
     );


### PR DESCRIPTION
It's possible for the latest version in `https://registry.npmjs.org/construct-hub-probe/latest` to not be included in the publish times that `https://registry.npmjs.org/construct-hub-probe` reports. This is likely because the package was just published.

This change protects from that scenario by failing the invocation. The next invocation will likely pick up the publish time of the version without our intervention. 

Before this change, an undefined `publishedAt` property would result in `publishedAt: "1970-01-01T00:00:00.000Z"` written into the state, which is then used to erroneously determine the time between npm publish and catalog availability. 

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*