### PR TITLE
fix(package-sources): extend tarball 404 retry window to 10 minutes

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -10857,7 +10857,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "202fcafbacba79e34718405c0865ef36a331b953ecddfe88a973c76c1627b527.zip",
+          "S3Key": "5379e436ae8cda25feb3a340b9ca335c4dd3532c299e5d19788712d9931c5361.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -10892,7 +10892,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           ],
         },
         "Runtime": "nodejs22.x",
-        "Timeout": 300,
+        "Timeout": 780,
         "TracingConfig": {
           "Mode": "Active",
         },
@@ -25321,7 +25321,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "202fcafbacba79e34718405c0865ef36a331b953ecddfe88a973c76c1627b527.zip",
+          "S3Key": "5379e436ae8cda25feb3a340b9ca335c4dd3532c299e5d19788712d9931c5361.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -25356,7 +25356,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           ],
         },
         "Runtime": "nodejs22.x",
-        "Timeout": 300,
+        "Timeout": 780,
         "TracingConfig": {
           "Mode": "Active",
         },
@@ -39349,7 +39349,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "202fcafbacba79e34718405c0865ef36a331b953ecddfe88a973c76c1627b527.zip",
+          "S3Key": "5379e436ae8cda25feb3a340b9ca335c4dd3532c299e5d19788712d9931c5361.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -39384,7 +39384,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           ],
         },
         "Runtime": "nodejs22.x",
-        "Timeout": 300,
+        "Timeout": 780,
         "TracingConfig": {
           "Mode": "Active",
         },
@@ -53521,7 +53521,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "202fcafbacba79e34718405c0865ef36a331b953ecddfe88a973c76c1627b527.zip",
+          "S3Key": "5379e436ae8cda25feb3a340b9ca335c4dd3532c299e5d19788712d9931c5361.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -53556,7 +53556,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           ],
         },
         "Runtime": "nodejs22.x",
-        "Timeout": 300,
+        "Timeout": 780,
         "TracingConfig": {
           "Mode": "Active",
         },
@@ -67702,7 +67702,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "202fcafbacba79e34718405c0865ef36a331b953ecddfe88a973c76c1627b527.zip",
+          "S3Key": "5379e436ae8cda25feb3a340b9ca335c4dd3532c299e5d19788712d9931c5361.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -67737,7 +67737,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           ],
         },
         "Runtime": "nodejs22.x",
-        "Timeout": 300,
+        "Timeout": 780,
         "TracingConfig": {
           "Mode": "Active",
         },

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -12126,7 +12126,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "202fcafbacba79e34718405c0865ef36a331b953ecddfe88a973c76c1627b527.zip",
+          "S3Key": "5379e436ae8cda25feb3a340b9ca335c4dd3532c299e5d19788712d9931c5361.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -12161,7 +12161,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           ],
         },
         "Runtime": "nodejs22.x",
-        "Timeout": 300,
+        "Timeout": 780,
         "TracingConfig": {
           "Mode": "Active",
         },

--- a/src/__tests__/package-sources/npmjs/stage-and-notify.lambda.test.ts
+++ b/src/__tests__/package-sources/npmjs/stage-and-notify.lambda.test.ts
@@ -86,6 +86,7 @@ test('happy path', async () => {
     logGroupName: 'group',
     logStreamName: 'stream',
     awsRequestId: 'request-id',
+    getRemainingTimeInMillis: () => 15 * 60_000,
   } as any;
 
   await expect(handler(event, context)).resolves.toBe(undefined);
@@ -141,7 +142,9 @@ test('ignores persistent 404', async () => {
     version: '0.0.785',
   };
 
-  const context: Context = {} as any;
+  const context: Context = {
+    getRemainingTimeInMillis: () => 15 * 60_000,
+  } as any;
 
   await expect(handler(event, context)).resolves.toBe(undefined);
   expect(mockS3).not.toHaveReceivedCommand(PutObjectCommand);
@@ -179,6 +182,7 @@ test('retries a 404 and stages the tarball once it becomes available', async () 
     logGroupName: 'group',
     logStreamName: 'stream',
     awsRequestId: 'request-id',
+    getRemainingTimeInMillis: () => 15 * 60_000,
   } as any;
 
   await expect(handler(event, context)).resolves.toBe(undefined);
@@ -192,6 +196,31 @@ test('retries a 404 and stages the tarball once it becomes available', async () 
     Metadata: expect.anything(),
   });
   expect(mockSQS).toHaveReceivedCommandTimes(SendMessageCommand, 1);
+});
+
+test('stops retrying a 404 when the invocation nears its timeout', async () => {
+  const basePath = 'https://registry.npmjs.org';
+  const uri = '/@pepperize/cdk-vpc/-/cdk-vpc-0.0.785.tgz';
+
+  // a single 404: the remaining-time guard must prevent any retry
+  nock(basePath).get(uri).reply(404);
+
+  const event: PackageVersion = {
+    tarballUrl: `${basePath}${uri}`,
+    integrity: '09d37ec93c5518bf4842ac8e381a5c06452500e5',
+    modified: new Date().toISOString(),
+    name: '@pepper/cdk-vpc',
+    seq: '26437963',
+    version: '0.0.785',
+  };
+
+  const context: Context = {
+    getRemainingTimeInMillis: () => 60_000,
+  } as any;
+
+  await expect(handler(event, context)).resolves.toBe(undefined);
+  expect(mockS3).not.toHaveReceivedCommand(PutObjectCommand);
+  expect(mockSQS).not.toHaveReceivedCommand(SendMessageCommand);
 });
 
 test('propagates non-404 errors without retrying', async () => {
@@ -210,7 +239,9 @@ test('propagates non-404 errors without retrying', async () => {
     version: '0.0.785',
   };
 
-  const context: Context = {} as any;
+  const context: Context = {
+    getRemainingTimeInMillis: () => 15 * 60_000,
+  } as any;
 
   await expect(handler(event, context)).rejects.toThrow(
     /Unsuccessful GET: 500/

--- a/src/__tests__/package-sources/npmjs/stage-and-notify.lambda.test.ts
+++ b/src/__tests__/package-sources/npmjs/stage-and-notify.lambda.test.ts
@@ -86,7 +86,6 @@ test('happy path', async () => {
     logGroupName: 'group',
     logStreamName: 'stream',
     awsRequestId: 'request-id',
-    getRemainingTimeInMillis: () => 15 * 60_000,
   } as any;
 
   await expect(handler(event, context)).resolves.toBe(undefined);
@@ -142,9 +141,7 @@ test('ignores persistent 404', async () => {
     version: '0.0.785',
   };
 
-  const context: Context = {
-    getRemainingTimeInMillis: () => 15 * 60_000,
-  } as any;
+  const context: Context = {} as any;
 
   await expect(handler(event, context)).resolves.toBe(undefined);
   expect(mockS3).not.toHaveReceivedCommand(PutObjectCommand);
@@ -182,7 +179,6 @@ test('retries a 404 and stages the tarball once it becomes available', async () 
     logGroupName: 'group',
     logStreamName: 'stream',
     awsRequestId: 'request-id',
-    getRemainingTimeInMillis: () => 15 * 60_000,
   } as any;
 
   await expect(handler(event, context)).resolves.toBe(undefined);
@@ -196,31 +192,6 @@ test('retries a 404 and stages the tarball once it becomes available', async () 
     Metadata: expect.anything(),
   });
   expect(mockSQS).toHaveReceivedCommandTimes(SendMessageCommand, 1);
-});
-
-test('stops retrying a 404 when the invocation nears its timeout', async () => {
-  const basePath = 'https://registry.npmjs.org';
-  const uri = '/@pepperize/cdk-vpc/-/cdk-vpc-0.0.785.tgz';
-
-  // a single 404: the remaining-time guard must prevent any retry
-  nock(basePath).get(uri).reply(404);
-
-  const event: PackageVersion = {
-    tarballUrl: `${basePath}${uri}`,
-    integrity: '09d37ec93c5518bf4842ac8e381a5c06452500e5',
-    modified: new Date().toISOString(),
-    name: '@pepper/cdk-vpc',
-    seq: '26437963',
-    version: '0.0.785',
-  };
-
-  const context: Context = {
-    getRemainingTimeInMillis: () => 60_000,
-  } as any;
-
-  await expect(handler(event, context)).resolves.toBe(undefined);
-  expect(mockS3).not.toHaveReceivedCommand(PutObjectCommand);
-  expect(mockSQS).not.toHaveReceivedCommand(SendMessageCommand);
 });
 
 test('propagates non-404 errors without retrying', async () => {
@@ -239,9 +210,7 @@ test('propagates non-404 errors without retrying', async () => {
     version: '0.0.785',
   };
 
-  const context: Context = {
-    getRemainingTimeInMillis: () => 15 * 60_000,
-  } as any;
+  const context: Context = {} as any;
 
   await expect(handler(event, context)).rejects.toThrow(
     /Unsuccessful GET: 500/

--- a/src/package-sources/npmjs.ts
+++ b/src/package-sources/npmjs.ts
@@ -176,7 +176,9 @@ export class NpmJs implements IPackageSource {
       },
       memorySize: 10_024, // 10GiB
       retryAttempts: 2,
-      timeout: Duration.minutes(5),
+      // Long enough for the 10 minute tarball 404 retry window, plus margin
+      // to download and store a large tarball.
+      timeout: Duration.minutes(13),
       tracing: Tracing.ACTIVE,
     });
 

--- a/src/package-sources/npmjs/stage-and-notify.lambda.ts
+++ b/src/package-sources/npmjs/stage-and-notify.lambda.ts
@@ -54,7 +54,7 @@ export async function handler(
 
   let tarball: Buffer;
   try {
-    tarball = await downloadTarball(event, context);
+    tarball = await downloadTarball(event);
   } catch (e) {
     if (e instanceof HttpNotFoundError) {
       // The tarball is still not available, even after retrying for a while
@@ -163,14 +163,8 @@ export interface PackageVersion {
  * shortly. Retries carry a unique query string because registry.npmjs.org
  * caches 404s at its CDN for 5 minutes: re-requesting the plain URL within
  * the retry deadline would only ever see the first, cached 404.
- *
- * Stops retrying early when the invocation nears its timeout, leaving room
- * to download and store a large tarball.
  */
-async function downloadTarball(
-  event: PackageVersion,
-  context: Context
-): Promise<Buffer> {
+async function downloadTarball(event: PackageVersion): Promise<Buffer> {
   const startTime = now();
   let attempt = 0;
   while (true) {
@@ -184,8 +178,7 @@ async function downloadTarball(
     } catch (e) {
       if (
         !(e instanceof HttpNotFoundError) ||
-        now() - startTime >= NOT_FOUND_RETRY.deadlineMs ||
-        context.getRemainingTimeInMillis() < 120_000
+        now() - startTime >= NOT_FOUND_RETRY.deadlineMs
       ) {
         throw e;
       }

--- a/src/package-sources/npmjs/stage-and-notify.lambda.ts
+++ b/src/package-sources/npmjs/stage-and-notify.lambda.ts
@@ -17,8 +17,8 @@ class HttpNotFoundError extends Error {}
  */
 const NOT_FOUND_RETRY = {
   baseDelayMs: 1_000,
-  maxDelayMs: 8_000,
-  deadlineMs: 60_000,
+  maxDelayMs: 60_000,
+  deadlineMs: 10 * 60_000,
 };
 
 /**
@@ -54,7 +54,7 @@ export async function handler(
 
   let tarball: Buffer;
   try {
-    tarball = await downloadTarball(event);
+    tarball = await downloadTarball(event, context);
   } catch (e) {
     if (e instanceof HttpNotFoundError) {
       // The tarball is still not available, even after retrying for a while
@@ -163,8 +163,14 @@ export interface PackageVersion {
  * shortly. Retries carry a unique query string because registry.npmjs.org
  * caches 404s at its CDN for 5 minutes: re-requesting the plain URL within
  * the retry deadline would only ever see the first, cached 404.
+ *
+ * Stops retrying early when the invocation nears its timeout, leaving room
+ * to download and store a large tarball.
  */
-async function downloadTarball(event: PackageVersion): Promise<Buffer> {
+async function downloadTarball(
+  event: PackageVersion,
+  context: Context
+): Promise<Buffer> {
   const startTime = now();
   let attempt = 0;
   while (true) {
@@ -178,7 +184,8 @@ async function downloadTarball(event: PackageVersion): Promise<Buffer> {
     } catch (e) {
       if (
         !(e instanceof HttpNotFoundError) ||
-        now() - startTime >= NOT_FOUND_RETRY.deadlineMs
+        now() - startTime >= NOT_FOUND_RETRY.deadlineMs ||
+        context.getRemainingTimeInMillis() < 120_000
       ) {
         throw e;
       }


### PR DESCRIPTION
Builds on #1919. 

- retry deadline 60s -> 10 minutes, backoff cap 8s -> 60s
- stager lambda timeout 5 -> 13 minutes (retry window plus margin to download and store a large tarball)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
