### PR TITLE
fix(package-sources): retry tarball 404s in stager lambda

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -10841,7 +10841,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2e5407671586cf6c53cd5ba0dad453d70fd012139584615453d3d2e17d37e85e.zip",
+          "S3Key": "b1b3e54e406937b6b9414d0a66623285cdcea2bcb5660aef34f1ad629984aa22.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -25289,7 +25289,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2e5407671586cf6c53cd5ba0dad453d70fd012139584615453d3d2e17d37e85e.zip",
+          "S3Key": "b1b3e54e406937b6b9414d0a66623285cdcea2bcb5660aef34f1ad629984aa22.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -39301,7 +39301,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2e5407671586cf6c53cd5ba0dad453d70fd012139584615453d3d2e17d37e85e.zip",
+          "S3Key": "b1b3e54e406937b6b9414d0a66623285cdcea2bcb5660aef34f1ad629984aa22.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -53457,7 +53457,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2e5407671586cf6c53cd5ba0dad453d70fd012139584615453d3d2e17d37e85e.zip",
+          "S3Key": "b1b3e54e406937b6b9414d0a66623285cdcea2bcb5660aef34f1ad629984aa22.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -67622,7 +67622,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2e5407671586cf6c53cd5ba0dad453d70fd012139584615453d3d2e17d37e85e.zip",
+          "S3Key": "b1b3e54e406937b6b9414d0a66623285cdcea2bcb5660aef34f1ad629984aa22.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -10841,7 +10841,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "900257fc0e790e236a40ae33866127d67d42accf368b74672d3c903f473256b9.zip",
+          "S3Key": "a7474c39344276ee55c9fce451cb4ef9079ec73c7d4f0308a7d7fdc2ebe0ba2f.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -25289,7 +25289,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "900257fc0e790e236a40ae33866127d67d42accf368b74672d3c903f473256b9.zip",
+          "S3Key": "a7474c39344276ee55c9fce451cb4ef9079ec73c7d4f0308a7d7fdc2ebe0ba2f.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -39301,7 +39301,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "900257fc0e790e236a40ae33866127d67d42accf368b74672d3c903f473256b9.zip",
+          "S3Key": "a7474c39344276ee55c9fce451cb4ef9079ec73c7d4f0308a7d7fdc2ebe0ba2f.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -53457,7 +53457,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "900257fc0e790e236a40ae33866127d67d42accf368b74672d3c903f473256b9.zip",
+          "S3Key": "a7474c39344276ee55c9fce451cb4ef9079ec73c7d4f0308a7d7fdc2ebe0ba2f.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -67622,7 +67622,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "900257fc0e790e236a40ae33866127d67d42accf368b74672d3c903f473256b9.zip",
+          "S3Key": "a7474c39344276ee55c9fce451cb4ef9079ec73c7d4f0308a7d7fdc2ebe0ba2f.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -2798,7 +2798,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "21b2d27316fdd35eda8ef38adf8ab7289033939576abe92159d31b90146e276e.zip",
+          "S3Key": "838128a1827f13fb7819e1a8ced579cbe85a770b0d07e0c190d5a9017e710e85.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -10841,7 +10841,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "4ff4400c63e15fdfdbc26729dbb5cdb2ff07cf0b51d9766178d6f4dee0e80ac8.zip",
+          "S3Key": "942243d246ecba1897271060e7f47be19187facbf8366afea5fae94a5fc442cc.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -17093,7 +17093,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "21b2d27316fdd35eda8ef38adf8ab7289033939576abe92159d31b90146e276e.zip",
+          "S3Key": "838128a1827f13fb7819e1a8ced579cbe85a770b0d07e0c190d5a9017e710e85.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -25289,7 +25289,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "4ff4400c63e15fdfdbc26729dbb5cdb2ff07cf0b51d9766178d6f4dee0e80ac8.zip",
+          "S3Key": "942243d246ecba1897271060e7f47be19187facbf8366afea5fae94a5fc442cc.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -31258,7 +31258,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "21b2d27316fdd35eda8ef38adf8ab7289033939576abe92159d31b90146e276e.zip",
+          "S3Key": "838128a1827f13fb7819e1a8ced579cbe85a770b0d07e0c190d5a9017e710e85.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -39301,7 +39301,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "4ff4400c63e15fdfdbc26729dbb5cdb2ff07cf0b51d9766178d6f4dee0e80ac8.zip",
+          "S3Key": "942243d246ecba1897271060e7f47be19187facbf8366afea5fae94a5fc442cc.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -45405,7 +45405,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "21b2d27316fdd35eda8ef38adf8ab7289033939576abe92159d31b90146e276e.zip",
+          "S3Key": "838128a1827f13fb7819e1a8ced579cbe85a770b0d07e0c190d5a9017e710e85.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -53457,7 +53457,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "4ff4400c63e15fdfdbc26729dbb5cdb2ff07cf0b51d9766178d6f4dee0e80ac8.zip",
+          "S3Key": "942243d246ecba1897271060e7f47be19187facbf8366afea5fae94a5fc442cc.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -59763,7 +59763,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "21b2d27316fdd35eda8ef38adf8ab7289033939576abe92159d31b90146e276e.zip",
+          "S3Key": "838128a1827f13fb7819e1a8ced579cbe85a770b0d07e0c190d5a9017e710e85.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -67622,7 +67622,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "4ff4400c63e15fdfdbc26729dbb5cdb2ff07cf0b51d9766178d6f4dee0e80ac8.zip",
+          "S3Key": "942243d246ecba1897271060e7f47be19187facbf8366afea5fae94a5fc442cc.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -10841,7 +10841,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "a7474c39344276ee55c9fce451cb4ef9079ec73c7d4f0308a7d7fdc2ebe0ba2f.zip",
+          "S3Key": "4ff4400c63e15fdfdbc26729dbb5cdb2ff07cf0b51d9766178d6f4dee0e80ac8.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -25289,7 +25289,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "a7474c39344276ee55c9fce451cb4ef9079ec73c7d4f0308a7d7fdc2ebe0ba2f.zip",
+          "S3Key": "4ff4400c63e15fdfdbc26729dbb5cdb2ff07cf0b51d9766178d6f4dee0e80ac8.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -39301,7 +39301,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "a7474c39344276ee55c9fce451cb4ef9079ec73c7d4f0308a7d7fdc2ebe0ba2f.zip",
+          "S3Key": "4ff4400c63e15fdfdbc26729dbb5cdb2ff07cf0b51d9766178d6f4dee0e80ac8.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -53457,7 +53457,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "a7474c39344276ee55c9fce451cb4ef9079ec73c7d4f0308a7d7fdc2ebe0ba2f.zip",
+          "S3Key": "4ff4400c63e15fdfdbc26729dbb5cdb2ff07cf0b51d9766178d6f4dee0e80ac8.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -67622,7 +67622,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "a7474c39344276ee55c9fce451cb4ef9079ec73c7d4f0308a7d7fdc2ebe0ba2f.zip",
+          "S3Key": "4ff4400c63e15fdfdbc26729dbb5cdb2ff07cf0b51d9766178d6f4dee0e80ac8.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -10841,7 +10841,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b1b3e54e406937b6b9414d0a66623285cdcea2bcb5660aef34f1ad629984aa22.zip",
+          "S3Key": "900257fc0e790e236a40ae33866127d67d42accf368b74672d3c903f473256b9.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -25289,7 +25289,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b1b3e54e406937b6b9414d0a66623285cdcea2bcb5660aef34f1ad629984aa22.zip",
+          "S3Key": "900257fc0e790e236a40ae33866127d67d42accf368b74672d3c903f473256b9.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -39301,7 +39301,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b1b3e54e406937b6b9414d0a66623285cdcea2bcb5660aef34f1ad629984aa22.zip",
+          "S3Key": "900257fc0e790e236a40ae33866127d67d42accf368b74672d3c903f473256b9.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -53457,7 +53457,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b1b3e54e406937b6b9414d0a66623285cdcea2bcb5660aef34f1ad629984aa22.zip",
+          "S3Key": "900257fc0e790e236a40ae33866127d67d42accf368b74672d3c903f473256b9.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -67622,7 +67622,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b1b3e54e406937b6b9414d0a66623285cdcea2bcb5660aef34f1ad629984aa22.zip",
+          "S3Key": "900257fc0e790e236a40ae33866127d67d42accf368b74672d3c903f473256b9.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -2798,7 +2798,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "21b2d27316fdd35eda8ef38adf8ab7289033939576abe92159d31b90146e276e.zip",
+          "S3Key": "838128a1827f13fb7819e1a8ced579cbe85a770b0d07e0c190d5a9017e710e85.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -10841,7 +10841,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8529741145bcd8c4655d7655808e39e45a7615782e294674c3818bb5665dda6f.zip",
+          "S3Key": "a43360b9854a95ecc333f4f96a273a54eb04dfbc1cf902ac5cb3ec7f55b0ee2c.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -17093,7 +17093,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "21b2d27316fdd35eda8ef38adf8ab7289033939576abe92159d31b90146e276e.zip",
+          "S3Key": "838128a1827f13fb7819e1a8ced579cbe85a770b0d07e0c190d5a9017e710e85.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -25289,7 +25289,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8529741145bcd8c4655d7655808e39e45a7615782e294674c3818bb5665dda6f.zip",
+          "S3Key": "a43360b9854a95ecc333f4f96a273a54eb04dfbc1cf902ac5cb3ec7f55b0ee2c.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -31258,7 +31258,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "21b2d27316fdd35eda8ef38adf8ab7289033939576abe92159d31b90146e276e.zip",
+          "S3Key": "838128a1827f13fb7819e1a8ced579cbe85a770b0d07e0c190d5a9017e710e85.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -39301,7 +39301,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8529741145bcd8c4655d7655808e39e45a7615782e294674c3818bb5665dda6f.zip",
+          "S3Key": "a43360b9854a95ecc333f4f96a273a54eb04dfbc1cf902ac5cb3ec7f55b0ee2c.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -45405,7 +45405,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "21b2d27316fdd35eda8ef38adf8ab7289033939576abe92159d31b90146e276e.zip",
+          "S3Key": "838128a1827f13fb7819e1a8ced579cbe85a770b0d07e0c190d5a9017e710e85.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -53457,7 +53457,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8529741145bcd8c4655d7655808e39e45a7615782e294674c3818bb5665dda6f.zip",
+          "S3Key": "a43360b9854a95ecc333f4f96a273a54eb04dfbc1cf902ac5cb3ec7f55b0ee2c.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -59763,7 +59763,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "21b2d27316fdd35eda8ef38adf8ab7289033939576abe92159d31b90146e276e.zip",
+          "S3Key": "838128a1827f13fb7819e1a8ced579cbe85a770b0d07e0c190d5a9017e710e85.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -67622,7 +67622,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8529741145bcd8c4655d7655808e39e45a7615782e294674c3818bb5665dda6f.zip",
+          "S3Key": "a43360b9854a95ecc333f4f96a273a54eb04dfbc1cf902ac5cb3ec7f55b0ee2c.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -2798,7 +2798,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "838128a1827f13fb7819e1a8ced579cbe85a770b0d07e0c190d5a9017e710e85.zip",
+          "S3Key": "21b2d27316fdd35eda8ef38adf8ab7289033939576abe92159d31b90146e276e.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -10841,7 +10841,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "942243d246ecba1897271060e7f47be19187facbf8366afea5fae94a5fc442cc.zip",
+          "S3Key": "8529741145bcd8c4655d7655808e39e45a7615782e294674c3818bb5665dda6f.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -17093,7 +17093,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "838128a1827f13fb7819e1a8ced579cbe85a770b0d07e0c190d5a9017e710e85.zip",
+          "S3Key": "21b2d27316fdd35eda8ef38adf8ab7289033939576abe92159d31b90146e276e.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -25289,7 +25289,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "942243d246ecba1897271060e7f47be19187facbf8366afea5fae94a5fc442cc.zip",
+          "S3Key": "8529741145bcd8c4655d7655808e39e45a7615782e294674c3818bb5665dda6f.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -31258,7 +31258,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "838128a1827f13fb7819e1a8ced579cbe85a770b0d07e0c190d5a9017e710e85.zip",
+          "S3Key": "21b2d27316fdd35eda8ef38adf8ab7289033939576abe92159d31b90146e276e.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -39301,7 +39301,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "942243d246ecba1897271060e7f47be19187facbf8366afea5fae94a5fc442cc.zip",
+          "S3Key": "8529741145bcd8c4655d7655808e39e45a7615782e294674c3818bb5665dda6f.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -45405,7 +45405,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "838128a1827f13fb7819e1a8ced579cbe85a770b0d07e0c190d5a9017e710e85.zip",
+          "S3Key": "21b2d27316fdd35eda8ef38adf8ab7289033939576abe92159d31b90146e276e.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -53457,7 +53457,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "942243d246ecba1897271060e7f47be19187facbf8366afea5fae94a5fc442cc.zip",
+          "S3Key": "8529741145bcd8c4655d7655808e39e45a7615782e294674c3818bb5665dda6f.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -59763,7 +59763,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "838128a1827f13fb7819e1a8ced579cbe85a770b0d07e0c190d5a9017e710e85.zip",
+          "S3Key": "21b2d27316fdd35eda8ef38adf8ab7289033939576abe92159d31b90146e276e.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -67622,7 +67622,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "942243d246ecba1897271060e7f47be19187facbf8366afea5fae94a5fc442cc.zip",
+          "S3Key": "8529741145bcd8c4655d7655808e39e45a7615782e294674c3818bb5665dda6f.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -3279,7 +3279,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "21b2d27316fdd35eda8ef38adf8ab7289033939576abe92159d31b90146e276e.zip",
+          "S3Key": "838128a1827f13fb7819e1a8ced579cbe85a770b0d07e0c190d5a9017e710e85.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -12110,7 +12110,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "4ff4400c63e15fdfdbc26729dbb5cdb2ff07cf0b51d9766178d6f4dee0e80ac8.zip",
+          "S3Key": "942243d246ecba1897271060e7f47be19187facbf8366afea5fae94a5fc442cc.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -3279,7 +3279,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "21b2d27316fdd35eda8ef38adf8ab7289033939576abe92159d31b90146e276e.zip",
+          "S3Key": "838128a1827f13fb7819e1a8ced579cbe85a770b0d07e0c190d5a9017e710e85.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -12110,7 +12110,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8529741145bcd8c4655d7655808e39e45a7615782e294674c3818bb5665dda6f.zip",
+          "S3Key": "a43360b9854a95ecc333f4f96a273a54eb04dfbc1cf902ac5cb3ec7f55b0ee2c.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -12110,7 +12110,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b1b3e54e406937b6b9414d0a66623285cdcea2bcb5660aef34f1ad629984aa22.zip",
+          "S3Key": "900257fc0e790e236a40ae33866127d67d42accf368b74672d3c903f473256b9.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -3279,7 +3279,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "838128a1827f13fb7819e1a8ced579cbe85a770b0d07e0c190d5a9017e710e85.zip",
+          "S3Key": "21b2d27316fdd35eda8ef38adf8ab7289033939576abe92159d31b90146e276e.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -12110,7 +12110,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "942243d246ecba1897271060e7f47be19187facbf8366afea5fae94a5fc442cc.zip",
+          "S3Key": "8529741145bcd8c4655d7655808e39e45a7615782e294674c3818bb5665dda6f.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -12110,7 +12110,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2e5407671586cf6c53cd5ba0dad453d70fd012139584615453d3d2e17d37e85e.zip",
+          "S3Key": "b1b3e54e406937b6b9414d0a66623285cdcea2bcb5660aef34f1ad629984aa22.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -12110,7 +12110,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "900257fc0e790e236a40ae33866127d67d42accf368b74672d3c903f473256b9.zip",
+          "S3Key": "a7474c39344276ee55c9fce451cb4ef9079ec73c7d4f0308a7d7fdc2ebe0ba2f.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -12110,7 +12110,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "a7474c39344276ee55c9fce451cb4ef9079ec73c7d4f0308a7d7fdc2ebe0ba2f.zip",
+          "S3Key": "4ff4400c63e15fdfdbc26729dbb5cdb2ff07cf0b51d9766178d6f4dee0e80ac8.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {

--- a/src/__tests__/package-sources/npmjs/stage-and-notify.lambda.test.ts
+++ b/src/__tests__/package-sources/npmjs/stage-and-notify.lambda.test.ts
@@ -114,7 +114,7 @@ test('happy path', async () => {
   });
 });
 
-test('ignores 404 for old package versions', async () => {
+test('ignores persistent 404', async () => {
   const basePath = 'https://registry.npmjs.org';
   const uri = '/@pepperize/cdk-vpc/-/cdk-vpc-0.0.785.tgz';
 
@@ -198,41 +198,6 @@ test('retries a 404 and stages the tarball once it becomes available', async () 
     Metadata: expect.anything(),
   });
   expect(mockSQS).toHaveReceivedCommandTimes(SendMessageCommand, 1);
-});
-
-test('throws on persistent 404 for a freshly published version', async () => {
-  const basePath = 'https://registry.npmjs.org';
-  const uri = '/@pepperize/cdk-vpc/-/cdk-vpc-0.0.785.tgz';
-
-  // deny list
-  mockS3
-    .on(GetObjectCommand, {
-      Bucket: MOCK_DENY_LIST_BUCKET,
-      Key: MOCK_DENY_LIST_OBJECT,
-    })
-    .resolves({
-      Body: stringToStream(JSON.stringify({})),
-    });
-
-  // registry response
-  nock(basePath).get(uri).reply(404).persist();
-
-  const event: PackageVersion = {
-    tarballUrl: `${basePath}${uri}`,
-    integrity: '09d37ec93c5518bf4842ac8e381a5c06452500e5',
-    modified: new Date().toISOString(),
-    name: '@pepper/cdk-vpc',
-    seq: '26437963',
-    version: '0.0.785',
-  };
-
-  const context: Context = {} as any;
-
-  await expect(handler(event, context)).rejects.toThrow(
-    /Tarball not found \(yet\?\) for recently published version/
-  );
-  expect(mockS3).not.toHaveReceivedCommand(PutObjectCommand);
-  expect(mockSQS).not.toHaveReceivedCommand(SendMessageCommand);
 });
 
 test('propagates non-404 errors without retrying', async () => {

--- a/src/__tests__/package-sources/npmjs/stage-and-notify.lambda.test.ts
+++ b/src/__tests__/package-sources/npmjs/stage-and-notify.lambda.test.ts
@@ -12,7 +12,6 @@ import {
   ENV_DENY_LIST_BUCKET_NAME,
   ENV_DENY_LIST_OBJECT_KEY,
 } from '../../../backend/deny-list/constants';
-import type { now, sleep } from '../../../backend/shared/time.lambda-shared';
 import { S3KeyPrefix } from '../../../package-sources/npmjs/constants.lambda-shared';
 import {
   handler,
@@ -20,22 +19,19 @@ import {
 } from '../../../package-sources/npmjs/stage-and-notify.lambda';
 import { stringToStream } from '../../streams';
 
-jest.mock('../../../backend/shared/time.lambda-shared');
-
-// Fake clock: `sleep` resolves immediately and advances the time returned by
-// `now`, so the 404 retry loop runs (and its deadline elapses) without any
-// real waiting.
-let fakeTime = 0;
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const mockTime = require('../../../backend/shared/time.lambda-shared');
-(mockTime.now as jest.MockedFunction<typeof now>).mockImplementation(
-  () => fakeTime
-);
-(mockTime.sleep as jest.MockedFunction<typeof sleep>).mockImplementation(
-  async (ms: number) => {
-    fakeTime += Math.max(ms, 1);
+/**
+ * Advances fake timers until `promise` settles, flushing real I/O (nock)
+ * between advances, then returns the promise.
+ */
+async function advanceTimersUntilSettled<T>(promise: Promise<T>): Promise<T> {
+  let settled = false;
+  promise.finally(() => (settled = true)).catch(() => {});
+  while (!settled) {
+    await new Promise((ok) => setImmediate(ok));
+    await jest.advanceTimersByTimeAsync(1_000);
   }
-);
+  return promise;
+}
 
 const MOCK_STAGING_BUCKET = 'foo';
 const MOCK_QUEUE_URL = 'bar';
@@ -46,9 +42,9 @@ const mockS3 = mockClient(S3Client);
 const mockSQS = mockClient(SQSClient);
 
 beforeEach(() => {
+  jest.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate'] });
   mockS3.reset();
   mockSQS.reset();
-  fakeTime = 0;
   process.env.BUCKET_NAME = MOCK_STAGING_BUCKET;
   process.env.QUEUE_URL = MOCK_QUEUE_URL;
   process.env[ENV_DENY_LIST_BUCKET_NAME] = MOCK_DENY_LIST_BUCKET;
@@ -66,6 +62,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  jest.useRealTimers();
   process.env.BUCKET_NAME = undefined;
   process.env.QUEUE_URL = undefined;
   delete process.env[ENV_DENY_LIST_BUCKET_NAME];
@@ -145,7 +142,9 @@ test('ignores persistent 404', async () => {
 
   const context: Context = {} as any;
 
-  await expect(handler(event, context)).resolves.toBe(undefined);
+  await expect(
+    advanceTimersUntilSettled(handler(event, context))
+  ).resolves.toBe(undefined);
   expect(mockS3).not.toHaveReceivedCommand(PutObjectCommand);
   expect(mockSQS).not.toHaveReceivedCommand(SendMessageCommand);
 });
@@ -180,7 +179,9 @@ test('retries a 404 and stages the tarball once it becomes available', async () 
     awsRequestId: 'request-id',
   } as any;
 
-  await expect(handler(event, context)).resolves.toBe(undefined);
+  await expect(
+    advanceTimersUntilSettled(handler(event, context))
+  ).resolves.toBe(undefined);
 
   expect(mockS3).toHaveReceivedCommandTimes(PutObjectCommand, 1);
   expect(mockS3).toHaveReceivedCommandWith(PutObjectCommand, {

--- a/src/__tests__/package-sources/npmjs/stage-and-notify.lambda.test.ts
+++ b/src/__tests__/package-sources/npmjs/stage-and-notify.lambda.test.ts
@@ -15,6 +15,7 @@ import {
 import { S3KeyPrefix } from '../../../package-sources/npmjs/constants.lambda-shared';
 import {
   handler,
+  NOT_FOUND_RETRY,
   PackageVersion,
 } from '../../../package-sources/npmjs/stage-and-notify.lambda';
 import { stringToStream } from '../../streams';
@@ -34,6 +35,11 @@ beforeEach(() => {
   process.env.QUEUE_URL = MOCK_QUEUE_URL;
   process.env[ENV_DENY_LIST_BUCKET_NAME] = MOCK_DENY_LIST_BUCKET;
   process.env[ENV_DENY_LIST_OBJECT_KEY] = MOCK_DENY_LIST_OBJECT;
+
+  // Keep the 404 retry loop fast in tests.
+  NOT_FOUND_RETRY.baseDelayMs = 1;
+  NOT_FOUND_RETRY.maxDelayMs = 5;
+  NOT_FOUND_RETRY.deadlineMs = 100;
 });
 
 afterEach(() => {
@@ -41,6 +47,7 @@ afterEach(() => {
   process.env.QUEUE_URL = undefined;
   delete process.env[ENV_DENY_LIST_BUCKET_NAME];
   delete process.env[ENV_DENY_LIST_OBJECT_KEY];
+  nock.cleanAll();
 });
 
 test('happy path', async () => {
@@ -107,7 +114,7 @@ test('happy path', async () => {
   });
 });
 
-test('ignores 404', async () => {
+test('ignores 404 for old package versions', async () => {
   const basePath = 'https://registry.npmjs.org';
   const uri = '/@pepperize/cdk-vpc/-/cdk-vpc-0.0.785.tgz';
 
@@ -122,7 +129,7 @@ test('ignores 404', async () => {
     });
 
   // registry response
-  nock(basePath).get(uri).reply(404);
+  nock(basePath).get(uri).reply(404).persist();
 
   const event: PackageVersion = {
     tarballUrl: `${basePath}${uri}`,
@@ -136,4 +143,129 @@ test('ignores 404', async () => {
   const context: Context = {} as any;
 
   await expect(handler(event, context)).resolves.toBe(undefined);
+  expect(mockS3).not.toHaveReceivedCommand(PutObjectCommand);
+  expect(mockSQS).not.toHaveReceivedCommand(SendMessageCommand);
+});
+
+test('retries a 404 and stages the tarball once it becomes available', async () => {
+  const basePath = 'https://registry.npmjs.org';
+  const uri = '@pepperize/cdk-vpc/-/cdk-vpc-0.0.785.tgz';
+  const stagingKey = `${S3KeyPrefix.STAGED_KEY_PREFIX}${uri}`;
+  const tarball = 'tarball';
+
+  // deny list
+  mockS3
+    .on(GetObjectCommand, {
+      Bucket: MOCK_DENY_LIST_BUCKET,
+      Key: MOCK_DENY_LIST_OBJECT,
+    })
+    .resolves({
+      Body: stringToStream(JSON.stringify({})),
+    });
+
+  // registry responses: metadata propagated before the tarball did
+  nock(basePath)
+    .get(`/${uri}`)
+    .reply(404)
+    .get(`/${uri}`)
+    .reply(404)
+    .get(`/${uri}`)
+    .reply(200, tarball);
+
+  const event: PackageVersion = {
+    tarballUrl: `${basePath}/${uri}`,
+    integrity: '09d37ec93c5518bf4842ac8e381a5c06452500e5',
+    modified: new Date().toISOString(),
+    name: '@pepper/cdk-vpc',
+    seq: '26437963',
+    version: '0.0.785',
+  };
+
+  const context: Context = {
+    logGroupName: 'group',
+    logStreamName: 'stream',
+    awsRequestId: 'request-id',
+  } as any;
+
+  await expect(handler(event, context)).resolves.toBe(undefined);
+
+  expect(mockS3).toHaveReceivedCommandTimes(PutObjectCommand, 1);
+  expect(mockS3).toHaveReceivedCommandWith(PutObjectCommand, {
+    Bucket: MOCK_STAGING_BUCKET,
+    Key: stagingKey,
+    Body: Buffer.from(tarball),
+    ContentType: 'application/octet-stream',
+    Metadata: expect.anything(),
+  });
+  expect(mockSQS).toHaveReceivedCommandTimes(SendMessageCommand, 1);
+});
+
+test('throws on persistent 404 for a freshly published version', async () => {
+  const basePath = 'https://registry.npmjs.org';
+  const uri = '/@pepperize/cdk-vpc/-/cdk-vpc-0.0.785.tgz';
+
+  // deny list
+  mockS3
+    .on(GetObjectCommand, {
+      Bucket: MOCK_DENY_LIST_BUCKET,
+      Key: MOCK_DENY_LIST_OBJECT,
+    })
+    .resolves({
+      Body: stringToStream(JSON.stringify({})),
+    });
+
+  // registry response
+  nock(basePath).get(uri).reply(404).persist();
+
+  const event: PackageVersion = {
+    tarballUrl: `${basePath}${uri}`,
+    integrity: '09d37ec93c5518bf4842ac8e381a5c06452500e5',
+    modified: new Date().toISOString(),
+    name: '@pepper/cdk-vpc',
+    seq: '26437963',
+    version: '0.0.785',
+  };
+
+  const context: Context = {} as any;
+
+  await expect(handler(event, context)).rejects.toThrow(
+    /Tarball not found \(yet\?\) for recently published version/
+  );
+  expect(mockS3).not.toHaveReceivedCommand(PutObjectCommand);
+  expect(mockSQS).not.toHaveReceivedCommand(SendMessageCommand);
+});
+
+test('propagates non-404 errors without retrying', async () => {
+  const basePath = 'https://registry.npmjs.org';
+  const uri = '/@pepperize/cdk-vpc/-/cdk-vpc-0.0.785.tgz';
+
+  // deny list
+  mockS3
+    .on(GetObjectCommand, {
+      Bucket: MOCK_DENY_LIST_BUCKET,
+      Key: MOCK_DENY_LIST_OBJECT,
+    })
+    .resolves({
+      Body: stringToStream(JSON.stringify({})),
+    });
+
+  // registry response (a single interceptor: a retry would fail differently)
+  nock(basePath).get(uri).reply(500);
+
+  const event: PackageVersion = {
+    tarballUrl: `${basePath}${uri}`,
+    integrity: '09d37ec93c5518bf4842ac8e381a5c06452500e5',
+    modified: new Date().toISOString(),
+    name: '@pepper/cdk-vpc',
+    seq: '26437963',
+    version: '0.0.785',
+  };
+
+  const context: Context = {} as any;
+
+  await expect(handler(event, context)).rejects.toThrow(
+    /Unsuccessful GET: 500/
+  );
+  expect(mockS3).not.toHaveReceivedCommand(PutObjectCommand);
+  expect(mockSQS).not.toHaveReceivedCommand(SendMessageCommand);
 });

--- a/src/__tests__/package-sources/npmjs/stage-and-notify.lambda.test.ts
+++ b/src/__tests__/package-sources/npmjs/stage-and-notify.lambda.test.ts
@@ -12,6 +12,7 @@ import {
   ENV_DENY_LIST_BUCKET_NAME,
   ENV_DENY_LIST_OBJECT_KEY,
 } from '../../../backend/deny-list/constants';
+import { now, sleep } from '../../../backend/shared/time.lambda-shared';
 import { S3KeyPrefix } from '../../../package-sources/npmjs/constants.lambda-shared';
 import {
   handler,
@@ -19,19 +20,13 @@ import {
 } from '../../../package-sources/npmjs/stage-and-notify.lambda';
 import { stringToStream } from '../../streams';
 
-/**
- * Advances fake timers until `promise` settles, flushing real I/O (nock)
- * between advances, then returns the promise.
- */
-async function advanceTimersUntilSettled<T>(promise: Promise<T>): Promise<T> {
-  let settled = false;
-  promise.finally(() => (settled = true)).catch(() => {});
-  while (!settled) {
-    await new Promise((ok) => setImmediate(ok));
-    await jest.advanceTimersByTimeAsync(1_000);
-  }
-  return promise;
-}
+jest.mock('../../../backend/shared/time.lambda-shared');
+
+let fakeTime = 0;
+jest.mocked(now).mockImplementation(() => fakeTime);
+jest.mocked(sleep).mockImplementation(async (ms) => {
+  fakeTime += ms;
+});
 
 const MOCK_STAGING_BUCKET = 'foo';
 const MOCK_QUEUE_URL = 'bar';
@@ -42,7 +37,7 @@ const mockS3 = mockClient(S3Client);
 const mockSQS = mockClient(SQSClient);
 
 beforeEach(() => {
-  jest.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate'] });
+  fakeTime = 0;
   mockS3.reset();
   mockSQS.reset();
   process.env.BUCKET_NAME = MOCK_STAGING_BUCKET;
@@ -62,7 +57,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  jest.useRealTimers();
   process.env.BUCKET_NAME = undefined;
   process.env.QUEUE_URL = undefined;
   delete process.env[ENV_DENY_LIST_BUCKET_NAME];
@@ -142,9 +136,7 @@ test('ignores persistent 404', async () => {
 
   const context: Context = {} as any;
 
-  await expect(
-    advanceTimersUntilSettled(handler(event, context))
-  ).resolves.toBe(undefined);
+  await expect(handler(event, context)).resolves.toBe(undefined);
   expect(mockS3).not.toHaveReceivedCommand(PutObjectCommand);
   expect(mockSQS).not.toHaveReceivedCommand(SendMessageCommand);
 });
@@ -179,9 +171,7 @@ test('retries a 404 and stages the tarball once it becomes available', async () 
     awsRequestId: 'request-id',
   } as any;
 
-  await expect(
-    advanceTimersUntilSettled(handler(event, context))
-  ).resolves.toBe(undefined);
+  await expect(handler(event, context)).resolves.toBe(undefined);
 
   expect(mockS3).toHaveReceivedCommandTimes(PutObjectCommand, 1);
   expect(mockS3).toHaveReceivedCommandWith(PutObjectCommand, {

--- a/src/__tests__/package-sources/npmjs/stage-and-notify.lambda.test.ts
+++ b/src/__tests__/package-sources/npmjs/stage-and-notify.lambda.test.ts
@@ -12,13 +12,30 @@ import {
   ENV_DENY_LIST_BUCKET_NAME,
   ENV_DENY_LIST_OBJECT_KEY,
 } from '../../../backend/deny-list/constants';
+import type { now, sleep } from '../../../backend/shared/time.lambda-shared';
 import { S3KeyPrefix } from '../../../package-sources/npmjs/constants.lambda-shared';
 import {
   handler,
-  NOT_FOUND_RETRY,
   PackageVersion,
 } from '../../../package-sources/npmjs/stage-and-notify.lambda';
 import { stringToStream } from '../../streams';
+
+jest.mock('../../../backend/shared/time.lambda-shared');
+
+// Fake clock: `sleep` resolves immediately and advances the time returned by
+// `now`, so the 404 retry loop runs (and its deadline elapses) without any
+// real waiting.
+let fakeTime = 0;
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const mockTime = require('../../../backend/shared/time.lambda-shared');
+(mockTime.now as jest.MockedFunction<typeof now>).mockImplementation(
+  () => fakeTime
+);
+(mockTime.sleep as jest.MockedFunction<typeof sleep>).mockImplementation(
+  async (ms: number) => {
+    fakeTime += Math.max(ms, 1);
+  }
+);
 
 const MOCK_STAGING_BUCKET = 'foo';
 const MOCK_QUEUE_URL = 'bar';
@@ -31,6 +48,7 @@ const mockSQS = mockClient(SQSClient);
 beforeEach(() => {
   mockS3.reset();
   mockSQS.reset();
+  fakeTime = 0;
   process.env.BUCKET_NAME = MOCK_STAGING_BUCKET;
   process.env.QUEUE_URL = MOCK_QUEUE_URL;
   process.env[ENV_DENY_LIST_BUCKET_NAME] = MOCK_DENY_LIST_BUCKET;
@@ -45,11 +63,6 @@ beforeEach(() => {
     .resolves({
       Body: stringToStream(JSON.stringify({})),
     });
-
-  // Keep the 404 retry loop fast in tests.
-  NOT_FOUND_RETRY.baseDelayMs = 1;
-  NOT_FOUND_RETRY.maxDelayMs = 5;
-  NOT_FOUND_RETRY.deadlineMs = 100;
 });
 
 afterEach(() => {

--- a/src/__tests__/package-sources/npmjs/stage-and-notify.lambda.test.ts
+++ b/src/__tests__/package-sources/npmjs/stage-and-notify.lambda.test.ts
@@ -36,6 +36,16 @@ beforeEach(() => {
   process.env[ENV_DENY_LIST_BUCKET_NAME] = MOCK_DENY_LIST_BUCKET;
   process.env[ENV_DENY_LIST_OBJECT_KEY] = MOCK_DENY_LIST_OBJECT;
 
+  // empty deny list
+  mockS3
+    .on(GetObjectCommand, {
+      Bucket: MOCK_DENY_LIST_BUCKET,
+      Key: MOCK_DENY_LIST_OBJECT,
+    })
+    .resolves({
+      Body: stringToStream(JSON.stringify({})),
+    });
+
   // Keep the 404 retry loop fast in tests.
   NOT_FOUND_RETRY.baseDelayMs = 1;
   NOT_FOUND_RETRY.maxDelayMs = 5;
@@ -55,16 +65,6 @@ test('happy path', async () => {
   const uri = '@pepperize/cdk-vpc/-/cdk-vpc-0.0.785.tgz';
   const stagingKey = `${S3KeyPrefix.STAGED_KEY_PREFIX}${uri}`;
   const tarball = 'tarball';
-
-  // deny list
-  mockS3
-    .on(GetObjectCommand, {
-      Bucket: MOCK_DENY_LIST_BUCKET,
-      Key: MOCK_DENY_LIST_OBJECT,
-    })
-    .resolves({
-      Body: stringToStream(JSON.stringify({})),
-    });
 
   // registry response
   nock(basePath).get(`/${uri}`).reply(200, tarball);
@@ -118,16 +118,6 @@ test('ignores persistent 404', async () => {
   const basePath = 'https://registry.npmjs.org';
   const uri = '/@pepperize/cdk-vpc/-/cdk-vpc-0.0.785.tgz';
 
-  // deny list
-  mockS3
-    .on(GetObjectCommand, {
-      Bucket: MOCK_DENY_LIST_BUCKET,
-      Key: MOCK_DENY_LIST_OBJECT,
-    })
-    .resolves({
-      Body: stringToStream(JSON.stringify({})),
-    });
-
   // registry response
   nock(basePath).get(uri).reply(404).persist();
 
@@ -152,16 +142,6 @@ test('retries a 404 and stages the tarball once it becomes available', async () 
   const uri = '@pepperize/cdk-vpc/-/cdk-vpc-0.0.785.tgz';
   const stagingKey = `${S3KeyPrefix.STAGED_KEY_PREFIX}${uri}`;
   const tarball = 'tarball';
-
-  // deny list
-  mockS3
-    .on(GetObjectCommand, {
-      Bucket: MOCK_DENY_LIST_BUCKET,
-      Key: MOCK_DENY_LIST_OBJECT,
-    })
-    .resolves({
-      Body: stringToStream(JSON.stringify({})),
-    });
 
   // registry responses: metadata propagated before the tarball did
   nock(basePath)
@@ -203,16 +183,6 @@ test('retries a 404 and stages the tarball once it becomes available', async () 
 test('propagates non-404 errors without retrying', async () => {
   const basePath = 'https://registry.npmjs.org';
   const uri = '/@pepperize/cdk-vpc/-/cdk-vpc-0.0.785.tgz';
-
-  // deny list
-  mockS3
-    .on(GetObjectCommand, {
-      Bucket: MOCK_DENY_LIST_BUCKET,
-      Key: MOCK_DENY_LIST_OBJECT,
-    })
-    .resolves({
-      Body: stringToStream(JSON.stringify({})),
-    });
 
   // registry response (a single interceptor: a retry would fail differently)
   nock(basePath).get(uri).reply(500);

--- a/src/backend/shared/time.lambda-shared.ts
+++ b/src/backend/shared/time.lambda-shared.ts
@@ -1,5 +1,1 @@
 export const now = Date.now;
-
-export async function sleep(ms: number) {
-  return new Promise((ok) => setTimeout(ok, ms));
-}

--- a/src/backend/shared/time.lambda-shared.ts
+++ b/src/backend/shared/time.lambda-shared.ts
@@ -1,1 +1,5 @@
 export const now = Date.now;
+
+export async function sleep(ms: number) {
+  return new Promise((ok) => setTimeout(ok, ms));
+}

--- a/src/package-sources/npmjs/stage-and-notify.lambda.ts
+++ b/src/package-sources/npmjs/stage-and-notify.lambda.ts
@@ -12,6 +12,26 @@ import { integrity } from '../../backend/shared/integrity.lambda-shared';
 class HttpNotFoundError extends Error {}
 
 /**
+ * Retry knobs for tarball downloads that return HTTP 404. npm metadata
+ * propagates faster than tarballs, so a version published seconds ago may
+ * transiently 404 on the tarball URL even though it will be available shortly.
+ *
+ * Exported (and mutable) so tests can shrink the delays.
+ */
+export const NOT_FOUND_RETRY = {
+  baseDelayMs: 1_000,
+  maxDelayMs: 8_000,
+  deadlineMs: 60_000,
+};
+
+/**
+ * A version published less than this long ago is considered "fresh": a 404 on
+ * its tarball is most likely metadata/tarball propagation lag, not a
+ * permanently missing tarball.
+ */
+export const FRESH_PACKAGE_WINDOW_MS = 30 * 60_000;
+
+/**
  * This function is invoked by the `npm-js-follower.lambda`  with a `PackageVersion` object, or by
  * an SQS trigger feeding from this function's Dead-Letter Queue (for re-trying purposes).
  *
@@ -42,18 +62,34 @@ export async function handler(
     return;
   }
 
-  let tarball: Buffer = Buffer.from('');
+  let tarball: Buffer;
   try {
-    // Download the tarball
-    console.log(`Downloading tarball from URL: ${event.tarballUrl}`);
-    tarball = await httpGet(event.tarballUrl);
+    tarball = await downloadTarball(event);
   } catch (e) {
     if (e instanceof HttpNotFoundError) {
-      // We received a message to download a file that should exist but doesn't.
-      // If we throw an error, the message will be sent to the DLQ, to be processed
-      // again in a re-drive. But given that this file will probably never be
-      // available, the re-drives will also fail, and we'll never be able to get rid
-      // of the message in the DLQ. Instead, we ignore this version by returning silently.
+      const ageMs = Date.now() - new Date(event.modified).getTime();
+      if (ageMs < FRESH_PACKAGE_WINDOW_MS) {
+        // The version was published very recently, so the tarball is most
+        // likely still propagating within npm and will become available soon.
+        // Throw so the Lambda async retries and the DLQ make this visible and
+        // re-drivable, instead of silently losing the version.
+        throw new Error(
+          `Tarball not found (yet?) for recently published version (${
+            event.name
+          }@${event.version}, modified ${event.modified}, ${Math.round(
+            ageMs / 1_000
+          )}s ago): ${event.tarballUrl}`
+        );
+      }
+      // The version is old, so the tarball should have long been available: it
+      // probably never will be (e.g: the version was unpublished). If we threw
+      // here, the message would bounce between the DLQ and this handler
+      // forever (a poison pill), so we ignore this version by returning
+      // silently. This also self-clears the DLQ: fresh-404 messages re-driven
+      // after the freshness window evaluate as old and are dropped.
+      console.log(
+        `Tarball not found for ${event.name}@${event.version} (modified ${event.modified}), ignoring this version: ${event.tarballUrl}`
+      );
       return;
     } else {
       throw e;
@@ -141,6 +177,47 @@ export interface PackageVersion {
   readonly integrity: string;
 
   readonly seq?: string;
+}
+
+/**
+ * Downloads the tarball for a package version, retrying HTTP 404 responses
+ * with jittered exponential back-off until `NOT_FOUND_RETRY.deadlineMs` has
+ * elapsed. This absorbs the common case where the tarball lags the metadata by
+ * a few seconds. If the tarball still cannot be found by the deadline, the
+ * last `HttpNotFoundError` is thrown for the caller to decide what to do.
+ */
+async function downloadTarball(event: PackageVersion): Promise<Buffer> {
+  const startTime = Date.now();
+  let attempt = 0;
+  while (true) {
+    try {
+      console.log(`Downloading tarball from URL: ${event.tarballUrl}`);
+      return await httpGet(event.tarballUrl);
+    } catch (e) {
+      if (
+        !(e instanceof HttpNotFoundError) ||
+        Date.now() - startTime >= NOT_FOUND_RETRY.deadlineMs
+      ) {
+        throw e;
+      }
+      const delay = Math.floor(
+        Math.random() *
+          Math.min(
+            NOT_FOUND_RETRY.baseDelayMs * Math.pow(2, attempt),
+            NOT_FOUND_RETRY.maxDelayMs
+          )
+      );
+      console.log(
+        `Tarball not found (HTTP 404), retrying in ${delay} ms: ${event.tarballUrl}`
+      );
+      await sleep(delay);
+      attempt++;
+    }
+  }
+}
+
+async function sleep(ms: number) {
+  return new Promise((ok) => setTimeout(ok, ms));
 }
 
 /**

--- a/src/package-sources/npmjs/stage-and-notify.lambda.ts
+++ b/src/package-sources/npmjs/stage-and-notify.lambda.ts
@@ -12,10 +12,7 @@ import { integrity } from '../../backend/shared/integrity.lambda-shared';
 class HttpNotFoundError extends Error {}
 
 /**
- * Retry knobs for tarball downloads that return HTTP 404. npm metadata
- * propagates faster than tarballs, so a version published seconds ago may
- * transiently 404 on the tarball URL even though it will be available shortly.
- *
+ * Retry configuration for tarball downloads that return HTTP 404.
  * Exported (and mutable) so tests can shrink the delays.
  */
 export const NOT_FOUND_RETRY = {

--- a/src/package-sources/npmjs/stage-and-notify.lambda.ts
+++ b/src/package-sources/npmjs/stage-and-notify.lambda.ts
@@ -158,10 +158,9 @@ export interface PackageVersion {
 
 /**
  * Downloads the tarball for a package version, retrying HTTP 404 responses
- * with jittered exponential back-off until `NOT_FOUND_RETRY.deadlineMs` has
- * elapsed. This absorbs the common case where the tarball lags the metadata by
- * a few seconds. If the tarball still cannot be found by the deadline, the
- * last `HttpNotFoundError` is thrown for the caller to decide what to do.
+ * for a while: npm metadata may propagate faster than tarballs, so a freshly
+ * published version can transiently 404 even though it will be available
+ * shortly.
  */
 async function downloadTarball(event: PackageVersion): Promise<Buffer> {
   const startTime = Date.now();

--- a/src/package-sources/npmjs/stage-and-notify.lambda.ts
+++ b/src/package-sources/npmjs/stage-and-notify.lambda.ts
@@ -8,7 +8,6 @@ import { DenyListClient } from '../../backend/deny-list/client.lambda-shared';
 import { S3_CLIENT, SQS_CLIENT } from '../../backend/shared/aws.lambda-shared';
 import { requireEnv } from '../../backend/shared/env.lambda-shared';
 import { integrity } from '../../backend/shared/integrity.lambda-shared';
-import { now, sleep } from '../../backend/shared/time.lambda-shared';
 
 class HttpNotFoundError extends Error {}
 
@@ -163,7 +162,7 @@ export interface PackageVersion {
  * shortly.
  */
 async function downloadTarball(event: PackageVersion): Promise<Buffer> {
-  const startTime = now();
+  const startTime = Date.now();
   let attempt = 0;
   while (true) {
     try {
@@ -172,16 +171,19 @@ async function downloadTarball(event: PackageVersion): Promise<Buffer> {
     } catch (e) {
       if (
         !(e instanceof HttpNotFoundError) ||
-        now() - startTime >= NOT_FOUND_RETRY.deadlineMs
+        Date.now() - startTime >= NOT_FOUND_RETRY.deadlineMs
       ) {
         throw e;
       }
-      const delay = Math.floor(
-        Math.random() *
-          Math.min(
-            NOT_FOUND_RETRY.baseDelayMs * Math.pow(2, attempt),
-            NOT_FOUND_RETRY.maxDelayMs
-          )
+      const delay = Math.max(
+        NOT_FOUND_RETRY.baseDelayMs,
+        Math.floor(
+          Math.random() *
+            Math.min(
+              NOT_FOUND_RETRY.baseDelayMs * Math.pow(2, attempt),
+              NOT_FOUND_RETRY.maxDelayMs
+            )
+        )
       );
       console.log(
         `Tarball not found (HTTP 404), retrying in ${delay} ms: ${event.tarballUrl}`
@@ -190,6 +192,10 @@ async function downloadTarball(event: PackageVersion): Promise<Buffer> {
       attempt++;
     }
   }
+}
+
+async function sleep(ms: number) {
+  return new Promise((ok) => setTimeout(ok, ms));
 }
 
 /**

--- a/src/package-sources/npmjs/stage-and-notify.lambda.ts
+++ b/src/package-sources/npmjs/stage-and-notify.lambda.ts
@@ -8,6 +8,7 @@ import { DenyListClient } from '../../backend/deny-list/client.lambda-shared';
 import { S3_CLIENT, SQS_CLIENT } from '../../backend/shared/aws.lambda-shared';
 import { requireEnv } from '../../backend/shared/env.lambda-shared';
 import { integrity } from '../../backend/shared/integrity.lambda-shared';
+import { now, sleep } from '../../backend/shared/time.lambda-shared';
 
 class HttpNotFoundError extends Error {}
 
@@ -162,7 +163,7 @@ export interface PackageVersion {
  * shortly.
  */
 async function downloadTarball(event: PackageVersion): Promise<Buffer> {
-  const startTime = Date.now();
+  const startTime = now();
   let attempt = 0;
   while (true) {
     try {
@@ -171,7 +172,7 @@ async function downloadTarball(event: PackageVersion): Promise<Buffer> {
     } catch (e) {
       if (
         !(e instanceof HttpNotFoundError) ||
-        Date.now() - startTime >= NOT_FOUND_RETRY.deadlineMs
+        now() - startTime >= NOT_FOUND_RETRY.deadlineMs
       ) {
         throw e;
       }
@@ -192,10 +193,6 @@ async function downloadTarball(event: PackageVersion): Promise<Buffer> {
       attempt++;
     }
   }
-}
-
-async function sleep(ms: number) {
-  return new Promise((ok) => setTimeout(ok, ms));
 }
 
 /**

--- a/src/package-sources/npmjs/stage-and-notify.lambda.ts
+++ b/src/package-sources/npmjs/stage-and-notify.lambda.ts
@@ -25,13 +25,6 @@ export const NOT_FOUND_RETRY = {
 };
 
 /**
- * A version published less than this long ago is considered "fresh": a 404 on
- * its tarball is most likely metadata/tarball propagation lag, not a
- * permanently missing tarball.
- */
-export const FRESH_PACKAGE_WINDOW_MS = 30 * 60_000;
-
-/**
  * This function is invoked by the `npm-js-follower.lambda`  with a `PackageVersion` object, or by
  * an SQS trigger feeding from this function's Dead-Letter Queue (for re-trying purposes).
  *
@@ -67,26 +60,13 @@ export async function handler(
     tarball = await downloadTarball(event);
   } catch (e) {
     if (e instanceof HttpNotFoundError) {
-      const ageMs = Date.now() - new Date(event.modified).getTime();
-      if (ageMs < FRESH_PACKAGE_WINDOW_MS) {
-        // The version was published very recently, so the tarball is most
-        // likely still propagating within npm and will become available soon.
-        // Throw so the Lambda async retries and the DLQ make this visible and
-        // re-drivable, instead of silently losing the version.
-        throw new Error(
-          `Tarball not found (yet?) for recently published version (${
-            event.name
-          }@${event.version}, modified ${event.modified}, ${Math.round(
-            ageMs / 1_000
-          )}s ago): ${event.tarballUrl}`
-        );
-      }
-      // The version is old, so the tarball should have long been available: it
-      // probably never will be (e.g: the version was unpublished). If we threw
-      // here, the message would bounce between the DLQ and this handler
-      // forever (a poison pill), so we ignore this version by returning
-      // silently. This also self-clears the DLQ: fresh-404 messages re-driven
-      // after the freshness window evaluate as old and are dropped.
+      // The tarball is still not available, even after retrying for a while
+      // (see `downloadTarball`). It is probably permanently missing (e.g: the
+      // version was unpublished). If we throw an error, the message will be
+      // sent to the DLQ, to be processed again in a re-drive. But given that
+      // this file will probably never be available, the re-drives will also
+      // fail, and we'll never be able to get rid of the message in the DLQ.
+      // Instead, we ignore this version by returning silently.
       console.log(
         `Tarball not found for ${event.name}@${event.version} (modified ${event.modified}), ignoring this version: ${event.tarballUrl}`
       );

--- a/src/package-sources/npmjs/stage-and-notify.lambda.ts
+++ b/src/package-sources/npmjs/stage-and-notify.lambda.ts
@@ -8,14 +8,14 @@ import { DenyListClient } from '../../backend/deny-list/client.lambda-shared';
 import { S3_CLIENT, SQS_CLIENT } from '../../backend/shared/aws.lambda-shared';
 import { requireEnv } from '../../backend/shared/env.lambda-shared';
 import { integrity } from '../../backend/shared/integrity.lambda-shared';
+import { now, sleep } from '../../backend/shared/time.lambda-shared';
 
 class HttpNotFoundError extends Error {}
 
 /**
  * Retry configuration for tarball downloads that return HTTP 404.
- * Exported (and mutable) so tests can shrink the delays.
  */
-export const NOT_FOUND_RETRY = {
+const NOT_FOUND_RETRY = {
   baseDelayMs: 1_000,
   maxDelayMs: 8_000,
   deadlineMs: 60_000,
@@ -163,7 +163,7 @@ export interface PackageVersion {
  * shortly.
  */
 async function downloadTarball(event: PackageVersion): Promise<Buffer> {
-  const startTime = Date.now();
+  const startTime = now();
   let attempt = 0;
   while (true) {
     try {
@@ -172,7 +172,7 @@ async function downloadTarball(event: PackageVersion): Promise<Buffer> {
     } catch (e) {
       if (
         !(e instanceof HttpNotFoundError) ||
-        Date.now() - startTime >= NOT_FOUND_RETRY.deadlineMs
+        now() - startTime >= NOT_FOUND_RETRY.deadlineMs
       ) {
         throw e;
       }
@@ -190,10 +190,6 @@ async function downloadTarball(event: PackageVersion): Promise<Buffer> {
       attempt++;
     }
   }
-}
-
-async function sleep(ms: number) {
-  return new Promise((ok) => setTimeout(ok, ms));
 }
 
 /**


### PR DESCRIPTION
Currently the follower lambda polls [replicate.npmjs.com](http://replicate.npmjs.com/) every 5 minutes. It reads the changes stream, fetches metadata for anything relevant, then invokes the stager with the tarball URL and marks the version as processed. Stager lambda downloads the tarball from [registry.npmjs.org](http://registry.npmjs.org/) and stages it into S3 for ingestion.

Here, metadata may propagate faster than the tarball so there's a potential race condition where the replica already lists a version but the tarball isn't downloadable. In this scenario the stager lambda gets 404 from registry. Since the follower already marked the version as processed, it's never retried.

<img width="849" height="723" alt="image" src="https://github.com/user-attachments/assets/315f7054-0255-4e3f-80cc-94cc157cfd93" />


ConstructHub-Prod and Gamma faced this condition on 2026-08-10: construct-hub-probe@0.0.13405 404'd after publish, was silently dropped, and fired the Canary alarm.

This change retries the tarball download on 404 with jittered exponential backoff (1s base, 8s cap, 60s deadline), same pattern as the follower's metadata-lag fix in #1831. This absorbs the common seconds-level race. If the tarball still 404s after the deadline, the existing behavior is unchanged: the version is dropped silently (the #1321 case, a permanently missing tarball that would otherwise poison-pill the DLQ).

For context, the two example packages from #1321 illustrate both kinds of 404: `@pepperize/cdk-vpc@0.0.785` still 404s three years later while its metadata lists the version (genuinely permanent), and `@aws-sdk/credential-provider-http@3.422.0` returns 200 now (a transient that the silent drop lost anyway).

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
