### PR TITLE
feat: per-alarm action and severity overrides

### DIFF
--- a/API.md
+++ b/API.md
@@ -537,8 +537,8 @@ const alarmOverride: AlarmOverride = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#construct-hub.AlarmOverride.property.actions">actions</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction[]</code> | Wire custom actions onto this alarm, replacing the severity bucket's action. |
-| <code><a href="#construct-hub.AlarmOverride.property.severity">severity</a></code> | <code>string</code> | Wire this alarm to a different severity bucket's action. |
+| <code><a href="#construct-hub.AlarmOverride.property.actions">actions</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction[]</code> | Wire these actions onto the alarm in place of the severity bucket's action. |
+| <code><a href="#construct-hub.AlarmOverride.property.severity">severity</a></code> | <code><a href="#construct-hub.AlarmSeverity">AlarmSeverity</a></code> | Wire this alarm to a different severity bucket's action. |
 
 ---
 
@@ -551,17 +551,17 @@ public readonly actions: IAlarmAction[];
 - *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction[]
 - *Default:* the severity bucket's action
 
-Wire custom actions onto this alarm, replacing the severity bucket's action.
+Wire these actions onto the alarm in place of the severity bucket's action.
 
 ---
 
 ##### `severity`<sup>Optional</sup> <a name="severity" id="construct-hub.AlarmOverride.property.severity"></a>
 
 ```typescript
-public readonly severity: string;
+public readonly severity: AlarmSeverity;
 ```
 
-- *Type:* string
+- *Type:* <a href="#construct-hub.AlarmSeverity">AlarmSeverity</a>
 - *Default:* the severity hardcoded by the alarm's author
 
 Wire this alarm to a different severity bucket's action.

--- a/API.md
+++ b/API.md
@@ -538,7 +538,7 @@ const alarmOverride: AlarmOverride = { ... }
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#construct-hub.AlarmOverride.property.actions">actions</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction[]</code> | Wire custom actions onto this alarm, replacing the severity bucket's action. |
-| <code><a href="#construct-hub.AlarmOverride.property.severity">severity</a></code> | <code><a href="#construct-hub.AlarmSeverity">AlarmSeverity</a></code> | Wire this alarm to a different severity bucket's action. |
+| <code><a href="#construct-hub.AlarmOverride.property.severity">severity</a></code> | <code>string</code> | Wire this alarm to a different severity bucket's action. |
 
 ---
 
@@ -558,10 +558,10 @@ Wire custom actions onto this alarm, replacing the severity bucket's action.
 ##### `severity`<sup>Optional</sup> <a name="severity" id="construct-hub.AlarmOverride.property.severity"></a>
 
 ```typescript
-public readonly severity: AlarmSeverity;
+public readonly severity: string;
 ```
 
-- *Type:* <a href="#construct-hub.AlarmSeverity">AlarmSeverity</a>
+- *Type:* string
 - *Default:* the severity hardcoded by the alarm's author
 
 Wire this alarm to a different severity bucket's action.
@@ -775,7 +775,7 @@ const constructHubProps: ConstructHubProps = { ... }
 | --- | --- | --- |
 | <code><a href="#construct-hub.ConstructHubProps.property.additionalDomains">additionalDomains</a></code> | <code><a href="#construct-hub.DomainRedirectSource">DomainRedirectSource</a>[]</code> | Additional domains which will be set up to redirect to the primary construct hub domain. |
 | <code><a href="#construct-hub.ConstructHubProps.property.alarmActions">alarmActions</a></code> | <code><a href="#construct-hub.AlarmActions">AlarmActions</a></code> | Actions to perform when alarms are set. |
-| <code><a href="#construct-hub.ConstructHubProps.property.alarmOverrides">alarmOverrides</a></code> | <code>{[ key: string ]: <a href="#construct-hub.AlarmOverride">AlarmOverride</a>}</code> | Per-alarm overrides keyed by the alarm's construct path relative to the `ConstructHub` construct (e.g. 'Sources/NpmJs/Canary/NotRunningOrFailing'). Use the `AlarmPath` enum for compile-time typo protection. |
+| <code><a href="#construct-hub.ConstructHubProps.property.alarmOverrides">alarmOverrides</a></code> | <code>{[ key: string ]: <a href="#construct-hub.AlarmOverride">AlarmOverride</a>}</code> | Per-alarm overrides keyed by the alarm's CloudWatch display name relative to the `ConstructHub` construct — i.e. the same string a customer sees in tickets and the CloudWatch console (e.g. 'Sources/NpmJs/Canary/NotRunningOrFailing'). |
 | <code><a href="#construct-hub.ConstructHubProps.property.alarmSeverities">alarmSeverities</a></code> | <code><a href="#construct-hub.AlarmSeverities">AlarmSeverities</a></code> | Configure the severities of various alarms. |
 | <code><a href="#construct-hub.ConstructHubProps.property.allowedLicenses">allowedLicenses</a></code> | <code><a href="#construct-hub.SpdxLicense">SpdxLicense</a>[]</code> | The allowed licenses for packages indexed by this instance of ConstructHub. |
 | <code><a href="#construct-hub.ConstructHubProps.property.appRegistryApplication">appRegistryApplication</a></code> | <code>boolean</code> | Create an AppRegistry application associated with the stack containing this construct. |
@@ -835,10 +835,13 @@ public readonly alarmOverrides: {[ key: string ]: AlarmOverride};
 
 - *Type:* {[ key: string ]: <a href="#construct-hub.AlarmOverride">AlarmOverride</a>}
 
-Per-alarm overrides keyed by the alarm's construct path relative to the `ConstructHub` construct (e.g. 'Sources/NpmJs/Canary/NotRunningOrFailing'). Use the `AlarmPath` enum for compile-time typo protection.
+Per-alarm overrides keyed by the alarm's CloudWatch display name relative to the `ConstructHub` construct — i.e. the same string a customer sees in tickets and the CloudWatch console (e.g. 'Sources/NpmJs/Canary/NotRunningOrFailing').
 
-For each entry, set `severity` to wire the alarm to a different bucket's
-action, `actions` to supply custom actions that bypass the buckets, or both.
+For each entry, set `severity` ('HIGH' | 'MEDIUM' | 'LOW') to wire the
+alarm to a different bucket's action, `actions` to supply custom actions
+that bypass the buckets, or both.
+
+Unknown keys are surfaced as synth-time validation errors.
 
 ---
 
@@ -14469,193 +14472,6 @@ the id of the external connection (i.e: `public:npmjs`).
 
 
 ## Enums <a name="Enums" id="Enums"></a>
-
-### AlarmPath <a name="AlarmPath" id="construct-hub.AlarmPath"></a>
-
-Construct paths of alarms that can be overridden via `alarmOverrides`.
-
-The path is relative to the `ConstructHub` construct.
-
-#### Members <a name="Members" id="Members"></a>
-
-| **Name** | **Description** |
-| --- | --- |
-| <code><a href="#construct-hub.AlarmPath.SOURCES_NPMJS_FOLLOWER_FAILURES">SOURCES_NPMJS_FOLLOWER_FAILURES</a></code> | *No description.* |
-| <code><a href="#construct-hub.AlarmPath.SOURCES_NPMJS_FOLLOWER_NOT_RUNNING">SOURCES_NPMJS_FOLLOWER_NOT_RUNNING</a></code> | *No description.* |
-| <code><a href="#construct-hub.AlarmPath.SOURCES_NPMJS_FOLLOWER_NO_CHANGES">SOURCES_NPMJS_FOLLOWER_NO_CHANGES</a></code> | *No description.* |
-| <code><a href="#construct-hub.AlarmPath.SOURCES_NPMJS_STAGER_DLQ_NOT_EMPTY">SOURCES_NPMJS_STAGER_DLQ_NOT_EMPTY</a></code> | *No description.* |
-| <code><a href="#construct-hub.AlarmPath.SOURCES_NPMJS_CANARY_SLA_BREACHED">SOURCES_NPMJS_CANARY_SLA_BREACHED</a></code> | *No description.* |
-| <code><a href="#construct-hub.AlarmPath.SOURCES_NPMJS_CANARY_STALE_PACKAGE">SOURCES_NPMJS_CANARY_STALE_PACKAGE</a></code> | *No description.* |
-| <code><a href="#construct-hub.AlarmPath.SOURCES_NPMJS_CANARY_FAILING">SOURCES_NPMJS_CANARY_FAILING</a></code> | *No description.* |
-| <code><a href="#construct-hub.AlarmPath.SOURCES_NPMJS_CANARY_NOT_RUNNING">SOURCES_NPMJS_CANARY_NOT_RUNNING</a></code> | *No description.* |
-| <code><a href="#construct-hub.AlarmPath.SOURCES_NPMJS_CANARY_NOT_RUNNING_OR_FAILING">SOURCES_NPMJS_CANARY_NOT_RUNNING_OR_FAILING</a></code> | *No description.* |
-| <code><a href="#construct-hub.AlarmPath.SOURCES_NPMJS_CANARY_GATEWAY_ERRORS">SOURCES_NPMJS_CANARY_GATEWAY_ERRORS</a></code> | *No description.* |
-| <code><a href="#construct-hub.AlarmPath.INGESTION_DLQ_NOT_EMPTY">INGESTION_DLQ_NOT_EMPTY</a></code> | *No description.* |
-| <code><a href="#construct-hub.AlarmPath.INGESTION_FAILURE">INGESTION_FAILURE</a></code> | *No description.* |
-| <code><a href="#construct-hub.AlarmPath.INGESTION_REPROCESS_WORKFLOW_FAILURE">INGESTION_REPROCESS_WORKFLOW_FAILURE</a></code> | *No description.* |
-| <code><a href="#construct-hub.AlarmPath.FEED_BUILDER_FAILURE">FEED_BUILDER_FAILURE</a></code> | *No description.* |
-| <code><a href="#construct-hub.AlarmPath.ORCHESTRATION_DLQ_NOT_EMPTY">ORCHESTRATION_DLQ_NOT_EMPTY</a></code> | *No description.* |
-| <code><a href="#construct-hub.AlarmPath.ORCHESTRATION_EXECUTIONS_FAILED">ORCHESTRATION_EXECUTIONS_FAILED</a></code> | *No description.* |
-| <code><a href="#construct-hub.AlarmPath.ORCHESTRATION_EXECUTION_FAILURE_RATE">ORCHESTRATION_EXECUTION_FAILURE_RATE</a></code> | *No description.* |
-| <code><a href="#construct-hub.AlarmPath.ORCHESTRATION_SHRINKING_CATALOG">ORCHESTRATION_SHRINKING_CATALOG</a></code> | *No description.* |
-| <code><a href="#construct-hub.AlarmPath.INVENTORY_CANARY_NOT_RUNNING">INVENTORY_CANARY_NOT_RUNNING</a></code> | *No description.* |
-| <code><a href="#construct-hub.AlarmPath.INVENTORY_CANARY_FAILURES">INVENTORY_CANARY_FAILURES</a></code> | *No description.* |
-| <code><a href="#construct-hub.AlarmPath.PACKAGE_STATS_FAILURES">PACKAGE_STATS_FAILURES</a></code> | *No description.* |
-| <code><a href="#construct-hub.AlarmPath.VERSION_TRACKER_FAILURES">VERSION_TRACKER_FAILURES</a></code> | *No description.* |
-| <code><a href="#construct-hub.AlarmPath.VERSION_TRACKER_NOT_RUNNING">VERSION_TRACKER_NOT_RUNNING</a></code> | *No description.* |
-| <code><a href="#construct-hub.AlarmPath.RELEASE_NOTES_GENERATION_FAILURE">RELEASE_NOTES_GENERATION_FAILURE</a></code> | *No description.* |
-| <code><a href="#construct-hub.AlarmPath.RELEASE_NOTES_TRIGGER_FAILURE">RELEASE_NOTES_TRIGGER_FAILURE</a></code> | *No description.* |
-| <code><a href="#construct-hub.AlarmPath.RELEASE_NOTES_INVALID_GITHUB_CREDENTIALS">RELEASE_NOTES_INVALID_GITHUB_CREDENTIALS</a></code> | *No description.* |
-| <code><a href="#construct-hub.AlarmPath.RELEASE_NOTES_GITHUB_RATE_LIMIT">RELEASE_NOTES_GITHUB_RATE_LIMIT</a></code> | *No description.* |
-| <code><a href="#construct-hub.AlarmPath.WEBAPP_ACM_CERTIFICATE_EXPIRES_SOON">WEBAPP_ACM_CERTIFICATE_EXPIRES_SOON</a></code> | *No description.* |
-| <code><a href="#construct-hub.AlarmPath.WEBAPP_ENDPOINT_CERTIFICATE_EXPIRES_SOON">WEBAPP_ENDPOINT_CERTIFICATE_EXPIRES_SOON</a></code> | *No description.* |
-
----
-
-##### `SOURCES_NPMJS_FOLLOWER_FAILURES` <a name="SOURCES_NPMJS_FOLLOWER_FAILURES" id="construct-hub.AlarmPath.SOURCES_NPMJS_FOLLOWER_FAILURES"></a>
-
----
-
-
-##### `SOURCES_NPMJS_FOLLOWER_NOT_RUNNING` <a name="SOURCES_NPMJS_FOLLOWER_NOT_RUNNING" id="construct-hub.AlarmPath.SOURCES_NPMJS_FOLLOWER_NOT_RUNNING"></a>
-
----
-
-
-##### `SOURCES_NPMJS_FOLLOWER_NO_CHANGES` <a name="SOURCES_NPMJS_FOLLOWER_NO_CHANGES" id="construct-hub.AlarmPath.SOURCES_NPMJS_FOLLOWER_NO_CHANGES"></a>
-
----
-
-
-##### `SOURCES_NPMJS_STAGER_DLQ_NOT_EMPTY` <a name="SOURCES_NPMJS_STAGER_DLQ_NOT_EMPTY" id="construct-hub.AlarmPath.SOURCES_NPMJS_STAGER_DLQ_NOT_EMPTY"></a>
-
----
-
-
-##### `SOURCES_NPMJS_CANARY_SLA_BREACHED` <a name="SOURCES_NPMJS_CANARY_SLA_BREACHED" id="construct-hub.AlarmPath.SOURCES_NPMJS_CANARY_SLA_BREACHED"></a>
-
----
-
-
-##### `SOURCES_NPMJS_CANARY_STALE_PACKAGE` <a name="SOURCES_NPMJS_CANARY_STALE_PACKAGE" id="construct-hub.AlarmPath.SOURCES_NPMJS_CANARY_STALE_PACKAGE"></a>
-
----
-
-
-##### `SOURCES_NPMJS_CANARY_FAILING` <a name="SOURCES_NPMJS_CANARY_FAILING" id="construct-hub.AlarmPath.SOURCES_NPMJS_CANARY_FAILING"></a>
-
----
-
-
-##### `SOURCES_NPMJS_CANARY_NOT_RUNNING` <a name="SOURCES_NPMJS_CANARY_NOT_RUNNING" id="construct-hub.AlarmPath.SOURCES_NPMJS_CANARY_NOT_RUNNING"></a>
-
----
-
-
-##### `SOURCES_NPMJS_CANARY_NOT_RUNNING_OR_FAILING` <a name="SOURCES_NPMJS_CANARY_NOT_RUNNING_OR_FAILING" id="construct-hub.AlarmPath.SOURCES_NPMJS_CANARY_NOT_RUNNING_OR_FAILING"></a>
-
----
-
-
-##### `SOURCES_NPMJS_CANARY_GATEWAY_ERRORS` <a name="SOURCES_NPMJS_CANARY_GATEWAY_ERRORS" id="construct-hub.AlarmPath.SOURCES_NPMJS_CANARY_GATEWAY_ERRORS"></a>
-
----
-
-
-##### `INGESTION_DLQ_NOT_EMPTY` <a name="INGESTION_DLQ_NOT_EMPTY" id="construct-hub.AlarmPath.INGESTION_DLQ_NOT_EMPTY"></a>
-
----
-
-
-##### `INGESTION_FAILURE` <a name="INGESTION_FAILURE" id="construct-hub.AlarmPath.INGESTION_FAILURE"></a>
-
----
-
-
-##### `INGESTION_REPROCESS_WORKFLOW_FAILURE` <a name="INGESTION_REPROCESS_WORKFLOW_FAILURE" id="construct-hub.AlarmPath.INGESTION_REPROCESS_WORKFLOW_FAILURE"></a>
-
----
-
-
-##### `FEED_BUILDER_FAILURE` <a name="FEED_BUILDER_FAILURE" id="construct-hub.AlarmPath.FEED_BUILDER_FAILURE"></a>
-
----
-
-
-##### `ORCHESTRATION_DLQ_NOT_EMPTY` <a name="ORCHESTRATION_DLQ_NOT_EMPTY" id="construct-hub.AlarmPath.ORCHESTRATION_DLQ_NOT_EMPTY"></a>
-
----
-
-
-##### `ORCHESTRATION_EXECUTIONS_FAILED` <a name="ORCHESTRATION_EXECUTIONS_FAILED" id="construct-hub.AlarmPath.ORCHESTRATION_EXECUTIONS_FAILED"></a>
-
----
-
-
-##### `ORCHESTRATION_EXECUTION_FAILURE_RATE` <a name="ORCHESTRATION_EXECUTION_FAILURE_RATE" id="construct-hub.AlarmPath.ORCHESTRATION_EXECUTION_FAILURE_RATE"></a>
-
----
-
-
-##### `ORCHESTRATION_SHRINKING_CATALOG` <a name="ORCHESTRATION_SHRINKING_CATALOG" id="construct-hub.AlarmPath.ORCHESTRATION_SHRINKING_CATALOG"></a>
-
----
-
-
-##### `INVENTORY_CANARY_NOT_RUNNING` <a name="INVENTORY_CANARY_NOT_RUNNING" id="construct-hub.AlarmPath.INVENTORY_CANARY_NOT_RUNNING"></a>
-
----
-
-
-##### `INVENTORY_CANARY_FAILURES` <a name="INVENTORY_CANARY_FAILURES" id="construct-hub.AlarmPath.INVENTORY_CANARY_FAILURES"></a>
-
----
-
-
-##### `PACKAGE_STATS_FAILURES` <a name="PACKAGE_STATS_FAILURES" id="construct-hub.AlarmPath.PACKAGE_STATS_FAILURES"></a>
-
----
-
-
-##### `VERSION_TRACKER_FAILURES` <a name="VERSION_TRACKER_FAILURES" id="construct-hub.AlarmPath.VERSION_TRACKER_FAILURES"></a>
-
----
-
-
-##### `VERSION_TRACKER_NOT_RUNNING` <a name="VERSION_TRACKER_NOT_RUNNING" id="construct-hub.AlarmPath.VERSION_TRACKER_NOT_RUNNING"></a>
-
----
-
-
-##### `RELEASE_NOTES_GENERATION_FAILURE` <a name="RELEASE_NOTES_GENERATION_FAILURE" id="construct-hub.AlarmPath.RELEASE_NOTES_GENERATION_FAILURE"></a>
-
----
-
-
-##### `RELEASE_NOTES_TRIGGER_FAILURE` <a name="RELEASE_NOTES_TRIGGER_FAILURE" id="construct-hub.AlarmPath.RELEASE_NOTES_TRIGGER_FAILURE"></a>
-
----
-
-
-##### `RELEASE_NOTES_INVALID_GITHUB_CREDENTIALS` <a name="RELEASE_NOTES_INVALID_GITHUB_CREDENTIALS" id="construct-hub.AlarmPath.RELEASE_NOTES_INVALID_GITHUB_CREDENTIALS"></a>
-
----
-
-
-##### `RELEASE_NOTES_GITHUB_RATE_LIMIT` <a name="RELEASE_NOTES_GITHUB_RATE_LIMIT" id="construct-hub.AlarmPath.RELEASE_NOTES_GITHUB_RATE_LIMIT"></a>
-
----
-
-
-##### `WEBAPP_ACM_CERTIFICATE_EXPIRES_SOON` <a name="WEBAPP_ACM_CERTIFICATE_EXPIRES_SOON" id="construct-hub.AlarmPath.WEBAPP_ACM_CERTIFICATE_EXPIRES_SOON"></a>
-
----
-
-
-##### `WEBAPP_ENDPOINT_CERTIFICATE_EXPIRES_SOON` <a name="WEBAPP_ENDPOINT_CERTIFICATE_EXPIRES_SOON" id="construct-hub.AlarmPath.WEBAPP_ENDPOINT_CERTIFICATE_EXPIRES_SOON"></a>
-
----
-
 
 ### AlarmSeverity <a name="AlarmSeverity" id="construct-hub.AlarmSeverity"></a>
 

--- a/API.md
+++ b/API.md
@@ -521,6 +521,53 @@ This must be an ARN that can be used with CloudWatch alarms.
 
 ---
 
+### AlarmOverride <a name="AlarmOverride" id="construct-hub.AlarmOverride"></a>
+
+An override for a specific alarm.
+
+#### Initializer <a name="Initializer" id="construct-hub.AlarmOverride.Initializer"></a>
+
+```typescript
+import { AlarmOverride } from 'construct-hub'
+
+const alarmOverride: AlarmOverride = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#construct-hub.AlarmOverride.property.actions">actions</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction[]</code> | Wire custom actions onto this alarm, replacing the severity bucket's action. |
+| <code><a href="#construct-hub.AlarmOverride.property.severity">severity</a></code> | <code><a href="#construct-hub.AlarmSeverity">AlarmSeverity</a></code> | Wire this alarm to a different severity bucket's action. |
+
+---
+
+##### `actions`<sup>Optional</sup> <a name="actions" id="construct-hub.AlarmOverride.property.actions"></a>
+
+```typescript
+public readonly actions: IAlarmAction[];
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction[]
+- *Default:* the severity bucket's action
+
+Wire custom actions onto this alarm, replacing the severity bucket's action.
+
+---
+
+##### `severity`<sup>Optional</sup> <a name="severity" id="construct-hub.AlarmOverride.property.severity"></a>
+
+```typescript
+public readonly severity: AlarmSeverity;
+```
+
+- *Type:* <a href="#construct-hub.AlarmSeverity">AlarmSeverity</a>
+- *Default:* the severity hardcoded by the alarm's author
+
+Wire this alarm to a different severity bucket's action.
+
+---
+
 ### AlarmSeverities <a name="AlarmSeverities" id="construct-hub.AlarmSeverities"></a>
 
 Configure severities for various alarms.
@@ -728,6 +775,7 @@ const constructHubProps: ConstructHubProps = { ... }
 | --- | --- | --- |
 | <code><a href="#construct-hub.ConstructHubProps.property.additionalDomains">additionalDomains</a></code> | <code><a href="#construct-hub.DomainRedirectSource">DomainRedirectSource</a>[]</code> | Additional domains which will be set up to redirect to the primary construct hub domain. |
 | <code><a href="#construct-hub.ConstructHubProps.property.alarmActions">alarmActions</a></code> | <code><a href="#construct-hub.AlarmActions">AlarmActions</a></code> | Actions to perform when alarms are set. |
+| <code><a href="#construct-hub.ConstructHubProps.property.alarmOverrides">alarmOverrides</a></code> | <code>{[ key: string ]: <a href="#construct-hub.AlarmOverride">AlarmOverride</a>}</code> | Per-alarm overrides keyed by the alarm's construct path relative to the `ConstructHub` construct (e.g. 'Sources/NpmJs/Canary/NotRunningOrFailing'). Use the `AlarmPath` enum for compile-time typo protection. |
 | <code><a href="#construct-hub.ConstructHubProps.property.alarmSeverities">alarmSeverities</a></code> | <code><a href="#construct-hub.AlarmSeverities">AlarmSeverities</a></code> | Configure the severities of various alarms. |
 | <code><a href="#construct-hub.ConstructHubProps.property.allowedLicenses">allowedLicenses</a></code> | <code><a href="#construct-hub.SpdxLicense">SpdxLicense</a>[]</code> | The allowed licenses for packages indexed by this instance of ConstructHub. |
 | <code><a href="#construct-hub.ConstructHubProps.property.appRegistryApplication">appRegistryApplication</a></code> | <code>boolean</code> | Create an AppRegistry application associated with the stack containing this construct. |
@@ -776,6 +824,21 @@ public readonly alarmActions: AlarmActions;
 - *Type:* <a href="#construct-hub.AlarmActions">AlarmActions</a>
 
 Actions to perform when alarms are set.
+
+---
+
+##### `alarmOverrides`<sup>Optional</sup> <a name="alarmOverrides" id="construct-hub.ConstructHubProps.property.alarmOverrides"></a>
+
+```typescript
+public readonly alarmOverrides: {[ key: string ]: AlarmOverride};
+```
+
+- *Type:* {[ key: string ]: <a href="#construct-hub.AlarmOverride">AlarmOverride</a>}
+
+Per-alarm overrides keyed by the alarm's construct path relative to the `ConstructHub` construct (e.g. 'Sources/NpmJs/Canary/NotRunningOrFailing'). Use the `AlarmPath` enum for compile-time typo protection.
+
+For each entry, set `severity` to wire the alarm to a different bucket's
+action, `actions` to supply custom actions that bypass the buckets, or both.
 
 ---
 
@@ -14406,6 +14469,193 @@ the id of the external connection (i.e: `public:npmjs`).
 
 
 ## Enums <a name="Enums" id="Enums"></a>
+
+### AlarmPath <a name="AlarmPath" id="construct-hub.AlarmPath"></a>
+
+Construct paths of alarms that can be overridden via `alarmOverrides`.
+
+The path is relative to the `ConstructHub` construct.
+
+#### Members <a name="Members" id="Members"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#construct-hub.AlarmPath.SOURCES_NPMJS_FOLLOWER_FAILURES">SOURCES_NPMJS_FOLLOWER_FAILURES</a></code> | *No description.* |
+| <code><a href="#construct-hub.AlarmPath.SOURCES_NPMJS_FOLLOWER_NOT_RUNNING">SOURCES_NPMJS_FOLLOWER_NOT_RUNNING</a></code> | *No description.* |
+| <code><a href="#construct-hub.AlarmPath.SOURCES_NPMJS_FOLLOWER_NO_CHANGES">SOURCES_NPMJS_FOLLOWER_NO_CHANGES</a></code> | *No description.* |
+| <code><a href="#construct-hub.AlarmPath.SOURCES_NPMJS_STAGER_DLQ_NOT_EMPTY">SOURCES_NPMJS_STAGER_DLQ_NOT_EMPTY</a></code> | *No description.* |
+| <code><a href="#construct-hub.AlarmPath.SOURCES_NPMJS_CANARY_SLA_BREACHED">SOURCES_NPMJS_CANARY_SLA_BREACHED</a></code> | *No description.* |
+| <code><a href="#construct-hub.AlarmPath.SOURCES_NPMJS_CANARY_STALE_PACKAGE">SOURCES_NPMJS_CANARY_STALE_PACKAGE</a></code> | *No description.* |
+| <code><a href="#construct-hub.AlarmPath.SOURCES_NPMJS_CANARY_FAILING">SOURCES_NPMJS_CANARY_FAILING</a></code> | *No description.* |
+| <code><a href="#construct-hub.AlarmPath.SOURCES_NPMJS_CANARY_NOT_RUNNING">SOURCES_NPMJS_CANARY_NOT_RUNNING</a></code> | *No description.* |
+| <code><a href="#construct-hub.AlarmPath.SOURCES_NPMJS_CANARY_NOT_RUNNING_OR_FAILING">SOURCES_NPMJS_CANARY_NOT_RUNNING_OR_FAILING</a></code> | *No description.* |
+| <code><a href="#construct-hub.AlarmPath.SOURCES_NPMJS_CANARY_GATEWAY_ERRORS">SOURCES_NPMJS_CANARY_GATEWAY_ERRORS</a></code> | *No description.* |
+| <code><a href="#construct-hub.AlarmPath.INGESTION_DLQ_NOT_EMPTY">INGESTION_DLQ_NOT_EMPTY</a></code> | *No description.* |
+| <code><a href="#construct-hub.AlarmPath.INGESTION_FAILURE">INGESTION_FAILURE</a></code> | *No description.* |
+| <code><a href="#construct-hub.AlarmPath.INGESTION_REPROCESS_WORKFLOW_FAILURE">INGESTION_REPROCESS_WORKFLOW_FAILURE</a></code> | *No description.* |
+| <code><a href="#construct-hub.AlarmPath.FEED_BUILDER_FAILURE">FEED_BUILDER_FAILURE</a></code> | *No description.* |
+| <code><a href="#construct-hub.AlarmPath.ORCHESTRATION_DLQ_NOT_EMPTY">ORCHESTRATION_DLQ_NOT_EMPTY</a></code> | *No description.* |
+| <code><a href="#construct-hub.AlarmPath.ORCHESTRATION_EXECUTIONS_FAILED">ORCHESTRATION_EXECUTIONS_FAILED</a></code> | *No description.* |
+| <code><a href="#construct-hub.AlarmPath.ORCHESTRATION_EXECUTION_FAILURE_RATE">ORCHESTRATION_EXECUTION_FAILURE_RATE</a></code> | *No description.* |
+| <code><a href="#construct-hub.AlarmPath.ORCHESTRATION_SHRINKING_CATALOG">ORCHESTRATION_SHRINKING_CATALOG</a></code> | *No description.* |
+| <code><a href="#construct-hub.AlarmPath.INVENTORY_CANARY_NOT_RUNNING">INVENTORY_CANARY_NOT_RUNNING</a></code> | *No description.* |
+| <code><a href="#construct-hub.AlarmPath.INVENTORY_CANARY_FAILURES">INVENTORY_CANARY_FAILURES</a></code> | *No description.* |
+| <code><a href="#construct-hub.AlarmPath.PACKAGE_STATS_FAILURES">PACKAGE_STATS_FAILURES</a></code> | *No description.* |
+| <code><a href="#construct-hub.AlarmPath.VERSION_TRACKER_FAILURES">VERSION_TRACKER_FAILURES</a></code> | *No description.* |
+| <code><a href="#construct-hub.AlarmPath.VERSION_TRACKER_NOT_RUNNING">VERSION_TRACKER_NOT_RUNNING</a></code> | *No description.* |
+| <code><a href="#construct-hub.AlarmPath.RELEASE_NOTES_GENERATION_FAILURE">RELEASE_NOTES_GENERATION_FAILURE</a></code> | *No description.* |
+| <code><a href="#construct-hub.AlarmPath.RELEASE_NOTES_TRIGGER_FAILURE">RELEASE_NOTES_TRIGGER_FAILURE</a></code> | *No description.* |
+| <code><a href="#construct-hub.AlarmPath.RELEASE_NOTES_INVALID_GITHUB_CREDENTIALS">RELEASE_NOTES_INVALID_GITHUB_CREDENTIALS</a></code> | *No description.* |
+| <code><a href="#construct-hub.AlarmPath.RELEASE_NOTES_GITHUB_RATE_LIMIT">RELEASE_NOTES_GITHUB_RATE_LIMIT</a></code> | *No description.* |
+| <code><a href="#construct-hub.AlarmPath.WEBAPP_ACM_CERTIFICATE_EXPIRES_SOON">WEBAPP_ACM_CERTIFICATE_EXPIRES_SOON</a></code> | *No description.* |
+| <code><a href="#construct-hub.AlarmPath.WEBAPP_ENDPOINT_CERTIFICATE_EXPIRES_SOON">WEBAPP_ENDPOINT_CERTIFICATE_EXPIRES_SOON</a></code> | *No description.* |
+
+---
+
+##### `SOURCES_NPMJS_FOLLOWER_FAILURES` <a name="SOURCES_NPMJS_FOLLOWER_FAILURES" id="construct-hub.AlarmPath.SOURCES_NPMJS_FOLLOWER_FAILURES"></a>
+
+---
+
+
+##### `SOURCES_NPMJS_FOLLOWER_NOT_RUNNING` <a name="SOURCES_NPMJS_FOLLOWER_NOT_RUNNING" id="construct-hub.AlarmPath.SOURCES_NPMJS_FOLLOWER_NOT_RUNNING"></a>
+
+---
+
+
+##### `SOURCES_NPMJS_FOLLOWER_NO_CHANGES` <a name="SOURCES_NPMJS_FOLLOWER_NO_CHANGES" id="construct-hub.AlarmPath.SOURCES_NPMJS_FOLLOWER_NO_CHANGES"></a>
+
+---
+
+
+##### `SOURCES_NPMJS_STAGER_DLQ_NOT_EMPTY` <a name="SOURCES_NPMJS_STAGER_DLQ_NOT_EMPTY" id="construct-hub.AlarmPath.SOURCES_NPMJS_STAGER_DLQ_NOT_EMPTY"></a>
+
+---
+
+
+##### `SOURCES_NPMJS_CANARY_SLA_BREACHED` <a name="SOURCES_NPMJS_CANARY_SLA_BREACHED" id="construct-hub.AlarmPath.SOURCES_NPMJS_CANARY_SLA_BREACHED"></a>
+
+---
+
+
+##### `SOURCES_NPMJS_CANARY_STALE_PACKAGE` <a name="SOURCES_NPMJS_CANARY_STALE_PACKAGE" id="construct-hub.AlarmPath.SOURCES_NPMJS_CANARY_STALE_PACKAGE"></a>
+
+---
+
+
+##### `SOURCES_NPMJS_CANARY_FAILING` <a name="SOURCES_NPMJS_CANARY_FAILING" id="construct-hub.AlarmPath.SOURCES_NPMJS_CANARY_FAILING"></a>
+
+---
+
+
+##### `SOURCES_NPMJS_CANARY_NOT_RUNNING` <a name="SOURCES_NPMJS_CANARY_NOT_RUNNING" id="construct-hub.AlarmPath.SOURCES_NPMJS_CANARY_NOT_RUNNING"></a>
+
+---
+
+
+##### `SOURCES_NPMJS_CANARY_NOT_RUNNING_OR_FAILING` <a name="SOURCES_NPMJS_CANARY_NOT_RUNNING_OR_FAILING" id="construct-hub.AlarmPath.SOURCES_NPMJS_CANARY_NOT_RUNNING_OR_FAILING"></a>
+
+---
+
+
+##### `SOURCES_NPMJS_CANARY_GATEWAY_ERRORS` <a name="SOURCES_NPMJS_CANARY_GATEWAY_ERRORS" id="construct-hub.AlarmPath.SOURCES_NPMJS_CANARY_GATEWAY_ERRORS"></a>
+
+---
+
+
+##### `INGESTION_DLQ_NOT_EMPTY` <a name="INGESTION_DLQ_NOT_EMPTY" id="construct-hub.AlarmPath.INGESTION_DLQ_NOT_EMPTY"></a>
+
+---
+
+
+##### `INGESTION_FAILURE` <a name="INGESTION_FAILURE" id="construct-hub.AlarmPath.INGESTION_FAILURE"></a>
+
+---
+
+
+##### `INGESTION_REPROCESS_WORKFLOW_FAILURE` <a name="INGESTION_REPROCESS_WORKFLOW_FAILURE" id="construct-hub.AlarmPath.INGESTION_REPROCESS_WORKFLOW_FAILURE"></a>
+
+---
+
+
+##### `FEED_BUILDER_FAILURE` <a name="FEED_BUILDER_FAILURE" id="construct-hub.AlarmPath.FEED_BUILDER_FAILURE"></a>
+
+---
+
+
+##### `ORCHESTRATION_DLQ_NOT_EMPTY` <a name="ORCHESTRATION_DLQ_NOT_EMPTY" id="construct-hub.AlarmPath.ORCHESTRATION_DLQ_NOT_EMPTY"></a>
+
+---
+
+
+##### `ORCHESTRATION_EXECUTIONS_FAILED` <a name="ORCHESTRATION_EXECUTIONS_FAILED" id="construct-hub.AlarmPath.ORCHESTRATION_EXECUTIONS_FAILED"></a>
+
+---
+
+
+##### `ORCHESTRATION_EXECUTION_FAILURE_RATE` <a name="ORCHESTRATION_EXECUTION_FAILURE_RATE" id="construct-hub.AlarmPath.ORCHESTRATION_EXECUTION_FAILURE_RATE"></a>
+
+---
+
+
+##### `ORCHESTRATION_SHRINKING_CATALOG` <a name="ORCHESTRATION_SHRINKING_CATALOG" id="construct-hub.AlarmPath.ORCHESTRATION_SHRINKING_CATALOG"></a>
+
+---
+
+
+##### `INVENTORY_CANARY_NOT_RUNNING` <a name="INVENTORY_CANARY_NOT_RUNNING" id="construct-hub.AlarmPath.INVENTORY_CANARY_NOT_RUNNING"></a>
+
+---
+
+
+##### `INVENTORY_CANARY_FAILURES` <a name="INVENTORY_CANARY_FAILURES" id="construct-hub.AlarmPath.INVENTORY_CANARY_FAILURES"></a>
+
+---
+
+
+##### `PACKAGE_STATS_FAILURES` <a name="PACKAGE_STATS_FAILURES" id="construct-hub.AlarmPath.PACKAGE_STATS_FAILURES"></a>
+
+---
+
+
+##### `VERSION_TRACKER_FAILURES` <a name="VERSION_TRACKER_FAILURES" id="construct-hub.AlarmPath.VERSION_TRACKER_FAILURES"></a>
+
+---
+
+
+##### `VERSION_TRACKER_NOT_RUNNING` <a name="VERSION_TRACKER_NOT_RUNNING" id="construct-hub.AlarmPath.VERSION_TRACKER_NOT_RUNNING"></a>
+
+---
+
+
+##### `RELEASE_NOTES_GENERATION_FAILURE` <a name="RELEASE_NOTES_GENERATION_FAILURE" id="construct-hub.AlarmPath.RELEASE_NOTES_GENERATION_FAILURE"></a>
+
+---
+
+
+##### `RELEASE_NOTES_TRIGGER_FAILURE` <a name="RELEASE_NOTES_TRIGGER_FAILURE" id="construct-hub.AlarmPath.RELEASE_NOTES_TRIGGER_FAILURE"></a>
+
+---
+
+
+##### `RELEASE_NOTES_INVALID_GITHUB_CREDENTIALS` <a name="RELEASE_NOTES_INVALID_GITHUB_CREDENTIALS" id="construct-hub.AlarmPath.RELEASE_NOTES_INVALID_GITHUB_CREDENTIALS"></a>
+
+---
+
+
+##### `RELEASE_NOTES_GITHUB_RATE_LIMIT` <a name="RELEASE_NOTES_GITHUB_RATE_LIMIT" id="construct-hub.AlarmPath.RELEASE_NOTES_GITHUB_RATE_LIMIT"></a>
+
+---
+
+
+##### `WEBAPP_ACM_CERTIFICATE_EXPIRES_SOON` <a name="WEBAPP_ACM_CERTIFICATE_EXPIRES_SOON" id="construct-hub.AlarmPath.WEBAPP_ACM_CERTIFICATE_EXPIRES_SOON"></a>
+
+---
+
+
+##### `WEBAPP_ENDPOINT_CERTIFICATE_EXPIRES_SOON` <a name="WEBAPP_ENDPOINT_CERTIFICATE_EXPIRES_SOON" id="construct-hub.AlarmPath.WEBAPP_ENDPOINT_CERTIFICATE_EXPIRES_SOON"></a>
+
+---
+
 
 ### AlarmSeverity <a name="AlarmSeverity" id="construct-hub.AlarmSeverity"></a>
 

--- a/API.md
+++ b/API.md
@@ -553,6 +553,9 @@ public readonly actions: IAlarmAction[];
 
 Wire these actions onto the alarm in place of the severity bucket's action.
 
+An empty array falls back to the bucket action — it does NOT mute the
+alarm. To silence an alarm intentionally, supply a no-op action.
+
 ---
 
 ##### `severity`<sup>Optional</sup> <a name="severity" id="construct-hub.AlarmOverride.property.severity"></a>
@@ -837,9 +840,9 @@ public readonly alarmOverrides: {[ key: string ]: AlarmOverride};
 
 Per-alarm overrides keyed by the alarm's CloudWatch display name relative to the `ConstructHub` construct — i.e. the same string a customer sees in tickets and the CloudWatch console (e.g. 'Sources/NpmJs/Canary/NotRunningOrFailing').
 
-For each entry, set `severity` ('HIGH' | 'MEDIUM' | 'LOW') to wire the
-alarm to a different bucket's action, `actions` to supply custom actions
-that bypass the buckets, or both.
+For each entry, set `severity` (`AlarmSeverity.HIGH` / `MEDIUM` / `LOW`)
+to wire the alarm to a different bucket's action, `actions` to supply
+custom actions that bypass the buckets, or both.
 
 Unknown keys are surfaced as synth-time validation errors.
 

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -4814,6 +4814,7 @@ Direct link to function: /lambda/home#/functions/",
             ],
           ],
         },
+        "AlarmName": "Test/ConstructHub/Monitoring/WebCanaryHomePage/Errors",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
         "EvaluationPeriods": 1,
         "Metrics": [
@@ -19190,6 +19191,7 @@ Direct link to function: /lambda/home#/functions/",
             ],
           ],
         },
+        "AlarmName": "Test/ConstructHub/Monitoring/WebCanaryHomePage/Errors",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
         "EvaluationPeriods": 1,
         "Metrics": [
@@ -33276,6 +33278,7 @@ Direct link to function: /lambda/home#/functions/",
             ],
           ],
         },
+        "AlarmName": "Test/ConstructHub/Monitoring/WebCanaryHomePage/Errors",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
         "EvaluationPeriods": 1,
         "Metrics": [
@@ -47446,6 +47449,7 @@ Direct link to function: /lambda/home#/functions/",
             ],
           ],
         },
+        "AlarmName": "Test/ConstructHub/Monitoring/WebCanaryHomePage/Errors",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
         "EvaluationPeriods": 1,
         "Metrics": [
@@ -55432,6 +55436,7 @@ function handler(event) {
             ],
           ],
         },
+        "AlarmName": "Test/ConstructHub/WebApp/ExpirationMonitor/ACMCertificateExpiresSoon",
         "ComparisonOperator": "LessThanThreshold",
         "Dimensions": [
           {
@@ -55500,6 +55505,7 @@ function handler(event) {
           "arn:aws:sns:us-east-1:123456789012:mystack-mytopic-NZJ5JSMVGFIE",
         ],
         "AlarmDescription": "The certificate used to serve my.construct.hub will expire in less than 45 days!",
+        "AlarmName": "Test/ConstructHub/WebApp/ExpirationMonitor/EndpointCertificateExpiresSoon",
         "ComparisonOperator": "LessThanThreshold",
         "Dimensions": [
           {
@@ -61907,6 +61913,7 @@ Direct link to function: /lambda/home#/functions/",
             ],
           ],
         },
+        "AlarmName": "Test/ConstructHub/Monitoring/WebCanaryHomePage/Errors",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
         "EvaluationPeriods": 1,
         "Metrics": [

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -5430,6 +5430,7 @@ Direct link to function: /lambda/home#/functions/",
             ],
           ],
         },
+        "AlarmName": "dev/ConstructHub/Monitoring/WebCanaryHomePage/Errors",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
         "EvaluationPeriods": 1,
         "Metrics": [

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -2556,6 +2556,11 @@ def sort_filter_rules(json_obj):
     },
     "ConstructHubFeedBuilderFailureAlarmA4E080D6": {
       "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "HighSeverityTopicC74B35F8",
+          },
+        ],
         "AlarmDescription": {
           "Fn::Join": [
             "",
@@ -2970,6 +2975,11 @@ Direct link to the function: /lambda/home#/functions/",
     },
     "ConstructHubIngestionDLQAlarm83BD1903": {
       "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "MyCustomTopic6CE14E59",
+          },
+        ],
         "AlarmDescription": {
           "Fn::Join": [
             "",
@@ -3170,6 +3180,11 @@ Direct link to the function: /lambda/home#/functions/",
     },
     "ConstructHubIngestionFailureAlarm9D0028DD": {
       "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "HighSeverityTopicC74B35F8",
+          },
+        ],
         "AlarmDescription": {
           "Fn::Join": [
             "",
@@ -5033,7 +5048,18 @@ Direct link to function: /lambda/home#/functions/",
           "Fn::Join": [
             "",
             [
-              "{"widgets":[{"type":"metric","width":24,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"Feed builder failures","region":"",
+              "{"widgets":[{"type":"metric","width":24,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"PackageStats Failures","region":"",
+              {
+                "Ref": "AWS::Region",
+              },
+              "","annotations":{"alarms":["",
+              {
+                "Fn::GetAtt": [
+                  "ConstructHubPackageStatsFailures833C3D9B",
+                  "Arn",
+                ],
+              },
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":6,"properties":{"view":"timeSeries","title":"Feed builder failures","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -5044,7 +5070,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":6,"properties":{"view":"timeSeries","title":"Catalog Size Shrunk","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":12,"properties":{"view":"timeSeries","title":"Catalog Size Shrunk","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -5055,7 +5081,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":12,"properties":{"view":"timeSeries","title":"Backend Orchestration Failed","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":18,"properties":{"view":"timeSeries","title":"Backend Orchestration Failed","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -5066,7 +5092,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":18,"properties":{"view":"timeSeries","title":"Execution Failure Rate above 75%","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":24,"properties":{"view":"timeSeries","title":"Execution Failure Rate above 75%","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -5077,7 +5103,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":24,"properties":{"view":"timeSeries","title":"ReleaseNotes generation Failure","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":30,"properties":{"view":"timeSeries","title":"ReleaseNotes generation Failure","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -5088,7 +5114,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":30,"properties":{"view":"timeSeries","title":"ReleaseNotes Github credential invalid","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":36,"properties":{"view":"timeSeries","title":"ReleaseNotes Github credential invalid","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -5099,7 +5125,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":36,"properties":{"view":"timeSeries","title":"Ingestion failures","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":42,"properties":{"view":"timeSeries","title":"Ingestion failures","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -5110,7 +5136,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":42,"properties":{"view":"timeSeries","title":"Home Page Canary","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":48,"properties":{"view":"timeSeries","title":"Home Page Canary","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -5121,7 +5147,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":48,"properties":{"view":"timeSeries","title":"NpmJs/Follower Not Running","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":54,"properties":{"view":"timeSeries","title":"NpmJs/Follower Not Running","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -5129,17 +5155,6 @@ Direct link to function: /lambda/home#/functions/",
               {
                 "Fn::GetAtt": [
                   "ConstructHubSourcesNpmJsFollowerNotRunningCEAF0E1E",
-                  "Arn",
-                ],
-              },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":54,"properties":{"view":"timeSeries","title":"NpmJs Follower Canary is not running or fails","region":"",
-              {
-                "Ref": "AWS::Region",
-              },
-              "","annotations":{"alarms":["",
-              {
-                "Fn::GetAtt": [
-                  "ConstructHubSourcesNpmJsCanaryNotRunningOrFailing62A8E2F6",
                   "Arn",
                 ],
               },
@@ -5415,6 +5430,11 @@ Direct link to function: /lambda/home#/functions/",
     },
     "ConstructHubMonitoringWebCanaryHomePageErrorsE7BB4002": {
       "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "HighSeverityTopicC74B35F8",
+          },
+        ],
         "AlarmDescription": {
           "Fn::Join": [
             "",
@@ -5920,6 +5940,11 @@ Direct link to function: /lambda/home#/functions/",
     },
     "ConstructHubOrchestrationCatalogBuilderShrinkingCatalogAlarm48329E25": {
       "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "HighSeverityTopicC74B35F8",
+          },
+        ],
         "AlarmDescription": {
           "Fn::Join": [
             "",
@@ -6283,6 +6308,11 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
     },
     "ConstructHubOrchestrationFailureRateAlarm3E65EEE1": {
       "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "HighSeverityTopicC74B35F8",
+          },
+        ],
         "AlarmDescription": "Execution Failure Rate above 75%",
         "AlarmName": "dev/ConstructHub/Orchestration/Resource/ExecutionFailureRate",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -6469,6 +6499,11 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
     },
     "ConstructHubOrchestrationOrchestrationFailed5AF50838": {
       "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "HighSeverityTopicC74B35F8",
+          },
+        ],
         "AlarmDescription": {
           "Fn::Join": [
             "",
@@ -10246,6 +10281,11 @@ Request a service quota increase for lambda functions",
     },
     "ConstructHubPackageStatsFailures833C3D9B": {
       "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "MyCustomTopic6CE14E59",
+          },
+        ],
         "AlarmDescription": "The package stats state machine failed!
 
 RunBook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md",
@@ -10602,6 +10642,11 @@ RunBook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
     },
     "ConstructHubReleaseNotesReleaseNotesGenerationFailure04ABD01D": {
       "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "HighSeverityTopicC74B35F8",
+          },
+        ],
         "AlarmDescription": {
           "Fn::Join": [
             "",
@@ -10685,6 +10730,11 @@ Consider either using GitHub application.",
     },
     "ConstructHubReleaseNotesReleaseNotesInvalidGitHubCredentialsE84D7534": {
       "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "HighSeverityTopicC74B35F8",
+          },
+        ],
         "AlarmDescription": "Release notes generation is failing due to Invalid GitHub token
 
 RunBook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md
@@ -11529,6 +11579,11 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "ConstructHubLicenseListCustomResource323F0FD4",
       ],
       "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "MediumSeverityTopic52CBAF3D",
+          },
+        ],
         "AlarmDescription": "The NpmJs package canary is not running or is failing. This prevents alarming when this instance of
 ConstructHub falls out of SLA for new package ingestion!
 
@@ -11705,6 +11760,11 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "ConstructHubLicenseListCustomResource323F0FD4",
       ],
       "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "MediumSeverityTopic52CBAF3D",
+          },
+        ],
         "AlarmDescription": "The canary package construct-hub-probe has not published a new version in over 1 day.
 This means the SLA alarm is blind — no new versions are being tracked, so SLA breaches cannot be detected.
 Metric: ConstructHub/PackageCanary / TimeSinceLastPublish
@@ -11794,6 +11854,11 @@ Direct link to Lambda function: /lambda/home#/functions/",
         "ConstructHubSourcesNpmJsSchedule34031870",
       ],
       "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "HighSeverityTopicC74B35F8",
+          },
+        ],
         "AlarmDescription": {
           "Fn::Join": [
             "",
@@ -17658,6 +17723,9 @@ function handler(event) {
       },
       "Type": "AWS::IAM::Role",
     },
+    "HighSeverityTopicC74B35F8": {
+      "Type": "AWS::SNS::Topic",
+    },
     "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A": {
       "DependsOn": [
         "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB",
@@ -17744,6 +17812,12 @@ function handler(event) {
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "MediumSeverityTopic52CBAF3D": {
+      "Type": "AWS::SNS::Topic",
+    },
+    "MyCustomTopic6CE14E59": {
+      "Type": "AWS::SNS::Topic",
     },
     "PackageVersionsTableWidgetHandler5fa848259c1d5e388c0df69f05c016dfBE2C27C2": {
       "DependsOn": [

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -2556,11 +2556,6 @@ def sort_filter_rules(json_obj):
     },
     "ConstructHubFeedBuilderFailureAlarmA4E080D6": {
       "Properties": {
-        "AlarmActions": [
-          {
-            "Ref": "HighSeverityTopicC74B35F8",
-          },
-        ],
         "AlarmDescription": {
           "Fn::Join": [
             "",
@@ -2975,11 +2970,6 @@ Direct link to the function: /lambda/home#/functions/",
     },
     "ConstructHubIngestionDLQAlarm83BD1903": {
       "Properties": {
-        "AlarmActions": [
-          {
-            "Ref": "MyCustomTopic6CE14E59",
-          },
-        ],
         "AlarmDescription": {
           "Fn::Join": [
             "",
@@ -3180,11 +3170,6 @@ Direct link to the function: /lambda/home#/functions/",
     },
     "ConstructHubIngestionFailureAlarm9D0028DD": {
       "Properties": {
-        "AlarmActions": [
-          {
-            "Ref": "HighSeverityTopicC74B35F8",
-          },
-        ],
         "AlarmDescription": {
           "Fn::Join": [
             "",
@@ -5048,18 +5033,7 @@ Direct link to function: /lambda/home#/functions/",
           "Fn::Join": [
             "",
             [
-              "{"widgets":[{"type":"metric","width":24,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"PackageStats Failures","region":"",
-              {
-                "Ref": "AWS::Region",
-              },
-              "","annotations":{"alarms":["",
-              {
-                "Fn::GetAtt": [
-                  "ConstructHubPackageStatsFailures833C3D9B",
-                  "Arn",
-                ],
-              },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":6,"properties":{"view":"timeSeries","title":"Feed builder failures","region":"",
+              "{"widgets":[{"type":"metric","width":24,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"Feed builder failures","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -5070,7 +5044,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":12,"properties":{"view":"timeSeries","title":"Catalog Size Shrunk","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":6,"properties":{"view":"timeSeries","title":"Catalog Size Shrunk","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -5081,7 +5055,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":18,"properties":{"view":"timeSeries","title":"Backend Orchestration Failed","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":12,"properties":{"view":"timeSeries","title":"Backend Orchestration Failed","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -5092,7 +5066,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":24,"properties":{"view":"timeSeries","title":"Execution Failure Rate above 75%","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":18,"properties":{"view":"timeSeries","title":"Execution Failure Rate above 75%","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -5103,7 +5077,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":30,"properties":{"view":"timeSeries","title":"ReleaseNotes generation Failure","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":24,"properties":{"view":"timeSeries","title":"ReleaseNotes generation Failure","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -5114,7 +5088,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":36,"properties":{"view":"timeSeries","title":"ReleaseNotes Github credential invalid","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":30,"properties":{"view":"timeSeries","title":"ReleaseNotes Github credential invalid","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -5125,7 +5099,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":42,"properties":{"view":"timeSeries","title":"Ingestion failures","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":36,"properties":{"view":"timeSeries","title":"Ingestion failures","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -5136,7 +5110,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":48,"properties":{"view":"timeSeries","title":"Home Page Canary","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":42,"properties":{"view":"timeSeries","title":"Home Page Canary","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -5147,7 +5121,7 @@ Direct link to function: /lambda/home#/functions/",
                   "Arn",
                 ],
               },
-              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":54,"properties":{"view":"timeSeries","title":"NpmJs/Follower Not Running","region":"",
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":48,"properties":{"view":"timeSeries","title":"NpmJs/Follower Not Running","region":"",
               {
                 "Ref": "AWS::Region",
               },
@@ -5155,6 +5129,17 @@ Direct link to function: /lambda/home#/functions/",
               {
                 "Fn::GetAtt": [
                   "ConstructHubSourcesNpmJsFollowerNotRunningCEAF0E1E",
+                  "Arn",
+                ],
+              },
+              ""]},"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":54,"properties":{"view":"timeSeries","title":"NpmJs Follower Canary is not running or fails","region":"",
+              {
+                "Ref": "AWS::Region",
+              },
+              "","annotations":{"alarms":["",
+              {
+                "Fn::GetAtt": [
+                  "ConstructHubSourcesNpmJsCanaryNotRunningOrFailing62A8E2F6",
                   "Arn",
                 ],
               },
@@ -5430,11 +5415,6 @@ Direct link to function: /lambda/home#/functions/",
     },
     "ConstructHubMonitoringWebCanaryHomePageErrorsE7BB4002": {
       "Properties": {
-        "AlarmActions": [
-          {
-            "Ref": "HighSeverityTopicC74B35F8",
-          },
-        ],
         "AlarmDescription": {
           "Fn::Join": [
             "",
@@ -5940,11 +5920,6 @@ Direct link to function: /lambda/home#/functions/",
     },
     "ConstructHubOrchestrationCatalogBuilderShrinkingCatalogAlarm48329E25": {
       "Properties": {
-        "AlarmActions": [
-          {
-            "Ref": "HighSeverityTopicC74B35F8",
-          },
-        ],
         "AlarmDescription": {
           "Fn::Join": [
             "",
@@ -6308,11 +6283,6 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
     },
     "ConstructHubOrchestrationFailureRateAlarm3E65EEE1": {
       "Properties": {
-        "AlarmActions": [
-          {
-            "Ref": "HighSeverityTopicC74B35F8",
-          },
-        ],
         "AlarmDescription": "Execution Failure Rate above 75%",
         "AlarmName": "dev/ConstructHub/Orchestration/Resource/ExecutionFailureRate",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -6499,11 +6469,6 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
     },
     "ConstructHubOrchestrationOrchestrationFailed5AF50838": {
       "Properties": {
-        "AlarmActions": [
-          {
-            "Ref": "HighSeverityTopicC74B35F8",
-          },
-        ],
         "AlarmDescription": {
           "Fn::Join": [
             "",
@@ -10281,11 +10246,6 @@ Request a service quota increase for lambda functions",
     },
     "ConstructHubPackageStatsFailures833C3D9B": {
       "Properties": {
-        "AlarmActions": [
-          {
-            "Ref": "MyCustomTopic6CE14E59",
-          },
-        ],
         "AlarmDescription": "The package stats state machine failed!
 
 RunBook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md",
@@ -10642,11 +10602,6 @@ RunBook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
     },
     "ConstructHubReleaseNotesReleaseNotesGenerationFailure04ABD01D": {
       "Properties": {
-        "AlarmActions": [
-          {
-            "Ref": "HighSeverityTopicC74B35F8",
-          },
-        ],
         "AlarmDescription": {
           "Fn::Join": [
             "",
@@ -10730,11 +10685,6 @@ Consider either using GitHub application.",
     },
     "ConstructHubReleaseNotesReleaseNotesInvalidGitHubCredentialsE84D7534": {
       "Properties": {
-        "AlarmActions": [
-          {
-            "Ref": "HighSeverityTopicC74B35F8",
-          },
-        ],
         "AlarmDescription": "Release notes generation is failing due to Invalid GitHub token
 
 RunBook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runbook.md
@@ -11579,11 +11529,6 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "ConstructHubLicenseListCustomResource323F0FD4",
       ],
       "Properties": {
-        "AlarmActions": [
-          {
-            "Ref": "MediumSeverityTopic52CBAF3D",
-          },
-        ],
         "AlarmDescription": "The NpmJs package canary is not running or is failing. This prevents alarming when this instance of
 ConstructHub falls out of SLA for new package ingestion!
 
@@ -11760,11 +11705,6 @@ Runbook: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
         "ConstructHubLicenseListCustomResource323F0FD4",
       ],
       "Properties": {
-        "AlarmActions": [
-          {
-            "Ref": "MediumSeverityTopic52CBAF3D",
-          },
-        ],
         "AlarmDescription": "The canary package construct-hub-probe has not published a new version in over 1 day.
 This means the SLA alarm is blind — no new versions are being tracked, so SLA breaches cannot be detected.
 Metric: ConstructHub/PackageCanary / TimeSinceLastPublish
@@ -11854,11 +11794,6 @@ Direct link to Lambda function: /lambda/home#/functions/",
         "ConstructHubSourcesNpmJsSchedule34031870",
       ],
       "Properties": {
-        "AlarmActions": [
-          {
-            "Ref": "HighSeverityTopicC74B35F8",
-          },
-        ],
         "AlarmDescription": {
           "Fn::Join": [
             "",
@@ -17723,9 +17658,6 @@ function handler(event) {
       },
       "Type": "AWS::IAM::Role",
     },
-    "HighSeverityTopicC74B35F8": {
-      "Type": "AWS::SNS::Topic",
-    },
     "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A": {
       "DependsOn": [
         "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB",
@@ -17812,12 +17744,6 @@ function handler(event) {
         ],
       },
       "Type": "AWS::IAM::Policy",
-    },
-    "MediumSeverityTopic52CBAF3D": {
-      "Type": "AWS::SNS::Topic",
-    },
-    "MyCustomTopic6CE14E59": {
-      "Type": "AWS::SNS::Topic",
     },
     "PackageVersionsTableWidgetHandler5fa848259c1d5e388c0df69f05c016dfBE2C27C2": {
       "DependsOn": [

--- a/src/__tests__/devapp/dev-stack.ts
+++ b/src/__tests__/devapp/dev-stack.ts
@@ -1,8 +1,10 @@
 import * as path from 'path';
 import * as process from 'process';
 import { Stack } from 'aws-cdk-lib';
+import { SnsAction } from 'aws-cdk-lib/aws-cloudwatch-actions';
 import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import * as secretsManager from 'aws-cdk-lib/aws-secretsmanager';
+import * as sns from 'aws-cdk-lib/aws-sns';
 import { Construct } from 'constructs';
 import * as dotenv from 'dotenv';
 import { ConstructHub, Isolation } from '../..';
@@ -108,10 +110,30 @@ export class DevStack extends Stack {
     const sensitiveTaskIsolation =
       props.sensitiveTaskIsolation ?? defaultIsolateSensitiveTasks();
 
+    // Manual-test scaffolding for #1599 alarm overrides.
+    const highTopic = new sns.Topic(this, 'HighSeverityTopic');
+    const mediumTopic = new sns.Topic(this, 'MediumSeverityTopic');
+    const customTopic = new sns.Topic(this, 'MyCustomTopic');
+
     new ConstructHub(this, 'ConstructHub', {
       featureFlags: {
         homeRedesign: true,
         searchRedesign: true,
+      },
+      alarmActions: {
+        highSeverityAction: new SnsAction(highTopic),
+        mediumSeverityAction: new SnsAction(mediumTopic),
+      },
+      alarmOverrides: {
+        // Severity-only — should wire MediumSeverityTopic, not High.
+        'Sources/NpmJs/Canary/NotRunningOrFailing': { severity: 'MEDIUM' },
+        // Actions-only — should wire MyCustomTopic, bypass both buckets.
+        'Ingestion/DLQNotEmpty': { actions: [new SnsAction(customTopic)] },
+        // Both — wires MyCustomTopic AND keeps the alarm on the high-sev dashboard.
+        'PackageStats/Failures': {
+          severity: 'HIGH',
+          actions: [new SnsAction(customTopic)],
+        },
       },
       denyList: [
         {

--- a/src/__tests__/devapp/dev-stack.ts
+++ b/src/__tests__/devapp/dev-stack.ts
@@ -1,10 +1,8 @@
 import * as path from 'path';
 import * as process from 'process';
 import { Stack } from 'aws-cdk-lib';
-import { SnsAction } from 'aws-cdk-lib/aws-cloudwatch-actions';
 import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import * as secretsManager from 'aws-cdk-lib/aws-secretsmanager';
-import * as sns from 'aws-cdk-lib/aws-sns';
 import { Construct } from 'constructs';
 import * as dotenv from 'dotenv';
 import { ConstructHub, Isolation } from '../..';
@@ -110,30 +108,10 @@ export class DevStack extends Stack {
     const sensitiveTaskIsolation =
       props.sensitiveTaskIsolation ?? defaultIsolateSensitiveTasks();
 
-    // Manual-test scaffolding for #1599 alarm overrides.
-    const highTopic = new sns.Topic(this, 'HighSeverityTopic');
-    const mediumTopic = new sns.Topic(this, 'MediumSeverityTopic');
-    const customTopic = new sns.Topic(this, 'MyCustomTopic');
-
     new ConstructHub(this, 'ConstructHub', {
       featureFlags: {
         homeRedesign: true,
         searchRedesign: true,
-      },
-      alarmActions: {
-        highSeverityAction: new SnsAction(highTopic),
-        mediumSeverityAction: new SnsAction(mediumTopic),
-      },
-      alarmOverrides: {
-        // Severity-only — should wire MediumSeverityTopic, not High.
-        'Sources/NpmJs/Canary/NotRunningOrFailing': { severity: 'MEDIUM' },
-        // Actions-only — should wire MyCustomTopic, bypass both buckets.
-        'Ingestion/DLQNotEmpty': { actions: [new SnsAction(customTopic)] },
-        // Both — wires MyCustomTopic AND keeps the alarm on the high-sev dashboard.
-        'PackageStats/Failures': {
-          severity: 'HIGH',
-          actions: [new SnsAction(customTopic)],
-        },
       },
       denyList: [
         {

--- a/src/__tests__/monitoring.test.ts
+++ b/src/__tests__/monitoring.test.ts
@@ -423,7 +423,5 @@ test('alarm overrides: alarm without explicit alarmName fails synth', () => {
   }).addHighSeverityAlarm('Alarm', alarm);
 
   // THEN: synth flags the missing alarmName
-  expect(() => Template.fromStack(stack)).toThrow(
-    /has no explicit alarmName/
-  );
+  expect(() => Template.fromStack(stack)).toThrow(/has no explicit alarmName/);
 });

--- a/src/__tests__/monitoring.test.ts
+++ b/src/__tests__/monitoring.test.ts
@@ -432,22 +432,3 @@ test('alarm overrides: alarms with explicit name and no override use the bucket 
   });
 });
 
-test('alarm overrides: alarm without explicit alarmName fails synth when overrides are set', () => {
-  // GIVEN
-  const stack = new Stack(undefined, 'TestStack');
-  const alarm = new Alarm(stack, 'Alarm', {
-    // no alarmName set
-    evaluationPeriods: 1,
-    metric: new Metric({ metricName: 'M', namespace: 'N' }),
-    threshold: 0,
-  });
-
-  // Any non-empty alarmOverrides activates the validator.
-  new Monitoring(stack, 'Monitoring', {
-    alarmActions: { highSeverity: 'arn:high' },
-    alarmOverrides: { 'Some/Other/Alarm': { severity: AlarmSeverity.LOW } },
-  }).addHighSeverityAlarm('Alarm', alarm);
-
-  // THEN: synth flags the missing alarmName
-  expect(() => Template.fromStack(stack)).toThrow(/has no explicit alarmName/);
-});

--- a/src/__tests__/monitoring.test.ts
+++ b/src/__tests__/monitoring.test.ts
@@ -3,7 +3,6 @@ import { Match, Template } from 'aws-cdk-lib/assertions';
 import { IAlarmAction, Alarm, Metric } from 'aws-cdk-lib/aws-cloudwatch';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as sns from 'aws-cdk-lib/aws-sns';
-import { AlarmSeverity } from '../api';
 import { Monitoring } from '../monitoring';
 
 const actions = {
@@ -272,6 +271,7 @@ test('alarm overrides: severity-only override wires the new bucket action', () =
   // GIVEN
   const stack = new Stack(undefined, 'TestStack');
   const alarm = new Alarm(stack, 'Alarm', {
+    alarmName: 'TestStack/Alarm',
     evaluationPeriods: 1,
     metric: new Metric({ metricName: 'M', namespace: 'N' }),
     threshold: 0,
@@ -284,7 +284,7 @@ test('alarm overrides: severity-only override wires the new bucket action', () =
       mediumSeverity: 'arn:medium',
     },
     alarmOverrides: {
-      Alarm: { severity: AlarmSeverity.MEDIUM },
+      Alarm: { severity: 'MEDIUM' },
     },
   }).addHighSeverityAlarm('Alarm', alarm);
 
@@ -298,6 +298,7 @@ test('alarm overrides: actions-only override replaces the bucket action', () => 
   // GIVEN
   const stack = new Stack(undefined, 'TestStack');
   const alarm = new Alarm(stack, 'Alarm', {
+    alarmName: 'TestStack/Alarm',
     evaluationPeriods: 1,
     metric: new Metric({ metricName: 'M', namespace: 'N' }),
     threshold: 0,
@@ -324,6 +325,7 @@ test('alarm overrides: severity + actions wires custom action and uses new dashb
   // GIVEN
   const stack = new Stack(undefined, 'TestStack');
   const alarm = new Alarm(stack, 'Alarm', {
+    alarmName: 'TestStack/Alarm',
     evaluationPeriods: 1,
     metric: new Metric({ metricName: 'M', namespace: 'N' }),
     threshold: 0,
@@ -336,7 +338,7 @@ test('alarm overrides: severity + actions wires custom action and uses new dashb
   const monitoring = new Monitoring(stack, 'Monitoring', {
     alarmActions: { highSeverity: 'arn:high', normalSeverity: 'arn:normal' },
     alarmOverrides: {
-      Alarm: { severity: AlarmSeverity.HIGH, actions: [customAction] },
+      Alarm: { severity: 'HIGH', actions: [customAction] },
     },
   });
   monitoring.addLowSeverityAlarm('Alarm', alarm);
@@ -353,25 +355,25 @@ test('alarm overrides: severity + actions wires custom action and uses new dashb
   expect(monitoring.lowSeverityAlarms).toEqual([]);
 });
 
-test('alarm overrides: unmatched key is a silent no-op', () => {
+test('alarm overrides: unknown key fails synth-time validation', () => {
   // GIVEN
   const stack = new Stack(undefined, 'TestStack');
   const alarm = new Alarm(stack, 'Alarm', {
+    alarmName: 'TestStack/Alarm',
     evaluationPeriods: 1,
     metric: new Metric({ metricName: 'M', namespace: 'N' }),
     threshold: 0,
   });
 
-  // WHEN: an override entry for a non-existent path
   new Monitoring(stack, 'Monitoring', {
     alarmActions: { highSeverity: 'arn:high' },
     alarmOverrides: {
-      'NonExistent/Alarm': { severity: AlarmSeverity.LOW },
+      'NonExistent/Alarm': { severity: 'LOW' },
     },
   }).addHighSeverityAlarm('Alarm', alarm);
 
-  // THEN: default bucket behavior — high bucket's action is wired
-  Template.fromStack(stack).hasResourceProperties('AWS::CloudWatch::Alarm', {
-    AlarmActions: ['arn:high'],
-  });
+  // THEN: synth surfaces an error pointing at the unknown key
+  expect(() => Template.fromStack(stack)).toThrow(
+    /alarmOverrides: 'NonExistent\/Alarm' did not match/
+  );
 });

--- a/src/__tests__/monitoring.test.ts
+++ b/src/__tests__/monitoring.test.ts
@@ -329,6 +329,30 @@ test('alarm overrides: actions-only override replaces the bucket action', () => 
   });
 });
 
+test('alarm overrides: empty actions array falls back to the bucket action', () => {
+  // GIVEN
+  const stack = new Stack(undefined, 'TestStack');
+  const alarm = new Alarm(stack, 'Alarm', {
+    alarmName: 'TestStack/Alarm',
+    evaluationPeriods: 1,
+    metric: new Metric({ metricName: 'M', namespace: 'N' }),
+    threshold: 0,
+  });
+
+  // WHEN: override sets actions: [] (does not silently mute the alarm)
+  new Monitoring(stack, 'Monitoring', {
+    alarmActions: { highSeverity: 'arn:high' },
+    alarmOverrides: {
+      Alarm: { actions: [] },
+    },
+  }).addHighSeverityAlarm('Alarm', alarm);
+
+  // THEN: bucket action is still wired
+  Template.fromStack(stack).hasResourceProperties('AWS::CloudWatch::Alarm', {
+    AlarmActions: ['arn:high'],
+  });
+});
+
 test('alarm overrides: severity + actions wires custom action and uses new dashboard placement', () => {
   // GIVEN
   const stack = new Stack(undefined, 'TestStack');
@@ -382,7 +406,7 @@ test('alarm overrides: unknown key fails synth-time validation', () => {
 
   // THEN: synth surfaces an error pointing at the unknown key
   expect(() => Template.fromStack(stack)).toThrow(
-    /alarmOverrides: 'NonExistent\/Alarm' did not match/
+    /alarmOverrides: 'NonExistent\/Alarm' did not match any alarm/
   );
 });
 
@@ -408,7 +432,7 @@ test('alarm overrides: alarms with explicit name and no override use the bucket 
   });
 });
 
-test('alarm overrides: alarm without explicit alarmName fails synth', () => {
+test('alarm overrides: alarm without explicit alarmName fails synth when overrides are set', () => {
   // GIVEN
   const stack = new Stack(undefined, 'TestStack');
   const alarm = new Alarm(stack, 'Alarm', {
@@ -418,8 +442,10 @@ test('alarm overrides: alarm without explicit alarmName fails synth', () => {
     threshold: 0,
   });
 
+  // Any non-empty alarmOverrides activates the validator.
   new Monitoring(stack, 'Monitoring', {
     alarmActions: { highSeverity: 'arn:high' },
+    alarmOverrides: { 'Some/Other/Alarm': { severity: AlarmSeverity.LOW } },
   }).addHighSeverityAlarm('Alarm', alarm);
 
   // THEN: synth flags the missing alarmName

--- a/src/__tests__/monitoring.test.ts
+++ b/src/__tests__/monitoring.test.ts
@@ -3,6 +3,7 @@ import { Match, Template } from 'aws-cdk-lib/assertions';
 import { IAlarmAction, Alarm, Metric } from 'aws-cdk-lib/aws-cloudwatch';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as sns from 'aws-cdk-lib/aws-sns';
+import { AlarmSeverity } from '../api';
 import { Monitoring } from '../monitoring';
 
 const actions = {
@@ -264,5 +265,113 @@ test('medium-severity alarm actions are registered', () => {
   // THEN
   Template.fromStack(stack).hasResourceProperties('AWS::CloudWatch::Alarm', {
     AlarmActions: [mediumSeverity, mediumSeverityActionArn],
+  });
+});
+
+test('alarm overrides: severity-only override wires the new bucket action', () => {
+  // GIVEN
+  const stack = new Stack(undefined, 'TestStack');
+  const alarm = new Alarm(stack, 'Alarm', {
+    evaluationPeriods: 1,
+    metric: new Metric({ metricName: 'M', namespace: 'N' }),
+    threshold: 0,
+  });
+
+  // WHEN: alarm registered as HIGH, override redirects to MEDIUM
+  new Monitoring(stack, 'Monitoring', {
+    alarmActions: {
+      highSeverity: 'arn:high',
+      mediumSeverity: 'arn:medium',
+    },
+    alarmOverrides: {
+      Alarm: { severity: AlarmSeverity.MEDIUM },
+    },
+  }).addHighSeverityAlarm('Alarm', alarm);
+
+  // THEN: medium bucket's action wired, not high
+  Template.fromStack(stack).hasResourceProperties('AWS::CloudWatch::Alarm', {
+    AlarmActions: ['arn:medium'],
+  });
+});
+
+test('alarm overrides: actions-only override replaces the bucket action', () => {
+  // GIVEN
+  const stack = new Stack(undefined, 'TestStack');
+  const alarm = new Alarm(stack, 'Alarm', {
+    evaluationPeriods: 1,
+    metric: new Metric({ metricName: 'M', namespace: 'N' }),
+    threshold: 0,
+  });
+  const customAction: IAlarmAction = {
+    bind: () => ({ alarmActionArn: 'arn:custom' }),
+  };
+
+  // WHEN: alarm registered as HIGH, override supplies a custom action
+  new Monitoring(stack, 'Monitoring', {
+    alarmActions: { highSeverity: 'arn:high' },
+    alarmOverrides: {
+      Alarm: { actions: [customAction] },
+    },
+  }).addHighSeverityAlarm('Alarm', alarm);
+
+  // THEN: only the custom action is wired
+  Template.fromStack(stack).hasResourceProperties('AWS::CloudWatch::Alarm', {
+    AlarmActions: ['arn:custom'],
+  });
+});
+
+test('alarm overrides: severity + actions wires custom action and uses new dashboard placement', () => {
+  // GIVEN
+  const stack = new Stack(undefined, 'TestStack');
+  const alarm = new Alarm(stack, 'Alarm', {
+    evaluationPeriods: 1,
+    metric: new Metric({ metricName: 'M', namespace: 'N' }),
+    threshold: 0,
+  });
+  const customAction: IAlarmAction = {
+    bind: () => ({ alarmActionArn: 'arn:custom' }),
+  };
+
+  // WHEN: alarm registered as LOW, override sets HIGH severity AND custom action
+  const monitoring = new Monitoring(stack, 'Monitoring', {
+    alarmActions: { highSeverity: 'arn:high', normalSeverity: 'arn:normal' },
+    alarmOverrides: {
+      Alarm: { severity: AlarmSeverity.HIGH, actions: [customAction] },
+    },
+  });
+  monitoring.addLowSeverityAlarm('Alarm', alarm);
+
+  // THEN: custom action wired (replacing both buckets)
+  Template.fromStack(stack).hasResourceProperties('AWS::CloudWatch::Alarm', {
+    AlarmActions: ['arn:custom'],
+  });
+
+  // AND: alarm appears in the high-severity getter (post-override severity)
+  expect(monitoring.highSeverityAlarms.map((a) => a.alarmArn)).toEqual([
+    alarm.alarmArn,
+  ]);
+  expect(monitoring.lowSeverityAlarms).toEqual([]);
+});
+
+test('alarm overrides: unmatched key is a silent no-op', () => {
+  // GIVEN
+  const stack = new Stack(undefined, 'TestStack');
+  const alarm = new Alarm(stack, 'Alarm', {
+    evaluationPeriods: 1,
+    metric: new Metric({ metricName: 'M', namespace: 'N' }),
+    threshold: 0,
+  });
+
+  // WHEN: an override entry for a non-existent path
+  new Monitoring(stack, 'Monitoring', {
+    alarmActions: { highSeverity: 'arn:high' },
+    alarmOverrides: {
+      'NonExistent/Alarm': { severity: AlarmSeverity.LOW },
+    },
+  }).addHighSeverityAlarm('Alarm', alarm);
+
+  // THEN: default bucket behavior — high bucket's action is wired
+  Template.fromStack(stack).hasResourceProperties('AWS::CloudWatch::Alarm', {
+    AlarmActions: ['arn:high'],
   });
 });

--- a/src/__tests__/monitoring.test.ts
+++ b/src/__tests__/monitoring.test.ts
@@ -431,4 +431,3 @@ test('alarm overrides: alarms with explicit name and no override use the bucket 
     AlarmActions: ['arn:high'],
   });
 });
-

--- a/src/__tests__/monitoring.test.ts
+++ b/src/__tests__/monitoring.test.ts
@@ -3,6 +3,7 @@ import { Match, Template } from 'aws-cdk-lib/assertions';
 import { IAlarmAction, Alarm, Metric } from 'aws-cdk-lib/aws-cloudwatch';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as sns from 'aws-cdk-lib/aws-sns';
+import { AlarmSeverity } from '../api';
 import { Monitoring } from '../monitoring';
 
 const actions = {
@@ -60,7 +61,11 @@ test('high severity alarms trigger the correct action', () => {
   });
   const alarm = topic
     .metricNumberOfNotificationsFailed()
-    .createAlarm(stack, 'Alarm', { threshold: 1, evaluationPeriods: 1 });
+    .createAlarm(stack, 'Alarm', {
+      alarmName: `${stack.node.path}/Alarm`,
+      threshold: 1,
+      evaluationPeriods: 1,
+    });
 
   // WHEN
   monitoring.addHighSeverityAlarm('My Alarm', alarm);
@@ -184,6 +189,7 @@ test('normal-severity alarm actions are registered', () => {
   // GIVEN
   const stack = new Stack(undefined, 'TestStack');
   const alarm = new Alarm(stack, 'Alarm', {
+    alarmName: `${stack.node.path}/Alarm`,
     evaluationPeriods: 1,
     metric: new Metric({
       metricName: 'FakeMetricName',
@@ -213,6 +219,7 @@ test('high-severity alarm actions are registered', () => {
   // GIVEN
   const stack = new Stack(undefined, 'TestStack');
   const alarm = new Alarm(stack, 'Alarm', {
+    alarmName: `${stack.node.path}/Alarm`,
     evaluationPeriods: 1,
     metric: new Metric({
       metricName: 'FakeMetricName',
@@ -242,6 +249,7 @@ test('medium-severity alarm actions are registered', () => {
   // GIVEN
   const stack = new Stack(undefined, 'TestStack');
   const alarm = new Alarm(stack, 'Alarm', {
+    alarmName: `${stack.node.path}/Alarm`,
     evaluationPeriods: 1,
     metric: new Metric({
       metricName: 'FakeMetricName',
@@ -284,7 +292,7 @@ test('alarm overrides: severity-only override wires the new bucket action', () =
       mediumSeverity: 'arn:medium',
     },
     alarmOverrides: {
-      Alarm: { severity: 'MEDIUM' },
+      Alarm: { severity: AlarmSeverity.MEDIUM },
     },
   }).addHighSeverityAlarm('Alarm', alarm);
 
@@ -338,7 +346,7 @@ test('alarm overrides: severity + actions wires custom action and uses new dashb
   const monitoring = new Monitoring(stack, 'Monitoring', {
     alarmActions: { highSeverity: 'arn:high', normalSeverity: 'arn:normal' },
     alarmOverrides: {
-      Alarm: { severity: 'HIGH', actions: [customAction] },
+      Alarm: { severity: AlarmSeverity.HIGH, actions: [customAction] },
     },
   });
   monitoring.addLowSeverityAlarm('Alarm', alarm);
@@ -368,12 +376,54 @@ test('alarm overrides: unknown key fails synth-time validation', () => {
   new Monitoring(stack, 'Monitoring', {
     alarmActions: { highSeverity: 'arn:high' },
     alarmOverrides: {
-      'NonExistent/Alarm': { severity: 'LOW' },
+      'NonExistent/Alarm': { severity: AlarmSeverity.LOW },
     },
   }).addHighSeverityAlarm('Alarm', alarm);
 
   // THEN: synth surfaces an error pointing at the unknown key
   expect(() => Template.fromStack(stack)).toThrow(
     /alarmOverrides: 'NonExistent\/Alarm' did not match/
+  );
+});
+
+test('alarm overrides: alarms with explicit name and no override use the bucket action', () => {
+  // GIVEN
+  const stack = new Stack(undefined, 'TestStack');
+  const alarm = new Alarm(stack, 'Alarm', {
+    alarmName: 'TestStack/Alarm',
+    evaluationPeriods: 1,
+    metric: new Metric({ metricName: 'M', namespace: 'N' }),
+    threshold: 0,
+  });
+
+  // WHEN: registered as HIGH with no override entry for it
+  new Monitoring(stack, 'Monitoring', {
+    alarmActions: { highSeverity: 'arn:high' },
+    alarmOverrides: {},
+  }).addHighSeverityAlarm('Alarm', alarm);
+
+  // THEN: default bucket action is wired (no regression)
+  Template.fromStack(stack).hasResourceProperties('AWS::CloudWatch::Alarm', {
+    AlarmActions: ['arn:high'],
+  });
+});
+
+test('alarm overrides: alarm without explicit alarmName fails synth', () => {
+  // GIVEN
+  const stack = new Stack(undefined, 'TestStack');
+  const alarm = new Alarm(stack, 'Alarm', {
+    // no alarmName set
+    evaluationPeriods: 1,
+    metric: new Metric({ metricName: 'M', namespace: 'N' }),
+    threshold: 0,
+  });
+
+  new Monitoring(stack, 'Monitoring', {
+    alarmActions: { highSeverity: 'arn:high' },
+  }).addHighSeverityAlarm('Alarm', alarm);
+
+  // THEN: synth flags the missing alarmName
+  expect(() => Template.fromStack(stack)).toThrow(
+    /has no explicit alarmName/
   );
 });

--- a/src/api.ts
+++ b/src/api.ts
@@ -44,7 +44,7 @@ export enum AlarmSeverity {
 
 /**
  * Configure severities for various alarms.
- * 
+ *
  * Alarms not included here are currently not configurable.
  */
 export interface AlarmSeverities {
@@ -59,6 +59,62 @@ export interface AlarmSeverities {
    */
   readonly packageCanarySLABreached?: AlarmSeverity;
 
+}
+
+/**
+ * Construct paths of alarms that can be overridden via `alarmOverrides`.
+ *
+ * The path is relative to the `ConstructHub` construct.
+ */
+export enum AlarmPath {
+  SOURCES_NPMJS_FOLLOWER_FAILURES = 'Sources/NpmJs/Follower/Failures',
+  SOURCES_NPMJS_FOLLOWER_NOT_RUNNING = 'Sources/NpmJs/Follower/NotRunning',
+  SOURCES_NPMJS_FOLLOWER_NO_CHANGES = 'Sources/NpmJs/Follower/NoChanges',
+  SOURCES_NPMJS_STAGER_DLQ_NOT_EMPTY = 'Sources/NpmJs/Stager/DLQNotEmpty',
+  SOURCES_NPMJS_CANARY_SLA_BREACHED = 'Sources/NpmJs/Canary/SLA-Breached',
+  SOURCES_NPMJS_CANARY_STALE_PACKAGE = 'Sources/NpmJs/Canary/StaleCanaryPackage',
+  SOURCES_NPMJS_CANARY_FAILING = 'Sources/NpmJs/Canary/Failing',
+  SOURCES_NPMJS_CANARY_NOT_RUNNING = 'Sources/NpmJs/Canary/NotRunning',
+  SOURCES_NPMJS_CANARY_NOT_RUNNING_OR_FAILING = 'Sources/NpmJs/Canary/NotRunningOrFailing',
+  SOURCES_NPMJS_CANARY_GATEWAY_ERRORS = 'Sources/NpmJs/Canary/GatewayErrors',
+  INGESTION_DLQ_NOT_EMPTY = 'Ingestion/DLQNotEmpty',
+  INGESTION_FAILURE = 'Ingestion/Failure',
+  INGESTION_REPROCESS_WORKFLOW_FAILURE = 'Ingestion/ReprocessWorkflow/Failure',
+  FEED_BUILDER_FAILURE = 'FeedBuilder/Failure',
+  ORCHESTRATION_DLQ_NOT_EMPTY = 'Orchestration/DLQ/NotEmpty',
+  ORCHESTRATION_EXECUTIONS_FAILED = 'Orchestration/Resource/ExecutionsFailed',
+  ORCHESTRATION_EXECUTION_FAILURE_RATE = 'Orchestration/Resource/ExecutionFailureRate',
+  ORCHESTRATION_SHRINKING_CATALOG = 'Orchestration/CatalogBuilder/ShrinkingCatalog',
+  INVENTORY_CANARY_NOT_RUNNING = 'InventoryCanary/NotRunning',
+  INVENTORY_CANARY_FAILURES = 'InventoryCanary/Failures',
+  PACKAGE_STATS_FAILURES = 'PackageStats/Failures',
+  VERSION_TRACKER_FAILURES = 'VersionTracker/Failures',
+  VERSION_TRACKER_NOT_RUNNING = 'VersionTracker/NotRunning',
+  RELEASE_NOTES_GENERATION_FAILURE = 'ReleaseNotes/ReleaseNotesGenerationFailure',
+  RELEASE_NOTES_TRIGGER_FAILURE = 'ReleaseNotes/ReleaseNotesTriggerFailure',
+  RELEASE_NOTES_INVALID_GITHUB_CREDENTIALS = 'ReleaseNotes/ReleaseNotesInvalidGitHubCredentials',
+  RELEASE_NOTES_GITHUB_RATE_LIMIT = 'ReleaseNotes/ReleaseNotes Github rate limit',
+  WEBAPP_ACM_CERTIFICATE_EXPIRES_SOON = 'WebApp/ExpirationMonitor/ACMAlarm',
+  WEBAPP_ENDPOINT_CERTIFICATE_EXPIRES_SOON = 'WebApp/ExpirationMonitor/EndpointAlarm',
+}
+
+/**
+ * An override for a specific alarm.
+ */
+export interface AlarmOverride {
+  /**
+   * Wire this alarm to a different severity bucket's action.
+   *
+   * @default - the severity hardcoded by the alarm's author
+   */
+  readonly severity?: AlarmSeverity;
+
+  /**
+   * Wire custom actions onto this alarm, replacing the severity bucket's action.
+   *
+   * @default - the severity bucket's action
+   */
+  readonly actions?: IAlarmAction[];
 }
 
 /**

--- a/src/api.ts
+++ b/src/api.ts
@@ -75,6 +75,9 @@ export interface AlarmOverride {
   /**
    * Wire these actions onto the alarm in place of the severity bucket's action.
    *
+   * An empty array falls back to the bucket action — it does NOT mute the
+   * alarm. To silence an alarm intentionally, supply a no-op action.
+   *
    * @default - the severity bucket's action
    */
   readonly actions?: IAlarmAction[];

--- a/src/api.ts
+++ b/src/api.ts
@@ -62,43 +62,6 @@ export interface AlarmSeverities {
 }
 
 /**
- * Construct paths of alarms that can be overridden via `alarmOverrides`.
- *
- * The path is relative to the `ConstructHub` construct.
- */
-export enum AlarmPath {
-  SOURCES_NPMJS_FOLLOWER_FAILURES = 'Sources/NpmJs/Follower/Failures',
-  SOURCES_NPMJS_FOLLOWER_NOT_RUNNING = 'Sources/NpmJs/Follower/NotRunning',
-  SOURCES_NPMJS_FOLLOWER_NO_CHANGES = 'Sources/NpmJs/Follower/NoChanges',
-  SOURCES_NPMJS_STAGER_DLQ_NOT_EMPTY = 'Sources/NpmJs/Stager/DLQNotEmpty',
-  SOURCES_NPMJS_CANARY_SLA_BREACHED = 'Sources/NpmJs/Canary/SLA-Breached',
-  SOURCES_NPMJS_CANARY_STALE_PACKAGE = 'Sources/NpmJs/Canary/StaleCanaryPackage',
-  SOURCES_NPMJS_CANARY_FAILING = 'Sources/NpmJs/Canary/Failing',
-  SOURCES_NPMJS_CANARY_NOT_RUNNING = 'Sources/NpmJs/Canary/NotRunning',
-  SOURCES_NPMJS_CANARY_NOT_RUNNING_OR_FAILING = 'Sources/NpmJs/Canary/NotRunningOrFailing',
-  SOURCES_NPMJS_CANARY_GATEWAY_ERRORS = 'Sources/NpmJs/Canary/GatewayErrors',
-  INGESTION_DLQ_NOT_EMPTY = 'Ingestion/DLQNotEmpty',
-  INGESTION_FAILURE = 'Ingestion/Failure',
-  INGESTION_REPROCESS_WORKFLOW_FAILURE = 'Ingestion/ReprocessWorkflow/Failure',
-  FEED_BUILDER_FAILURE = 'FeedBuilder/Failure',
-  ORCHESTRATION_DLQ_NOT_EMPTY = 'Orchestration/DLQ/NotEmpty',
-  ORCHESTRATION_EXECUTIONS_FAILED = 'Orchestration/Resource/ExecutionsFailed',
-  ORCHESTRATION_EXECUTION_FAILURE_RATE = 'Orchestration/Resource/ExecutionFailureRate',
-  ORCHESTRATION_SHRINKING_CATALOG = 'Orchestration/CatalogBuilder/ShrinkingCatalog',
-  INVENTORY_CANARY_NOT_RUNNING = 'InventoryCanary/NotRunning',
-  INVENTORY_CANARY_FAILURES = 'InventoryCanary/Failures',
-  PACKAGE_STATS_FAILURES = 'PackageStats/Failures',
-  VERSION_TRACKER_FAILURES = 'VersionTracker/Failures',
-  VERSION_TRACKER_NOT_RUNNING = 'VersionTracker/NotRunning',
-  RELEASE_NOTES_GENERATION_FAILURE = 'ReleaseNotes/ReleaseNotesGenerationFailure',
-  RELEASE_NOTES_TRIGGER_FAILURE = 'ReleaseNotes/ReleaseNotesTriggerFailure',
-  RELEASE_NOTES_INVALID_GITHUB_CREDENTIALS = 'ReleaseNotes/ReleaseNotesInvalidGitHubCredentials',
-  RELEASE_NOTES_GITHUB_RATE_LIMIT = 'ReleaseNotes/ReleaseNotes Github rate limit',
-  WEBAPP_ACM_CERTIFICATE_EXPIRES_SOON = 'WebApp/ExpirationMonitor/ACMAlarm',
-  WEBAPP_ENDPOINT_CERTIFICATE_EXPIRES_SOON = 'WebApp/ExpirationMonitor/EndpointAlarm',
-}
-
-/**
  * An override for a specific alarm.
  */
 export interface AlarmOverride {
@@ -107,7 +70,7 @@ export interface AlarmOverride {
    *
    * @default - the severity hardcoded by the alarm's author
    */
-  readonly severity?: AlarmSeverity;
+  readonly severity?: 'HIGH' | 'MEDIUM' | 'LOW';
 
   /**
    * Wire custom actions onto this alarm, replacing the severity bucket's action.

--- a/src/api.ts
+++ b/src/api.ts
@@ -70,10 +70,10 @@ export interface AlarmOverride {
    *
    * @default - the severity hardcoded by the alarm's author
    */
-  readonly severity?: 'HIGH' | 'MEDIUM' | 'LOW';
+  readonly severity?: AlarmSeverity;
 
   /**
-   * Wire custom actions onto this alarm, replacing the severity bucket's action.
+   * Wire these actions onto the alarm in place of the severity bucket's action.
    *
    * @default - the severity bucket's action
    */

--- a/src/construct-hub.ts
+++ b/src/construct-hub.ts
@@ -87,9 +87,9 @@ export interface ConstructHubProps {
    * to the `ConstructHub` construct — i.e. the same string a customer sees in
    * tickets and the CloudWatch console (e.g. 'Sources/NpmJs/Canary/NotRunningOrFailing').
    *
-   * For each entry, set `severity` ('HIGH' | 'MEDIUM' | 'LOW') to wire the
-   * alarm to a different bucket's action, `actions` to supply custom actions
-   * that bypass the buckets, or both.
+   * For each entry, set `severity` (`AlarmSeverity.HIGH` / `MEDIUM` / `LOW`)
+   * to wire the alarm to a different bucket's action, `actions` to supply
+   * custom actions that bypass the buckets, or both.
    *
    * Unknown keys are surfaced as synth-time validation errors.
    */

--- a/src/construct-hub.ts
+++ b/src/construct-hub.ts
@@ -12,7 +12,7 @@ import * as sqs from 'aws-cdk-lib/aws-sqs';
 import { IStateMachine } from 'aws-cdk-lib/aws-stepfunctions';
 import { Construct } from 'constructs';
 import { createRestrictedSecurityGroups } from './_limited-internet-access';
-import { AlarmActions, AlarmSeverities, Domain } from './api';
+import { AlarmActions, AlarmOverride, AlarmSeverities, Domain } from './api';
 import { DenyList, Ingestion } from './backend';
 import { DenyListRule } from './backend/deny-list/api';
 import { FeedBuilder } from './backend/feed-builder';
@@ -81,6 +81,16 @@ export interface ConstructHubProps {
    * Configure the severities of various alarms.
    */
   readonly alarmSeverities?: AlarmSeverities;
+
+  /**
+   * Per-alarm overrides keyed by the alarm's construct path relative to the
+   * `ConstructHub` construct (e.g. 'Sources/NpmJs/Canary/NotRunningOrFailing').
+   * Use the `AlarmPath` enum for compile-time typo protection.
+   *
+   * For each entry, set `severity` to wire the alarm to a different bucket's
+   * action, `actions` to supply custom actions that bypass the buckets, or both.
+   */
+  readonly alarmOverrides?: { [path: string]: AlarmOverride };
 
   /**
    * Whether compute environments for sensitive tasks (which operate on
@@ -310,6 +320,7 @@ export class ConstructHub extends Construct implements iam.IGrantable {
 
     this.monitoring = new Monitoring(this, 'Monitoring', {
       alarmActions: props.alarmActions,
+      alarmOverrides: props.alarmOverrides,
     });
 
     const overviewDashboard = new OverviewDashboard(this, 'OverviewDashboard', {

--- a/src/construct-hub.ts
+++ b/src/construct-hub.ts
@@ -83,14 +83,17 @@ export interface ConstructHubProps {
   readonly alarmSeverities?: AlarmSeverities;
 
   /**
-   * Per-alarm overrides keyed by the alarm's construct path relative to the
-   * `ConstructHub` construct (e.g. 'Sources/NpmJs/Canary/NotRunningOrFailing').
-   * Use the `AlarmPath` enum for compile-time typo protection.
+   * Per-alarm overrides keyed by the alarm's CloudWatch display name relative
+   * to the `ConstructHub` construct — i.e. the same string a customer sees in
+   * tickets and the CloudWatch console (e.g. 'Sources/NpmJs/Canary/NotRunningOrFailing').
    *
-   * For each entry, set `severity` to wire the alarm to a different bucket's
-   * action, `actions` to supply custom actions that bypass the buckets, or both.
+   * For each entry, set `severity` ('HIGH' | 'MEDIUM' | 'LOW') to wire the
+   * alarm to a different bucket's action, `actions` to supply custom actions
+   * that bypass the buckets, or both.
+   *
+   * Unknown keys are surfaced as synth-time validation errors.
    */
-  readonly alarmOverrides?: { [path: string]: AlarmOverride };
+  readonly alarmOverrides?: { [alarmName: string]: AlarmOverride };
 
   /**
    * Whether compute environments for sensitive tasks (which operate on

--- a/src/monitored-certificate/index.ts
+++ b/src/monitored-certificate/index.ts
@@ -97,6 +97,7 @@ export class MonitoredCertificate extends Construct {
 
     this.alarmAcmCertificateExpiresSoon =
       this.metricAcmCertificateDaysToExpiry().createAlarm(this, 'ACMAlarm', {
+        alarmName: `${this.node.path}/ACMCertificateExpiresSoon`,
         alarmDescription: `The ACM certificate ${props.certificate.certificateArn} will expire in less than 45 days!`,
         comparisonOperator: ComparisonOperator.LESS_THAN_THRESHOLD,
         evaluationPeriods: 1,
@@ -109,6 +110,7 @@ export class MonitoredCertificate extends Construct {
         this,
         'EndpointAlarm',
         {
+          alarmName: `${this.node.path}/EndpointCertificateExpiresSoon`,
           alarmDescription: `The certificate used to serve ${props.domainName} will expire in less than 45 days!`,
           comparisonOperator: ComparisonOperator.LESS_THAN_THRESHOLD,
           evaluationPeriods: 1,

--- a/src/monitoring/index.ts
+++ b/src/monitoring/index.ts
@@ -33,6 +33,7 @@ export interface MonitoringProps {
 export class Monitoring extends Construct implements IMonitoring {
   private alarmActions?: AlarmActions;
   private alarmOverrides: { [path: string]: AlarmOverride };
+  private matchedOverrideKeys = new Set<string>();
   private _highSeverityAlarms: cw.AlarmBase[];
   private _mediumSeverityAlarms: cw.AlarmBase[];
   private _lowSeverityAlarms: cw.AlarmBase[];
@@ -70,6 +71,19 @@ export class Monitoring extends Construct implements IMonitoring {
       this,
       'HighSeverityDashboard'
     );
+
+    // Warn at synth time about override keys that didn't match any alarm.
+    this.node.addValidation({
+      validate: () => {
+        const unknown = Object.keys(this.alarmOverrides).filter(
+          (k) => !this.matchedOverrideKeys.has(k)
+        );
+        return unknown.map(
+          (k) =>
+            `alarmOverrides: '${k}' did not match any alarm — typo? Refer to API.md for the list of overridable alarm names.`
+        );
+      },
+    });
   }
 
   /**
@@ -138,18 +152,26 @@ export class Monitoring extends Construct implements IMonitoring {
    * dashboard placement, bookkeeping) according to the override and return
    * true. Otherwise return false to let the caller fall back to default
    * bucket-based behavior.
+   *
+   * Lookup is by the alarm's CloudWatch display name (the `alarmName`
+   * property), with the `${stack}/${ConstructHub-id}/` prefix stripped — so
+   * customers write the same string they see in tickets.
    */
   private applyOverride(
     title: string,
     alarm: cw.AlarmBase,
     defaultSeverity: AlarmSeverity
   ): boolean {
-    const prefix = `${this.node.scope!.node.path}/`;
-    if (!alarm.node.path.startsWith(prefix)) return false;
-    const override = this.alarmOverrides[alarm.node.path.slice(prefix.length)];
+    const relative = this.relativeAlarmName(alarm);
+    if (!relative) return false;
+    const override = this.alarmOverrides[relative];
     if (!override) return false;
 
-    const severity = override.severity ?? defaultSeverity;
+    this.matchedOverrideKeys.add(relative);
+
+    const severity = override.severity
+      ? severityFromString(override.severity)
+      : defaultSeverity;
 
     if (override.actions) {
       for (const action of override.actions) {
@@ -181,6 +203,23 @@ export class Monitoring extends Construct implements IMonitoring {
     }
 
     return true;
+  }
+
+  /**
+   * Returns the alarm's CloudWatch display name with the `${ConstructHub.path}/`
+   * prefix stripped, or undefined if the alarm has no explicit name.
+   */
+  private relativeAlarmName(alarm: cw.AlarmBase): string | undefined {
+    const cfn = alarm.node.defaultChild as
+      | cw.CfnAlarm
+      | cw.CfnCompositeAlarm
+      | undefined;
+    const fullName =
+      (cfn as cw.CfnAlarm | undefined)?.alarmName ??
+      (cfn as cw.CfnCompositeAlarm | undefined)?.alarmName;
+    if (!fullName) return undefined;
+    const prefix = `${this.node.scope!.node.path}/`;
+    return fullName.startsWith(prefix) ? fullName.slice(prefix.length) : undefined;
   }
 
   public get highSeverityAlarms() {
@@ -231,5 +270,13 @@ export function addAlarm(title: string, alarm: cw.Alarm, severity: AlarmSeverity
       break;
     default:
       throw new Error(`Unknown alarm severity: ${severity}`);
+  }
+}
+
+function severityFromString(s: 'HIGH' | 'MEDIUM' | 'LOW'): AlarmSeverity {
+  switch (s) {
+    case 'HIGH': return AlarmSeverity.HIGH;
+    case 'MEDIUM': return AlarmSeverity.MEDIUM;
+    case 'LOW': return AlarmSeverity.LOW;
   }
 }

--- a/src/monitoring/index.ts
+++ b/src/monitoring/index.ts
@@ -15,10 +15,10 @@ export interface MonitoringProps {
   readonly alarmActions?: AlarmActions;
 
   /**
-   * Per-alarm overrides keyed by the alarm's construct path relative to the
-   * `ConstructHub` construct.
+   * Per-alarm overrides keyed by the alarm's CloudWatch display name relative
+   * to the `ConstructHub` construct.
    */
-  readonly alarmOverrides?: { [path: string]: AlarmOverride };
+  readonly alarmOverrides?: { [alarmName: string]: AlarmOverride };
 }
 
 /**
@@ -32,7 +32,7 @@ export interface MonitoringProps {
  */
 export class Monitoring extends Construct implements IMonitoring {
   private alarmActions?: AlarmActions;
-  private alarmOverrides: { [path: string]: AlarmOverride };
+  private alarmOverrides: { [alarmName: string]: AlarmOverride };
   private matchedOverrideKeys = new Set<string>();
   private _highSeverityAlarms: cw.AlarmBase[];
   private _mediumSeverityAlarms: cw.AlarmBase[];
@@ -72,16 +72,30 @@ export class Monitoring extends Construct implements IMonitoring {
       'HighSeverityDashboard'
     );
 
-    // Warn at synth time about override keys that didn't match any alarm.
+    // Synth-time checks:
+    //   1. Every registered alarm must have an explicit `alarmName`, otherwise
+    //      it is silently un-overridable.
+    //   2. Every key in `alarmOverrides` must match a registered alarm.
     this.node.addValidation({
       validate: () => {
-        const unknown = Object.keys(this.alarmOverrides).filter(
-          (k) => !this.matchedOverrideKeys.has(k)
-        );
-        return unknown.map(
-          (k) =>
-            `alarmOverrides: '${k}' did not match any alarm — typo? Refer to API.md for the list of overridable alarm names.`
-        );
+        const errors: string[] = [];
+        for (const alarm of this.allRegisteredAlarms()) {
+          if (!this.relativeAlarmName(alarm)) {
+            errors.push(
+              `alarm '${alarm.node.path}' has no explicit alarmName, ` +
+                'so it cannot be overridden via `alarmOverrides`. Set ' +
+                '`alarmName: ${scope.node.path}/<short-name>` at the registration site.'
+            );
+          }
+        }
+        for (const k of Object.keys(this.alarmOverrides)) {
+          if (!this.matchedOverrideKeys.has(k)) {
+            errors.push(
+              `alarmOverrides: '${k}' did not match any alarm — typo? Refer to API.md for the list of overridable alarm names.`
+            );
+          }
+        }
+        return errors;
       },
     });
   }
@@ -169,9 +183,7 @@ export class Monitoring extends Construct implements IMonitoring {
 
     this.matchedOverrideKeys.add(relative);
 
-    const severity = override.severity
-      ? severityFromString(override.severity)
-      : defaultSeverity;
+    const severity = override.severity ?? defaultSeverity;
 
     if (override.actions) {
       for (const action of override.actions) {
@@ -218,7 +230,9 @@ export class Monitoring extends Construct implements IMonitoring {
       (cfn as cw.CfnAlarm | undefined)?.alarmName ??
       (cfn as cw.CfnCompositeAlarm | undefined)?.alarmName;
     if (!fullName) return undefined;
-    const prefix = `${this.node.scope!.node.path}/`;
+    const parent = this.node.scope;
+    if (!parent) return undefined;
+    const prefix = `${parent.node.path}/`;
     return fullName.startsWith(prefix) ? fullName.slice(prefix.length) : undefined;
   }
 
@@ -232,6 +246,14 @@ export class Monitoring extends Construct implements IMonitoring {
 
   public get lowSeverityAlarms() {
     return [...this._lowSeverityAlarms];
+  }
+
+  private allRegisteredAlarms(): cw.AlarmBase[] {
+    return [
+      ...this._highSeverityAlarms,
+      ...this._mediumSeverityAlarms,
+      ...this._lowSeverityAlarms,
+    ];
   }
 
   /**
@@ -273,10 +295,3 @@ export function addAlarm(title: string, alarm: cw.Alarm, severity: AlarmSeverity
   }
 }
 
-function severityFromString(s: 'HIGH' | 'MEDIUM' | 'LOW'): AlarmSeverity {
-  switch (s) {
-    case 'HIGH': return AlarmSeverity.HIGH;
-    case 'MEDIUM': return AlarmSeverity.MEDIUM;
-    case 'LOW': return AlarmSeverity.LOW;
-  }
-}

--- a/src/monitoring/index.ts
+++ b/src/monitoring/index.ts
@@ -3,7 +3,7 @@ import { Watchful } from 'cdk-watchful';
 import { Construct } from 'constructs';
 import { IMonitoring } from './api';
 import { WebCanary } from './web-canary';
-import { AlarmActions, AlarmSeverity } from '../api';
+import { AlarmActions, AlarmOverride, AlarmSeverity } from '../api';
 
 /**
  * Props for the monitoring construct.
@@ -13,6 +13,12 @@ export interface MonitoringProps {
    * ARNs of alarm actions to take for various severities.
    */
   readonly alarmActions?: AlarmActions;
+
+  /**
+   * Per-alarm overrides keyed by the alarm's construct path relative to the
+   * `ConstructHub` construct.
+   */
+  readonly alarmOverrides?: { [path: string]: AlarmOverride };
 }
 
 /**
@@ -26,6 +32,7 @@ export interface MonitoringProps {
  */
 export class Monitoring extends Construct implements IMonitoring {
   private alarmActions?: AlarmActions;
+  private alarmOverrides: { [path: string]: AlarmOverride };
   private _highSeverityAlarms: cw.AlarmBase[];
   private _mediumSeverityAlarms: cw.AlarmBase[];
   private _lowSeverityAlarms: cw.AlarmBase[];
@@ -43,6 +50,7 @@ export class Monitoring extends Construct implements IMonitoring {
     super(scope, id);
 
     this.alarmActions = props.alarmActions;
+    this.alarmOverrides = props.alarmOverrides ?? {};
 
     this.watchful = new Watchful(this, 'Watchful', {
       // alarms that come from watchful are all considered normal severity
@@ -69,6 +77,8 @@ export class Monitoring extends Construct implements IMonitoring {
    * @param alarm
    */
   public addHighSeverityAlarm(title: string, alarm: cw.AlarmBase) {
+    if (this.applyOverride(title, alarm, AlarmSeverity.HIGH)) return;
+
     const highSeverityActionArn = this.alarmActions?.highSeverity;
     if (highSeverityActionArn) {
       alarm.addAlarmAction({
@@ -91,7 +101,9 @@ export class Monitoring extends Construct implements IMonitoring {
     this._highSeverityAlarms.push(alarm);
   }
 
-  public addLowSeverityAlarm(_title: string, alarm: cw.AlarmBase) {
+  public addLowSeverityAlarm(title: string, alarm: cw.AlarmBase) {
+    if (this.applyOverride(title, alarm, AlarmSeverity.LOW)) return;
+
     const normalSeverityActionArn = this.alarmActions?.normalSeverity;
     if (normalSeverityActionArn) {
       alarm.addAlarmAction({
@@ -105,7 +117,9 @@ export class Monitoring extends Construct implements IMonitoring {
     this._lowSeverityAlarms.push(alarm);
   }
 
-  public addMediumSeverityAlarm(_title: string, alarm: cw.AlarmBase) {
+  public addMediumSeverityAlarm(title: string, alarm: cw.AlarmBase) {
+    if (this.applyOverride(title, alarm, AlarmSeverity.MEDIUM)) return;
+
     const actionArn = this.alarmActions?.mediumSeverity;
     if (actionArn) {
       alarm.addAlarmAction({
@@ -117,6 +131,56 @@ export class Monitoring extends Construct implements IMonitoring {
       alarm.addAlarmAction(action);
     }
     this._mediumSeverityAlarms.push(alarm);
+  }
+
+  /**
+   * If `alarm` has an entry in `alarmOverrides`, fully wire it (actions,
+   * dashboard placement, bookkeeping) according to the override and return
+   * true. Otherwise return false to let the caller fall back to default
+   * bucket-based behavior.
+   */
+  private applyOverride(
+    title: string,
+    alarm: cw.AlarmBase,
+    defaultSeverity: AlarmSeverity
+  ): boolean {
+    const prefix = `${this.node.scope!.node.path}/`;
+    if (!alarm.node.path.startsWith(prefix)) return false;
+    const override = this.alarmOverrides[alarm.node.path.slice(prefix.length)];
+    if (!override) return false;
+
+    const severity = override.severity ?? defaultSeverity;
+
+    if (override.actions) {
+      for (const action of override.actions) {
+        alarm.addAlarmAction(action);
+      }
+    } else {
+      const arn =
+        severity === AlarmSeverity.HIGH ? this.alarmActions?.highSeverity :
+          severity === AlarmSeverity.MEDIUM ? this.alarmActions?.mediumSeverity :
+            this.alarmActions?.normalSeverity;
+      if (arn) alarm.addAlarmAction({ bind: () => ({ alarmActionArn: arn }) });
+
+      const action =
+        severity === AlarmSeverity.HIGH ? this.alarmActions?.highSeverityAction :
+          severity === AlarmSeverity.MEDIUM ? this.alarmActions?.mediumSeverityAction :
+            this.alarmActions?.normalSeverityAction;
+      if (action) alarm.addAlarmAction(action);
+    }
+
+    if (severity === AlarmSeverity.HIGH) {
+      this.highSeverityDashboard.addWidgets(
+        new cw.AlarmWidget({ alarm, title, width: 24 })
+      );
+      this._highSeverityAlarms.push(alarm);
+    } else if (severity === AlarmSeverity.MEDIUM) {
+      this._mediumSeverityAlarms.push(alarm);
+    } else {
+      this._lowSeverityAlarms.push(alarm);
+    }
+
+    return true;
   }
 
   public get highSeverityAlarms() {

--- a/src/monitoring/index.ts
+++ b/src/monitoring/index.ts
@@ -231,9 +231,7 @@ export class Monitoring extends Construct implements IMonitoring {
       | undefined;
     const fullName = cfn?.alarmName;
     if (!fullName) return undefined;
-    const parent = this.node.scope;
-    if (!parent) return undefined;
-    const prefix = `${parent.node.path}/`;
+    const prefix = `${this.node.scope!.node.path}/`;
     return fullName.startsWith(prefix) ? fullName.slice(prefix.length) : undefined;
   }
 

--- a/src/monitoring/index.ts
+++ b/src/monitoring/index.ts
@@ -72,12 +72,12 @@ export class Monitoring extends Construct implements IMonitoring {
       'HighSeverityDashboard'
     );
 
-    // Synth-time checks:
-    //   1. Every registered alarm must have an explicit `alarmName`, otherwise
-    //      it is silently un-overridable.
-    //   2. Every key in `alarmOverrides` must match a registered alarm.
+    // Synth-time checks. Only run when `alarmOverrides` is in use — otherwise
+    // we'd reject anonymous alarms that subclasses or downstream forks may
+    // legitimately register without intending to make them overridable.
     this.node.addValidation({
       validate: () => {
+        if (Object.keys(this.alarmOverrides).length === 0) return [];
         const errors: string[] = [];
         for (const alarm of this.allRegisteredAlarms()) {
           if (!this.relativeAlarmName(alarm)) {
@@ -91,7 +91,7 @@ export class Monitoring extends Construct implements IMonitoring {
         for (const k of Object.keys(this.alarmOverrides)) {
           if (!this.matchedOverrideKeys.has(k)) {
             errors.push(
-              `alarmOverrides: '${k}' did not match any alarm — typo? Refer to API.md for the list of overridable alarm names.`
+              `alarmOverrides: '${k}' did not match any alarm. See ConstructHubProps.alarmOverrides for the list of overridable alarm names.`
             );
           }
         }
@@ -185,7 +185,7 @@ export class Monitoring extends Construct implements IMonitoring {
 
     const severity = override.severity ?? defaultSeverity;
 
-    if (override.actions) {
+    if (override.actions && override.actions.length > 0) {
       for (const action of override.actions) {
         alarm.addAlarmAction(action);
       }
@@ -222,13 +222,14 @@ export class Monitoring extends Construct implements IMonitoring {
    * prefix stripped, or undefined if the alarm has no explicit name.
    */
   private relativeAlarmName(alarm: cw.AlarmBase): string | undefined {
+    // Both CfnAlarm and CfnCompositeAlarm expose `alarmName` directly.
+    // Note: this only resolves when the alarm name is set to a literal string at
+    // synth time. A CDK token (e.g. `Fn.join(...)`) won't match the prefix below.
     const cfn = alarm.node.defaultChild as
       | cw.CfnAlarm
       | cw.CfnCompositeAlarm
       | undefined;
-    const fullName =
-      (cfn as cw.CfnAlarm | undefined)?.alarmName ??
-      (cfn as cw.CfnCompositeAlarm | undefined)?.alarmName;
+    const fullName = cfn?.alarmName;
     if (!fullName) return undefined;
     const parent = this.node.scope;
     if (!parent) return undefined;
@@ -294,4 +295,3 @@ export function addAlarm(title: string, alarm: cw.Alarm, severity: AlarmSeverity
       throw new Error(`Unknown alarm severity: ${severity}`);
   }
 }
-

--- a/src/monitoring/index.ts
+++ b/src/monitoring/index.ts
@@ -1,3 +1,4 @@
+import { Token } from 'aws-cdk-lib';
 import * as cw from 'aws-cdk-lib/aws-cloudwatch';
 import { Watchful } from 'cdk-watchful';
 import { Construct } from 'constructs';
@@ -72,31 +73,16 @@ export class Monitoring extends Construct implements IMonitoring {
       'HighSeverityDashboard'
     );
 
-    // Synth-time checks. Only run when `alarmOverrides` is in use — otherwise
-    // we'd reject anonymous alarms that subclasses or downstream forks may
-    // legitimately register without intending to make them overridable.
+    // Surface override keys that didn't match any alarm at synth time, so
+    // typos fail before deploy.
     this.node.addValidation({
-      validate: () => {
-        if (Object.keys(this.alarmOverrides).length === 0) return [];
-        const errors: string[] = [];
-        for (const alarm of this.allRegisteredAlarms()) {
-          if (!this.relativeAlarmName(alarm)) {
-            errors.push(
-              `alarm '${alarm.node.path}' has no explicit alarmName, ` +
-                'so it cannot be overridden via `alarmOverrides`. Set ' +
-                '`alarmName: ${scope.node.path}/<short-name>` at the registration site.'
-            );
-          }
-        }
-        for (const k of Object.keys(this.alarmOverrides)) {
-          if (!this.matchedOverrideKeys.has(k)) {
-            errors.push(
+      validate: () =>
+        Object.keys(this.alarmOverrides)
+          .filter((k) => !this.matchedOverrideKeys.has(k))
+          .map(
+            (k) =>
               `alarmOverrides: '${k}' did not match any alarm. See ConstructHubProps.alarmOverrides for the list of overridable alarm names.`
-            );
-          }
-        }
-        return errors;
-      },
+          ),
     });
   }
 
@@ -222,15 +208,12 @@ export class Monitoring extends Construct implements IMonitoring {
    * prefix stripped, or undefined if the alarm has no explicit name.
    */
   private relativeAlarmName(alarm: cw.AlarmBase): string | undefined {
-    // Both CfnAlarm and CfnCompositeAlarm expose `alarmName` directly.
-    // Note: this only resolves when the alarm name is set to a literal string at
-    // synth time. A CDK token (e.g. `Fn.join(...)`) won't match the prefix below.
     const cfn = alarm.node.defaultChild as
       | cw.CfnAlarm
       | cw.CfnCompositeAlarm
       | undefined;
     const fullName = cfn?.alarmName;
-    if (!fullName) return undefined;
+    if (!fullName || Token.isUnresolved(fullName)) return undefined;
     const prefix = `${this.node.scope!.node.path}/`;
     return fullName.startsWith(prefix) ? fullName.slice(prefix.length) : undefined;
   }
@@ -245,14 +228,6 @@ export class Monitoring extends Construct implements IMonitoring {
 
   public get lowSeverityAlarms() {
     return [...this._lowSeverityAlarms];
-  }
-
-  private allRegisteredAlarms(): cw.AlarmBase[] {
-    return [
-      ...this._highSeverityAlarms,
-      ...this._mediumSeverityAlarms,
-      ...this._lowSeverityAlarms,
-    ];
   }
 
   /**

--- a/src/monitoring/web-canary.ts
+++ b/src/monitoring/web-canary.ts
@@ -55,6 +55,7 @@ export class WebCanary extends Construct {
 
     // alarm if 4 or more pings have failed within a period of 5 minutes (80% failure rate)
     this.alarm = errors.createAlarm(this, 'Errors', {
+      alarmName: `${this.node.path}/Errors`,
       alarmDescription: `80% error rate for ${props.url} (${display})`,
       threshold: 4,
       evaluationPeriods: 1,


### PR DESCRIPTION
Fixes #1599

This PR adds `alarmOverrides` on `ConstructHub` so customers can change what fires for a specific alarm at deploy time.

Today every alarm is locked into one of three severity buckets and each bucket has one action. Customers can't reclassify a single alarm or attach a custom action to one. The existing `AlarmSeverities` interface only covers two named alarms.

### Example usage

This is the actual stack used to verify the feature against a real AWS account; every override flavor is exercised below.

```ts
import * as cdk from 'aws-cdk-lib/core';
import { SnsAction } from 'aws-cdk-lib/aws-cloudwatch-actions';
import * as sns from 'aws-cdk-lib/aws-sns';
import { Construct } from 'constructs';
import { AlarmSeverity, ConstructHub, Isolation } from 'construct-hub';

export class TempStack extends cdk.Stack {
  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
    super(scope, id, props);

    const highTopic = new sns.Topic(this, 'HighTopic');
    const lowTopic = new sns.Topic(this, 'LowTopic');
    const customTopic = new sns.Topic(this, 'CustomTopic');

    new ConstructHub(this, 'ConstructHub', {
      sensitiveTaskIsolation: Isolation.UNLIMITED_INTERNET_ACCESS,
      alarmActions: {
        highSeverityAction: new SnsAction(highTopic),
        normalSeverityAction: new SnsAction(lowTopic),
      },
      alarmOverrides: {
        // (1) HIGH → LOW — downgrade
        'Sources/NpmJs/Canary/NotRunningOrFailing': { severity: AlarmSeverity.LOW },
        // (2) LOW → HIGH — upgrade (should appear on the high-sev dashboard)
        'PackageStats/Failures': { severity: AlarmSeverity.HIGH },
        // (3) actions-only — bypasses the bucket action
        'Ingestion/DLQNotEmpty': { actions: [new SnsAction(customTopic)] },
        // (4) severity + actions
        'Sources/NpmJs/Canary/StaleCanaryPackage': {
          severity: AlarmSeverity.HIGH,
          actions: [new SnsAction(customTopic)],
        },
        // (5) actions: [] — falls back to bucket action (does NOT mute)
        'VersionTracker/NotRunning': { actions: [] },
      },
    });
  }
}
```

The actual `aws cloudwatch describe-alarms` output after deploy:

| Alarm | Default sev | Override | Wired to | ✓ |
|---|---|---|---|---|
| `Sources/NpmJs/Canary/NotRunningOrFailing` | HIGH | `severity: LOW` | LowTopic | ✅ |
| `PackageStats/Failures` | LOW | `severity: HIGH` | HighTopic | ✅ |
| `Ingestion/DLQNotEmpty` | HIGH | `actions: [custom]` | CustomTopic | ✅ |
| `Sources/NpmJs/Canary/StaleCanaryPackage` | MEDIUM | `severity: HIGH, actions: [custom]` | CustomTopic | ✅ |
| `VersionTracker/NotRunning` | LOW | `actions: []` | LowTopic (fallback) | ✅ |
| `Ingestion/Failure` (control) | HIGH | — | HighTopic | ✅ |
| `VersionTracker/Failures` (control) | LOW | — | LowTopic | ✅ |

The two control rows (no override) prove the override is what's changing the wiring, not a fixed rule.

<details>
<summary>Raw <code>aws cloudwatch describe-alarms</code> output</summary>

```
--- Sources/NpmJs/Canary/NotRunningOrFailing ---
  AlarmName: AlarmOverridesSanity/ConstructHub/Sources/NpmJs/Canary/NotRunningOrFailing
  StateValue: OK
  AlarmAction: arn:aws:sns:us-east-1:XXXXXXXXXXXX:AlarmOverridesSanity-LowTopic4E7342F5-2LhqEbe3Nq27  (LowTopic)

--- PackageStats/Failures ---
  AlarmName: AlarmOverridesSanity/ConstructHub/PackageStats/Failures
  StateValue: INSUFFICIENT_DATA
  AlarmAction: arn:aws:sns:us-east-1:XXXXXXXXXXXX:AlarmOverridesSanity-HighTopic335D797C-GajKrapOI2K8  (HighTopic)

--- Ingestion/DLQNotEmpty ---
  AlarmName: AlarmOverridesSanity/ConstructHub/Ingestion/DLQNotEmpty
  StateValue: OK
  AlarmAction: arn:aws:sns:us-east-1:XXXXXXXXXXXX:AlarmOverridesSanity-CustomTopicE1837878-3SNvSZVTUsuD  (CustomTopic)

--- Sources/NpmJs/Canary/StaleCanaryPackage ---
  AlarmName: AlarmOverridesSanity/ConstructHub/Sources/NpmJs/Canary/StaleCanaryPackage
  StateValue: OK
  AlarmAction: arn:aws:sns:us-east-1:XXXXXXXXXXXX:AlarmOverridesSanity-CustomTopicE1837878-3SNvSZVTUsuD  (CustomTopic)

--- VersionTracker/NotRunning ---
  AlarmName: AlarmOverridesSanity/ConstructHub/VersionTracker/NotRunning
  StateValue: OK
  AlarmAction: arn:aws:sns:us-east-1:XXXXXXXXXXXX:AlarmOverridesSanity-LowTopic4E7342F5-2LhqEbe3Nq27  (LowTopic)

--- Ingestion/Failure (control) ---
  AlarmName: AlarmOverridesSanity/ConstructHub/Ingestion/Failure
  StateValue: OK
  AlarmAction: arn:aws:sns:us-east-1:XXXXXXXXXXXX:AlarmOverridesSanity-HighTopic335D797C-GajKrapOI2K8  (HighTopic)

--- VersionTracker/Failures (control) ---
  AlarmName: AlarmOverridesSanity/ConstructHub/VersionTracker/Failures
  StateValue: OK
  AlarmAction: arn:aws:sns:us-east-1:XXXXXXXXXXXX:AlarmOverridesSanity-LowTopic4E7342F5-2LhqEbe3Nq27  (LowTopic)
```
</details>

- `severity` — wire this alarm to a different bucket's action (`AlarmSeverity.HIGH` / `MEDIUM` / `LOW`).
- `actions` — supply custom actions that bypass the buckets entirely.
- Either, both, or neither.

Keys are the alarm's **CloudWatch display name** relative to the `ConstructHub` construct i.e. the same string a customer sees in tickets and the CloudWatch console.

> [!NOTE]
> The existing `AlarmActions` interface calls the lowest-tier slot `normalSeverity` (legacy). Everywhere else in
> the codebase (the `AlarmSeverity` enum, `add*SeverityAlarm` methods, and our new `severity` field) uses 
>`LOW`.  Renaming `AlarmActions.normalSeverity` → `lowSeverity` can be a separate PR.

>[!WARNING] 
>Three previously-anonymous alarms now have explicit `alarmName`s
>
>The lookup mechanism keys on the alarm's CloudWatch display name. Three alarms in the codebase predate the `alarmName: ${scope.node.path}/...` convention and had no explicit name set:
>
>- `MonitoredCertificate/ACMAlarm` (45-day cert expiry)
>- `MonitoredCertificate/EndpointAlarm` (45-day cert expiry)
>- `Monitoring/WebCanary/Errors` (web canary error rate)
>
>This PR adds explicit names to all three, which means **CloudFormation will replace the existing alarms (delete + create) on next deploy**. The replacement is acceptable because (a) CloudWatch alarms hold no state, (b) the gap is bounded by the deploy duration, and (c) none of the three are time-sensitive (cert expiry is a 45-day window; the web canary fires only on sustained errors). 

### Implementation

- New `AlarmOverride` interface in `src/api.ts`.
- `Monitoring` reads `(alarm.node.defaultChild as CfnAlarm | CfnCompositeAlarm).alarmName`, strips the `ConstructHub` prefix, looks up the override. If found, fully wires the alarm itself; otherwise falls through to existing per-bucket logic. Each `add*SeverityAlarm` gains one early-return line; existing logic is untouched.
- `alarmOverrides` lives entirely on `ConstructHub` props, no per-source plumbing.
- Unknown override keys, and any registered alarm without an explicit `alarmName`, are surfaced as synth-time validation errors via `node.addValidation`. Validation only runs when `alarmOverrides` is non-empty, so existing customers and downstream forks are unaffected.
- An `actions: []` override falls back to the bucket action (rather than silently muting the alarm).

### Coverage

Every alarm registered through `IMonitoring` is overridable. Three alarms that previously had no explicit `alarmName` (the two cert-expiry alarms and the web canary alarm) now have one, so they're covered too.

### Tests

7 new tests in `monitoring.test.ts`: severity-only override, actions-only override, both, empty `actions: []` falls back to bucket, unknown override key (synth-time error), default path with explicit alarmName, alarm registered without alarmName when overrides are set (synth-time error).

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
