### PR TITLE
fix(package-sources): bust CDN cache when retrying tarball 404s

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -10857,7 +10857,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2d535a26c08e5f7abb9d5fbf96b2d4faf99e947d6614b48b37d739499ce88c56.zip",
+          "S3Key": "202fcafbacba79e34718405c0865ef36a331b953ecddfe88a973c76c1627b527.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -25321,7 +25321,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2d535a26c08e5f7abb9d5fbf96b2d4faf99e947d6614b48b37d739499ce88c56.zip",
+          "S3Key": "202fcafbacba79e34718405c0865ef36a331b953ecddfe88a973c76c1627b527.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -39349,7 +39349,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2d535a26c08e5f7abb9d5fbf96b2d4faf99e947d6614b48b37d739499ce88c56.zip",
+          "S3Key": "202fcafbacba79e34718405c0865ef36a331b953ecddfe88a973c76c1627b527.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -53521,7 +53521,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2d535a26c08e5f7abb9d5fbf96b2d4faf99e947d6614b48b37d739499ce88c56.zip",
+          "S3Key": "202fcafbacba79e34718405c0865ef36a331b953ecddfe88a973c76c1627b527.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -67702,7 +67702,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2d535a26c08e5f7abb9d5fbf96b2d4faf99e947d6614b48b37d739499ce88c56.zip",
+          "S3Key": "202fcafbacba79e34718405c0865ef36a331b953ecddfe88a973c76c1627b527.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -10857,7 +10857,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "202fcafbacba79e34718405c0865ef36a331b953ecddfe88a973c76c1627b527.zip",
+          "S3Key": "5379e436ae8cda25feb3a340b9ca335c4dd3532c299e5d19788712d9931c5361.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -10892,7 +10892,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           ],
         },
         "Runtime": "nodejs22.x",
-        "Timeout": 300,
+        "Timeout": 780,
         "TracingConfig": {
           "Mode": "Active",
         },
@@ -25321,7 +25321,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "202fcafbacba79e34718405c0865ef36a331b953ecddfe88a973c76c1627b527.zip",
+          "S3Key": "5379e436ae8cda25feb3a340b9ca335c4dd3532c299e5d19788712d9931c5361.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -25356,7 +25356,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           ],
         },
         "Runtime": "nodejs22.x",
-        "Timeout": 300,
+        "Timeout": 780,
         "TracingConfig": {
           "Mode": "Active",
         },
@@ -39349,7 +39349,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "202fcafbacba79e34718405c0865ef36a331b953ecddfe88a973c76c1627b527.zip",
+          "S3Key": "5379e436ae8cda25feb3a340b9ca335c4dd3532c299e5d19788712d9931c5361.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -39384,7 +39384,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           ],
         },
         "Runtime": "nodejs22.x",
-        "Timeout": 300,
+        "Timeout": 780,
         "TracingConfig": {
           "Mode": "Active",
         },
@@ -53521,7 +53521,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "202fcafbacba79e34718405c0865ef36a331b953ecddfe88a973c76c1627b527.zip",
+          "S3Key": "5379e436ae8cda25feb3a340b9ca335c4dd3532c299e5d19788712d9931c5361.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -53556,7 +53556,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           ],
         },
         "Runtime": "nodejs22.x",
-        "Timeout": 300,
+        "Timeout": 780,
         "TracingConfig": {
           "Mode": "Active",
         },
@@ -67702,7 +67702,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "202fcafbacba79e34718405c0865ef36a331b953ecddfe88a973c76c1627b527.zip",
+          "S3Key": "5379e436ae8cda25feb3a340b9ca335c4dd3532c299e5d19788712d9931c5361.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -67737,7 +67737,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           ],
         },
         "Runtime": "nodejs22.x",
-        "Timeout": 300,
+        "Timeout": 780,
         "TracingConfig": {
           "Mode": "Active",
         },

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -10857,7 +10857,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5379e436ae8cda25feb3a340b9ca335c4dd3532c299e5d19788712d9931c5361.zip",
+          "S3Key": "fd7f6d8b76b9d4eef63f8ab469781c36a99e7ded841d6e1660dc18c7738e8286.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -25321,7 +25321,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5379e436ae8cda25feb3a340b9ca335c4dd3532c299e5d19788712d9931c5361.zip",
+          "S3Key": "fd7f6d8b76b9d4eef63f8ab469781c36a99e7ded841d6e1660dc18c7738e8286.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -39349,7 +39349,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5379e436ae8cda25feb3a340b9ca335c4dd3532c299e5d19788712d9931c5361.zip",
+          "S3Key": "fd7f6d8b76b9d4eef63f8ab469781c36a99e7ded841d6e1660dc18c7738e8286.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -53521,7 +53521,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5379e436ae8cda25feb3a340b9ca335c4dd3532c299e5d19788712d9931c5361.zip",
+          "S3Key": "fd7f6d8b76b9d4eef63f8ab469781c36a99e7ded841d6e1660dc18c7738e8286.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -67702,7 +67702,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5379e436ae8cda25feb3a340b9ca335c4dd3532c299e5d19788712d9931c5361.zip",
+          "S3Key": "fd7f6d8b76b9d4eef63f8ab469781c36a99e7ded841d6e1660dc18c7738e8286.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -12126,7 +12126,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2d535a26c08e5f7abb9d5fbf96b2d4faf99e947d6614b48b37d739499ce88c56.zip",
+          "S3Key": "202fcafbacba79e34718405c0865ef36a331b953ecddfe88a973c76c1627b527.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -12126,7 +12126,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5379e436ae8cda25feb3a340b9ca335c4dd3532c299e5d19788712d9931c5361.zip",
+          "S3Key": "fd7f6d8b76b9d4eef63f8ab469781c36a99e7ded841d6e1660dc18c7738e8286.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -12126,7 +12126,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "202fcafbacba79e34718405c0865ef36a331b953ecddfe88a973c76c1627b527.zip",
+          "S3Key": "5379e436ae8cda25feb3a340b9ca335c4dd3532c299e5d19788712d9931c5361.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -12161,7 +12161,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           ],
         },
         "Runtime": "nodejs22.x",
-        "Timeout": 300,
+        "Timeout": 780,
         "TracingConfig": {
           "Mode": "Active",
         },

--- a/src/__tests__/package-sources/npmjs/stage-and-notify.lambda.test.ts
+++ b/src/__tests__/package-sources/npmjs/stage-and-notify.lambda.test.ts
@@ -122,8 +122,15 @@ test('ignores persistent 404', async () => {
   const basePath = 'https://registry.npmjs.org';
   const uri = '/@pepperize/cdk-vpc/-/cdk-vpc-0.0.785.tgz';
 
-  // registry response
-  nock(basePath).get(uri).reply(404).persist();
+  // registry response: the plain URL 404s once, every cache-busted retry
+  // 404s as well
+  nock(basePath)
+    .get(uri)
+    .reply(404)
+    .get(uri)
+    .query((q) => q.cacheBust != null)
+    .reply(404)
+    .persist();
 
   const event: PackageVersion = {
     tarballUrl: `${basePath}${uri}`,
@@ -147,13 +154,16 @@ test('retries a 404 and stages the tarball once it becomes available', async () 
   const stagingKey = `${S3KeyPrefix.STAGED_KEY_PREFIX}${uri}`;
   const tarball = 'tarball';
 
-  // registry responses: metadata propagated before the tarball did
+  // registry responses: metadata propagated before the tarball did; retries
+  // must carry a cache-busting query, or these interceptors won't match
   nock(basePath)
     .get(`/${uri}`)
     .reply(404)
     .get(`/${uri}`)
+    .query((q) => q.cacheBust != null)
     .reply(404)
     .get(`/${uri}`)
+    .query((q) => q.cacheBust != null)
     .reply(200, tarball);
 
   const event: PackageVersion = {

--- a/src/__tests__/package-sources/npmjs/stage-and-notify.lambda.test.ts
+++ b/src/__tests__/package-sources/npmjs/stage-and-notify.lambda.test.ts
@@ -122,6 +122,7 @@ test('ignores persistent 404', async () => {
   const basePath = 'https://registry.npmjs.org';
   const uri = '/@pepperize/cdk-vpc/-/cdk-vpc-0.0.785.tgz';
 
+
   // registry response: the plain URL 404s once, every cache-busted retry
   // 404s as well
   nock(basePath)

--- a/src/__tests__/package-sources/npmjs/stage-and-notify.lambda.test.ts
+++ b/src/__tests__/package-sources/npmjs/stage-and-notify.lambda.test.ts
@@ -122,7 +122,6 @@ test('ignores persistent 404', async () => {
   const basePath = 'https://registry.npmjs.org';
   const uri = '/@pepperize/cdk-vpc/-/cdk-vpc-0.0.785.tgz';
 
-
   // registry response: the plain URL 404s once, every cache-busted retry
   // 404s as well
   nock(basePath)

--- a/src/package-sources/npmjs.ts
+++ b/src/package-sources/npmjs.ts
@@ -176,7 +176,9 @@ export class NpmJs implements IPackageSource {
       },
       memorySize: 10_024, // 10GiB
       retryAttempts: 2,
-      timeout: Duration.minutes(5),
+      // Long enough for the 10 minute tarball 404 retry window, plus margin
+      // to download and store a large tarball.
+      timeout: Duration.minutes(13),
       tracing: Tracing.ACTIVE,
     });
 

--- a/src/package-sources/npmjs/stage-and-notify.lambda.ts
+++ b/src/package-sources/npmjs/stage-and-notify.lambda.ts
@@ -160,15 +160,21 @@ export interface PackageVersion {
  * Downloads the tarball for a package version, retrying HTTP 404 responses
  * for a while: npm metadata may propagate faster than tarballs, so a freshly
  * published version can transiently 404 even though it will be available
- * shortly.
+ * shortly. Retries carry a unique query string because registry.npmjs.org
+ * caches 404s at its CDN for 5 minutes: re-requesting the plain URL within
+ * the retry deadline would only ever see the first, cached 404.
  */
 async function downloadTarball(event: PackageVersion): Promise<Buffer> {
   const startTime = now();
   let attempt = 0;
   while (true) {
     try {
-      console.log(`Downloading tarball from URL: ${event.tarballUrl}`);
-      return await httpGet(event.tarballUrl);
+      const url =
+        attempt === 0
+          ? event.tarballUrl
+          : `${event.tarballUrl}?cacheBust=${now()}`;
+      console.log(`Downloading tarball from URL: ${url}`);
+      return await httpGet(url);
     } catch (e) {
       if (
         !(e instanceof HttpNotFoundError) ||

--- a/src/package-sources/npmjs/stage-and-notify.lambda.ts
+++ b/src/package-sources/npmjs/stage-and-notify.lambda.ts
@@ -17,8 +17,8 @@ class HttpNotFoundError extends Error {}
  */
 const NOT_FOUND_RETRY = {
   baseDelayMs: 1_000,
-  maxDelayMs: 8_000,
-  deadlineMs: 60_000,
+  maxDelayMs: 60_000,
+  deadlineMs: 10 * 60_000,
 };
 
 /**


### PR DESCRIPTION
#1913 added a retry loop to the stager lambda for the metadata-vs-tarball propagation race: on 404 it retries with backoff for up to 60s before falling back to the silent drop. 

Turns out the retry loop can't do its job: [registry.npmjs.org](http://registry.npmjs.org/) sits behind Cloudflare, which caches 404 responses with `cache-control: public, max-age=300`. The first 404 poisons the edge cache for 5 minutes, so every retry within the 60s deadline is served the same cached 404 (`age:` header increments on repeat requests) regardless of whether the tarball has since become available.

This change appends a unique `?cacheBust=<timestamp>` query to each retry (the first attempt stays on the plain URL, which is the fast path and also what warms the cache correctly on 200). 

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*