### PR TITLE
fix(package-sources): stuck versions widget shows already-ingested versions

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -832,7 +832,7 @@ def sort_filter_rules(json_obj):
               {
                 "Ref": "ConstructHubSourcesNpmJsCanary5558FC45",
               },
-              "' | fields @timestamp, @message\\n| filter @message like /\\"DwellTime\\"/\\n| parse @message '\\"PackageVersion\\":\\"*\\"' as version\\n| parse @message '\\"DwellTime\\":*,' as dwellTimeSec\\n| stats max(dwellTimeSec) as maxDwellTimeSec by version\\n| sort maxDwellTimeSec desc"}},{"type":"text","width":24,"height":2,"x":0,"y":83,"properties":{"markdown":"# Ingestion Function\\n\\n[button:Ingestion Function](/lambda/home#/functions/",
+              "' | fields @timestamp, @message\\n| filter @message like /\\"DwellTime\\"/\\n| filter toMillis(@timestamp) > (now() - 900) * 1000\\n| parse @message '\\"PackageVersion\\":\\"*\\"' as version\\n| parse @message '\\"DwellTime\\":*,' as dwellTimeSec\\n| stats max(dwellTimeSec) as maxDwellTimeSec by version\\n| sort maxDwellTimeSec desc"}},{"type":"text","width":24,"height":2,"x":0,"y":83,"properties":{"markdown":"# Ingestion Function\\n\\n[button:Ingestion Function](/lambda/home#/functions/",
               {
                 "Ref": "ConstructHubIngestion407909CE",
               },
@@ -14922,7 +14922,7 @@ def sort_filter_rules(json_obj):
               {
                 "Ref": "ConstructHubSourcesNpmJsCanary5558FC45",
               },
-              "' | fields @timestamp, @message\\n| filter @message like /\\"DwellTime\\"/\\n| parse @message '\\"PackageVersion\\":\\"*\\"' as version\\n| parse @message '\\"DwellTime\\":*,' as dwellTimeSec\\n| stats max(dwellTimeSec) as maxDwellTimeSec by version\\n| sort maxDwellTimeSec desc"}},{"type":"text","width":24,"height":2,"x":0,"y":83,"properties":{"markdown":"# Ingestion Function\\n\\n[button:Ingestion Function](/lambda/home#/functions/",
+              "' | fields @timestamp, @message\\n| filter @message like /\\"DwellTime\\"/\\n| filter toMillis(@timestamp) > (now() - 900) * 1000\\n| parse @message '\\"PackageVersion\\":\\"*\\"' as version\\n| parse @message '\\"DwellTime\\":*,' as dwellTimeSec\\n| stats max(dwellTimeSec) as maxDwellTimeSec by version\\n| sort maxDwellTimeSec desc"}},{"type":"text","width":24,"height":2,"x":0,"y":83,"properties":{"markdown":"# Ingestion Function\\n\\n[button:Ingestion Function](/lambda/home#/functions/",
               {
                 "Ref": "ConstructHubIngestion407909CE",
               },
@@ -29324,7 +29324,7 @@ def sort_filter_rules(json_obj):
               {
                 "Ref": "ConstructHubSourcesNpmJsCanary5558FC45",
               },
-              "' | fields @timestamp, @message\\n| filter @message like /\\"DwellTime\\"/\\n| parse @message '\\"PackageVersion\\":\\"*\\"' as version\\n| parse @message '\\"DwellTime\\":*,' as dwellTimeSec\\n| stats max(dwellTimeSec) as maxDwellTimeSec by version\\n| sort maxDwellTimeSec desc"}},{"type":"text","width":24,"height":2,"x":0,"y":83,"properties":{"markdown":"# Ingestion Function\\n\\n[button:Ingestion Function](/lambda/home#/functions/",
+              "' | fields @timestamp, @message\\n| filter @message like /\\"DwellTime\\"/\\n| filter toMillis(@timestamp) > (now() - 900) * 1000\\n| parse @message '\\"PackageVersion\\":\\"*\\"' as version\\n| parse @message '\\"DwellTime\\":*,' as dwellTimeSec\\n| stats max(dwellTimeSec) as maxDwellTimeSec by version\\n| sort maxDwellTimeSec desc"}},{"type":"text","width":24,"height":2,"x":0,"y":83,"properties":{"markdown":"# Ingestion Function\\n\\n[button:Ingestion Function](/lambda/home#/functions/",
               {
                 "Ref": "ConstructHubIngestion407909CE",
               },
@@ -43500,7 +43500,7 @@ def sort_filter_rules(json_obj):
               {
                 "Ref": "ConstructHubSourcesNpmJsCanary5558FC45",
               },
-              "' | fields @timestamp, @message\\n| filter @message like /\\"DwellTime\\"/\\n| parse @message '\\"PackageVersion\\":\\"*\\"' as version\\n| parse @message '\\"DwellTime\\":*,' as dwellTimeSec\\n| stats max(dwellTimeSec) as maxDwellTimeSec by version\\n| sort maxDwellTimeSec desc"}},{"type":"text","width":24,"height":2,"x":0,"y":83,"properties":{"markdown":"# Ingestion Function\\n\\n[button:Ingestion Function](/lambda/home#/functions/",
+              "' | fields @timestamp, @message\\n| filter @message like /\\"DwellTime\\"/\\n| filter toMillis(@timestamp) > (now() - 900) * 1000\\n| parse @message '\\"PackageVersion\\":\\"*\\"' as version\\n| parse @message '\\"DwellTime\\":*,' as dwellTimeSec\\n| stats max(dwellTimeSec) as maxDwellTimeSec by version\\n| sort maxDwellTimeSec desc"}},{"type":"text","width":24,"height":2,"x":0,"y":83,"properties":{"markdown":"# Ingestion Function\\n\\n[button:Ingestion Function](/lambda/home#/functions/",
               {
                 "Ref": "ConstructHubIngestion407909CE",
               },
@@ -57861,7 +57861,7 @@ def sort_filter_rules(json_obj):
               {
                 "Ref": "ConstructHubSourcesNpmJsCanary5558FC45",
               },
-              "' | fields @timestamp, @message\\n| filter @message like /\\"DwellTime\\"/\\n| parse @message '\\"PackageVersion\\":\\"*\\"' as version\\n| parse @message '\\"DwellTime\\":*,' as dwellTimeSec\\n| stats max(dwellTimeSec) as maxDwellTimeSec by version\\n| sort maxDwellTimeSec desc"}},{"type":"text","width":24,"height":2,"x":0,"y":83,"properties":{"markdown":"# Ingestion Function\\n\\n[button:Ingestion Function](/lambda/home#/functions/",
+              "' | fields @timestamp, @message\\n| filter @message like /\\"DwellTime\\"/\\n| filter toMillis(@timestamp) > (now() - 900) * 1000\\n| parse @message '\\"PackageVersion\\":\\"*\\"' as version\\n| parse @message '\\"DwellTime\\":*,' as dwellTimeSec\\n| stats max(dwellTimeSec) as maxDwellTimeSec by version\\n| sort maxDwellTimeSec desc"}},{"type":"text","width":24,"height":2,"x":0,"y":83,"properties":{"markdown":"# Ingestion Function\\n\\n[button:Ingestion Function](/lambda/home#/functions/",
               {
                 "Ref": "ConstructHubIngestion407909CE",
               },

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -894,7 +894,7 @@ def sort_filter_rules(json_obj):
               {
                 "Ref": "ConstructHubSourcesNpmJsCanary5558FC45",
               },
-              "' | fields @timestamp, @message\\n| filter @message like /\\"DwellTime\\"/\\n| parse @message '\\"PackageVersion\\":\\"*\\"' as version\\n| parse @message '\\"DwellTime\\":*,' as dwellTimeSec\\n| stats max(dwellTimeSec) as maxDwellTimeSec by version\\n| sort maxDwellTimeSec desc"}},{"type":"text","width":24,"height":2,"x":0,"y":83,"properties":{"markdown":"# Ingestion Function\\n\\n[button:Ingestion Function](/lambda/home#/functions/",
+              "' | fields @timestamp, @message\\n| filter @message like /\\"DwellTime\\"/\\n| filter toMillis(@timestamp) > (now() - 900) * 1000\\n| parse @message '\\"PackageVersion\\":\\"*\\"' as version\\n| parse @message '\\"DwellTime\\":*,' as dwellTimeSec\\n| stats max(dwellTimeSec) as maxDwellTimeSec by version\\n| sort maxDwellTimeSec desc"}},{"type":"text","width":24,"height":2,"x":0,"y":83,"properties":{"markdown":"# Ingestion Function\\n\\n[button:Ingestion Function](/lambda/home#/functions/",
               {
                 "Ref": "ConstructHubIngestion407909CE",
               },

--- a/src/package-sources/npmjs.ts
+++ b/src/package-sources/npmjs.ts
@@ -69,6 +69,13 @@ const FOLLOWER_RUN_RATE = Duration.minutes(5);
  */
 const NO_CHANGES_ALARM_DURATION = Duration.hours(24);
 
+/**
+ * How recently the canary must have reported a version as not-yet-visible for
+ * the "Stuck Versions" widget to consider it still stuck. A few canary runs
+ * (which happen every 5 minutes), to tolerate a missed run.
+ */
+const STUCK_VERSION_WINDOW = Duration.minutes(15);
+
 export interface NpmJsProps {
   /**
    * The bucket to use for staging npm packages.
@@ -774,6 +781,14 @@ export class NpmJs implements IPackageSource {
         queryLines: [
           'fields @timestamp, @message',
           'filter @message like /"DwellTime"/',
+          // The canary only reports DwellTime for versions it still cannot see,
+          // so recent reports are the versions that are stuck right now. Without
+          // this, every version that was ever slow within the dashboard's time
+          // range shows up, including ones that have since been ingested.
+          // `now()` is in seconds, `toMillis` in milliseconds.
+          `filter toMillis(@timestamp) > (now() - ${
+            STUCK_VERSION_WINDOW.toSeconds()
+          }) * 1000`,
           `parse @message '"PackageVersion":"*"' as version`,
           `parse @message '"DwellTime":*,' as dwellTimeSec`,
           'stats max(dwellTimeSec) as maxDwellTimeSec by version',


### PR DESCRIPTION
The Stuck Versions widget (added in #1914) aggregates `max(DwellTime) by version` over the dashboard's whole time range. The canary stops reporting DwellTime for a version once it becomes visible in ConstructHub, but the earlier log lines stay in the window, so the table lists every version that was ever slow, not the ones that are stuck now. On a 3 day range it was showing three already-resolved incidents alongside versions that dwelled a normal few minutes before ingesting fine.

Filters to versions the canary has reported within the last 15 minutes (it runs every 5), which is what the widget title claims and what oncall needs when the SLA-Breached alarm is red.

Verified against the ConstructHub-Prod canary log group over a 5 day range: no rows in a 15 minute window (nothing stuck at the time, both canary alarms green), and only 0.0.13434 in a 6 hour window (that day's incident, which stopped reporting once it was re-staged). Note `now()` is in seconds while `toMillis()` is in milliseconds, so the comparison needs the `* 1000`, otherwise the filter silently matches everything.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*