### PR TITLE
fix: Construct Hub fails with CDK v2.268.0 and higher

### DIFF
--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -3,98 +3,6 @@
 exports[`minimal usage 1`] = `
 {
   "Mappings": {
-    "CloudwatchlambdainsightsversionMap": {
-      "af-south-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:af-south-1:012438385374:layer:LambdaInsightsExtension:28",
-      },
-      "ap-east-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-east-1:519774774795:layer:LambdaInsightsExtension:28",
-      },
-      "ap-northeast-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-northeast-1:580247275435:layer:LambdaInsightsExtension:60",
-      },
-      "ap-northeast-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-northeast-2:580247275435:layer:LambdaInsightsExtension:37",
-      },
-      "ap-northeast-3": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-northeast-3:194566237122:layer:LambdaInsightsExtension:19",
-      },
-      "ap-south-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-south-1:580247275435:layer:LambdaInsightsExtension:36",
-      },
-      "ap-south-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-south-2:891564319516:layer:LambdaInsightsExtension:10",
-      },
-      "ap-southeast-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-southeast-1:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "ap-southeast-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-southeast-2:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "ap-southeast-3": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-southeast-3:439286490199:layer:LambdaInsightsExtension:14",
-      },
-      "ap-southeast-4": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-southeast-4:158895979263:layer:LambdaInsightsExtension:5",
-      },
-      "ca-central-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ca-central-1:580247275435:layer:LambdaInsightsExtension:37",
-      },
-      "cn-north-1": {
-        "1x0x229x0xx86x64": "arn:aws-cn:lambda:cn-north-1:488211338238:layer:LambdaInsightsExtension:29",
-      },
-      "cn-northwest-1": {
-        "1x0x229x0xx86x64": "arn:aws-cn:lambda:cn-northwest-1:488211338238:layer:LambdaInsightsExtension:29",
-      },
-      "eu-central-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-central-1:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "eu-central-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-central-2:033019950311:layer:LambdaInsightsExtension:11",
-      },
-      "eu-north-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-north-1:580247275435:layer:LambdaInsightsExtension:35",
-      },
-      "eu-south-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-south-1:339249233099:layer:LambdaInsightsExtension:28",
-      },
-      "eu-south-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-south-2:352183217350:layer:LambdaInsightsExtension:12",
-      },
-      "eu-west-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-west-1:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "eu-west-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-west-2:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "eu-west-3": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-west-3:580247275435:layer:LambdaInsightsExtension:37",
-      },
-      "il-central-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:il-central-1:459530977127:layer:LambdaInsightsExtension:12",
-      },
-      "me-central-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:me-central-1:732604637566:layer:LambdaInsightsExtension:11",
-      },
-      "me-south-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:me-south-1:285320876703:layer:LambdaInsightsExtension:28",
-      },
-      "sa-east-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:sa-east-1:580247275435:layer:LambdaInsightsExtension:37",
-      },
-      "us-east-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:us-east-1:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "us-east-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:us-east-2:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "us-west-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:us-west-1:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "us-west-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:us-west-2:580247275435:layer:LambdaInsightsExtension:38",
-      },
-    },
     "LatestNodeRuntimeMap": {
       "af-south-1": {
         "value": "nodejs20.x",
@@ -12927,15 +12835,6 @@ function handler(event) {
           {
             "Ref": "ConstructHubWebAppDeployWebsiteAwsCliLayer23CFFBC1",
           },
-          {
-            "Fn::FindInMap": [
-              "CloudwatchlambdainsightsversionMap",
-              {
-                "Ref": "AWS::Region",
-              },
-              "1x0x229x0xx86x64",
-            ],
-          },
         ],
         "MemorySize": 512,
         "Role": {
@@ -12973,18 +12872,6 @@ function handler(event) {
                   "Ref": "AWS::Partition",
                 },
                 ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/CloudWatchLambdaInsightsExecutionRolePolicy",
               ],
             ],
           },
@@ -14031,98 +13918,6 @@ function handler(event) {
 exports[`piggy-backing on an existing CodeArtifact domain 1`] = `
 {
   "Mappings": {
-    "CloudwatchlambdainsightsversionMap": {
-      "af-south-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:af-south-1:012438385374:layer:LambdaInsightsExtension:28",
-      },
-      "ap-east-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-east-1:519774774795:layer:LambdaInsightsExtension:28",
-      },
-      "ap-northeast-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-northeast-1:580247275435:layer:LambdaInsightsExtension:60",
-      },
-      "ap-northeast-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-northeast-2:580247275435:layer:LambdaInsightsExtension:37",
-      },
-      "ap-northeast-3": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-northeast-3:194566237122:layer:LambdaInsightsExtension:19",
-      },
-      "ap-south-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-south-1:580247275435:layer:LambdaInsightsExtension:36",
-      },
-      "ap-south-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-south-2:891564319516:layer:LambdaInsightsExtension:10",
-      },
-      "ap-southeast-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-southeast-1:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "ap-southeast-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-southeast-2:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "ap-southeast-3": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-southeast-3:439286490199:layer:LambdaInsightsExtension:14",
-      },
-      "ap-southeast-4": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-southeast-4:158895979263:layer:LambdaInsightsExtension:5",
-      },
-      "ca-central-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ca-central-1:580247275435:layer:LambdaInsightsExtension:37",
-      },
-      "cn-north-1": {
-        "1x0x229x0xx86x64": "arn:aws-cn:lambda:cn-north-1:488211338238:layer:LambdaInsightsExtension:29",
-      },
-      "cn-northwest-1": {
-        "1x0x229x0xx86x64": "arn:aws-cn:lambda:cn-northwest-1:488211338238:layer:LambdaInsightsExtension:29",
-      },
-      "eu-central-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-central-1:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "eu-central-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-central-2:033019950311:layer:LambdaInsightsExtension:11",
-      },
-      "eu-north-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-north-1:580247275435:layer:LambdaInsightsExtension:35",
-      },
-      "eu-south-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-south-1:339249233099:layer:LambdaInsightsExtension:28",
-      },
-      "eu-south-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-south-2:352183217350:layer:LambdaInsightsExtension:12",
-      },
-      "eu-west-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-west-1:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "eu-west-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-west-2:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "eu-west-3": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-west-3:580247275435:layer:LambdaInsightsExtension:37",
-      },
-      "il-central-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:il-central-1:459530977127:layer:LambdaInsightsExtension:12",
-      },
-      "me-central-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:me-central-1:732604637566:layer:LambdaInsightsExtension:11",
-      },
-      "me-south-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:me-south-1:285320876703:layer:LambdaInsightsExtension:28",
-      },
-      "sa-east-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:sa-east-1:580247275435:layer:LambdaInsightsExtension:37",
-      },
-      "us-east-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:us-east-1:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "us-east-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:us-east-2:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "us-west-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:us-west-1:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "us-west-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:us-west-2:580247275435:layer:LambdaInsightsExtension:38",
-      },
-    },
     "LatestNodeRuntimeMap": {
       "af-south-1": {
         "value": "nodejs20.x",
@@ -27391,15 +27186,6 @@ function handler(event) {
           {
             "Ref": "ConstructHubWebAppDeployWebsiteAwsCliLayer23CFFBC1",
           },
-          {
-            "Fn::FindInMap": [
-              "CloudwatchlambdainsightsversionMap",
-              {
-                "Ref": "AWS::Region",
-              },
-              "1x0x229x0xx86x64",
-            ],
-          },
         ],
         "MemorySize": 512,
         "Role": {
@@ -27437,18 +27223,6 @@ function handler(event) {
                   "Ref": "AWS::Partition",
                 },
                 ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/CloudWatchLambdaInsightsExecutionRolePolicy",
               ],
             ],
           },
@@ -28495,98 +28269,6 @@ function handler(event) {
 exports[`with all internet access 1`] = `
 {
   "Mappings": {
-    "CloudwatchlambdainsightsversionMap": {
-      "af-south-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:af-south-1:012438385374:layer:LambdaInsightsExtension:28",
-      },
-      "ap-east-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-east-1:519774774795:layer:LambdaInsightsExtension:28",
-      },
-      "ap-northeast-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-northeast-1:580247275435:layer:LambdaInsightsExtension:60",
-      },
-      "ap-northeast-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-northeast-2:580247275435:layer:LambdaInsightsExtension:37",
-      },
-      "ap-northeast-3": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-northeast-3:194566237122:layer:LambdaInsightsExtension:19",
-      },
-      "ap-south-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-south-1:580247275435:layer:LambdaInsightsExtension:36",
-      },
-      "ap-south-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-south-2:891564319516:layer:LambdaInsightsExtension:10",
-      },
-      "ap-southeast-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-southeast-1:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "ap-southeast-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-southeast-2:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "ap-southeast-3": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-southeast-3:439286490199:layer:LambdaInsightsExtension:14",
-      },
-      "ap-southeast-4": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-southeast-4:158895979263:layer:LambdaInsightsExtension:5",
-      },
-      "ca-central-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ca-central-1:580247275435:layer:LambdaInsightsExtension:37",
-      },
-      "cn-north-1": {
-        "1x0x229x0xx86x64": "arn:aws-cn:lambda:cn-north-1:488211338238:layer:LambdaInsightsExtension:29",
-      },
-      "cn-northwest-1": {
-        "1x0x229x0xx86x64": "arn:aws-cn:lambda:cn-northwest-1:488211338238:layer:LambdaInsightsExtension:29",
-      },
-      "eu-central-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-central-1:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "eu-central-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-central-2:033019950311:layer:LambdaInsightsExtension:11",
-      },
-      "eu-north-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-north-1:580247275435:layer:LambdaInsightsExtension:35",
-      },
-      "eu-south-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-south-1:339249233099:layer:LambdaInsightsExtension:28",
-      },
-      "eu-south-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-south-2:352183217350:layer:LambdaInsightsExtension:12",
-      },
-      "eu-west-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-west-1:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "eu-west-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-west-2:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "eu-west-3": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-west-3:580247275435:layer:LambdaInsightsExtension:37",
-      },
-      "il-central-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:il-central-1:459530977127:layer:LambdaInsightsExtension:12",
-      },
-      "me-central-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:me-central-1:732604637566:layer:LambdaInsightsExtension:11",
-      },
-      "me-south-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:me-south-1:285320876703:layer:LambdaInsightsExtension:28",
-      },
-      "sa-east-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:sa-east-1:580247275435:layer:LambdaInsightsExtension:37",
-      },
-      "us-east-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:us-east-1:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "us-east-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:us-east-2:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "us-west-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:us-west-1:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "us-west-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:us-west-2:580247275435:layer:LambdaInsightsExtension:38",
-      },
-    },
     "LatestNodeRuntimeMap": {
       "af-south-1": {
         "value": "nodejs20.x",
@@ -41419,15 +41101,6 @@ function handler(event) {
           {
             "Ref": "ConstructHubWebAppDeployWebsiteAwsCliLayer23CFFBC1",
           },
-          {
-            "Fn::FindInMap": [
-              "CloudwatchlambdainsightsversionMap",
-              {
-                "Ref": "AWS::Region",
-              },
-              "1x0x229x0xx86x64",
-            ],
-          },
         ],
         "MemorySize": 512,
         "Role": {
@@ -41465,18 +41138,6 @@ function handler(event) {
                   "Ref": "AWS::Partition",
                 },
                 ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/CloudWatchLambdaInsightsExecutionRolePolicy",
               ],
             ],
           },
@@ -42529,98 +42190,6 @@ exports[`with domain 1`] = `
       },
       "aws-cn": {
         "zoneId": "Z3RFFRIM2A3IF5",
-      },
-    },
-    "CloudwatchlambdainsightsversionMap": {
-      "af-south-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:af-south-1:012438385374:layer:LambdaInsightsExtension:28",
-      },
-      "ap-east-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-east-1:519774774795:layer:LambdaInsightsExtension:28",
-      },
-      "ap-northeast-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-northeast-1:580247275435:layer:LambdaInsightsExtension:60",
-      },
-      "ap-northeast-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-northeast-2:580247275435:layer:LambdaInsightsExtension:37",
-      },
-      "ap-northeast-3": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-northeast-3:194566237122:layer:LambdaInsightsExtension:19",
-      },
-      "ap-south-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-south-1:580247275435:layer:LambdaInsightsExtension:36",
-      },
-      "ap-south-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-south-2:891564319516:layer:LambdaInsightsExtension:10",
-      },
-      "ap-southeast-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-southeast-1:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "ap-southeast-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-southeast-2:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "ap-southeast-3": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-southeast-3:439286490199:layer:LambdaInsightsExtension:14",
-      },
-      "ap-southeast-4": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-southeast-4:158895979263:layer:LambdaInsightsExtension:5",
-      },
-      "ca-central-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ca-central-1:580247275435:layer:LambdaInsightsExtension:37",
-      },
-      "cn-north-1": {
-        "1x0x229x0xx86x64": "arn:aws-cn:lambda:cn-north-1:488211338238:layer:LambdaInsightsExtension:29",
-      },
-      "cn-northwest-1": {
-        "1x0x229x0xx86x64": "arn:aws-cn:lambda:cn-northwest-1:488211338238:layer:LambdaInsightsExtension:29",
-      },
-      "eu-central-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-central-1:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "eu-central-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-central-2:033019950311:layer:LambdaInsightsExtension:11",
-      },
-      "eu-north-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-north-1:580247275435:layer:LambdaInsightsExtension:35",
-      },
-      "eu-south-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-south-1:339249233099:layer:LambdaInsightsExtension:28",
-      },
-      "eu-south-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-south-2:352183217350:layer:LambdaInsightsExtension:12",
-      },
-      "eu-west-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-west-1:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "eu-west-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-west-2:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "eu-west-3": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-west-3:580247275435:layer:LambdaInsightsExtension:37",
-      },
-      "il-central-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:il-central-1:459530977127:layer:LambdaInsightsExtension:12",
-      },
-      "me-central-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:me-central-1:732604637566:layer:LambdaInsightsExtension:11",
-      },
-      "me-south-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:me-south-1:285320876703:layer:LambdaInsightsExtension:28",
-      },
-      "sa-east-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:sa-east-1:580247275435:layer:LambdaInsightsExtension:37",
-      },
-      "us-east-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:us-east-1:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "us-east-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:us-east-2:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "us-west-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:us-west-1:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "us-west-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:us-west-2:580247275435:layer:LambdaInsightsExtension:38",
       },
     },
     "LatestNodeRuntimeMap": {
@@ -55843,15 +55412,6 @@ function handler(event) {
           {
             "Ref": "ConstructHubWebAppDeployWebsiteAwsCliLayer23CFFBC1",
           },
-          {
-            "Fn::FindInMap": [
-              "CloudwatchlambdainsightsversionMap",
-              {
-                "Ref": "AWS::Region",
-              },
-              "1x0x229x0xx86x64",
-            ],
-          },
         ],
         "MemorySize": 512,
         "Role": {
@@ -55889,18 +55449,6 @@ function handler(event) {
                   "Ref": "AWS::Partition",
                 },
                 ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/CloudWatchLambdaInsightsExecutionRolePolicy",
               ],
             ],
           },
@@ -56947,98 +56495,6 @@ function handler(event) {
 exports[`with limited internet access 1`] = `
 {
   "Mappings": {
-    "CloudwatchlambdainsightsversionMap": {
-      "af-south-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:af-south-1:012438385374:layer:LambdaInsightsExtension:28",
-      },
-      "ap-east-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-east-1:519774774795:layer:LambdaInsightsExtension:28",
-      },
-      "ap-northeast-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-northeast-1:580247275435:layer:LambdaInsightsExtension:60",
-      },
-      "ap-northeast-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-northeast-2:580247275435:layer:LambdaInsightsExtension:37",
-      },
-      "ap-northeast-3": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-northeast-3:194566237122:layer:LambdaInsightsExtension:19",
-      },
-      "ap-south-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-south-1:580247275435:layer:LambdaInsightsExtension:36",
-      },
-      "ap-south-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-south-2:891564319516:layer:LambdaInsightsExtension:10",
-      },
-      "ap-southeast-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-southeast-1:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "ap-southeast-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-southeast-2:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "ap-southeast-3": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-southeast-3:439286490199:layer:LambdaInsightsExtension:14",
-      },
-      "ap-southeast-4": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-southeast-4:158895979263:layer:LambdaInsightsExtension:5",
-      },
-      "ca-central-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ca-central-1:580247275435:layer:LambdaInsightsExtension:37",
-      },
-      "cn-north-1": {
-        "1x0x229x0xx86x64": "arn:aws-cn:lambda:cn-north-1:488211338238:layer:LambdaInsightsExtension:29",
-      },
-      "cn-northwest-1": {
-        "1x0x229x0xx86x64": "arn:aws-cn:lambda:cn-northwest-1:488211338238:layer:LambdaInsightsExtension:29",
-      },
-      "eu-central-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-central-1:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "eu-central-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-central-2:033019950311:layer:LambdaInsightsExtension:11",
-      },
-      "eu-north-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-north-1:580247275435:layer:LambdaInsightsExtension:35",
-      },
-      "eu-south-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-south-1:339249233099:layer:LambdaInsightsExtension:28",
-      },
-      "eu-south-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-south-2:352183217350:layer:LambdaInsightsExtension:12",
-      },
-      "eu-west-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-west-1:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "eu-west-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-west-2:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "eu-west-3": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-west-3:580247275435:layer:LambdaInsightsExtension:37",
-      },
-      "il-central-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:il-central-1:459530977127:layer:LambdaInsightsExtension:12",
-      },
-      "me-central-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:me-central-1:732604637566:layer:LambdaInsightsExtension:11",
-      },
-      "me-south-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:me-south-1:285320876703:layer:LambdaInsightsExtension:28",
-      },
-      "sa-east-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:sa-east-1:580247275435:layer:LambdaInsightsExtension:37",
-      },
-      "us-east-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:us-east-1:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "us-east-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:us-east-2:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "us-west-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:us-west-1:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "us-west-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:us-west-2:580247275435:layer:LambdaInsightsExtension:38",
-      },
-    },
     "LatestNodeRuntimeMap": {
       "af-south-1": {
         "value": "nodejs20.x",
@@ -73279,15 +72735,6 @@ function handler(event) {
           {
             "Ref": "ConstructHubWebAppDeployWebsiteAwsCliLayer23CFFBC1",
           },
-          {
-            "Fn::FindInMap": [
-              "CloudwatchlambdainsightsversionMap",
-              {
-                "Ref": "AWS::Region",
-              },
-              "1x0x229x0xx86x64",
-            ],
-          },
         ],
         "MemorySize": 512,
         "Role": {
@@ -73325,18 +72772,6 @@ function handler(event) {
                   "Ref": "AWS::Partition",
                 },
                 ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/CloudWatchLambdaInsightsExecutionRolePolicy",
               ],
             ],
           },

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -3,98 +3,6 @@
 exports[`golden snapshot 1`] = `
 {
   "Mappings": {
-    "CloudwatchlambdainsightsversionMap": {
-      "af-south-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:af-south-1:012438385374:layer:LambdaInsightsExtension:28",
-      },
-      "ap-east-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-east-1:519774774795:layer:LambdaInsightsExtension:28",
-      },
-      "ap-northeast-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-northeast-1:580247275435:layer:LambdaInsightsExtension:60",
-      },
-      "ap-northeast-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-northeast-2:580247275435:layer:LambdaInsightsExtension:37",
-      },
-      "ap-northeast-3": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-northeast-3:194566237122:layer:LambdaInsightsExtension:19",
-      },
-      "ap-south-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-south-1:580247275435:layer:LambdaInsightsExtension:36",
-      },
-      "ap-south-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-south-2:891564319516:layer:LambdaInsightsExtension:10",
-      },
-      "ap-southeast-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-southeast-1:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "ap-southeast-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-southeast-2:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "ap-southeast-3": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-southeast-3:439286490199:layer:LambdaInsightsExtension:14",
-      },
-      "ap-southeast-4": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ap-southeast-4:158895979263:layer:LambdaInsightsExtension:5",
-      },
-      "ca-central-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:ca-central-1:580247275435:layer:LambdaInsightsExtension:37",
-      },
-      "cn-north-1": {
-        "1x0x229x0xx86x64": "arn:aws-cn:lambda:cn-north-1:488211338238:layer:LambdaInsightsExtension:29",
-      },
-      "cn-northwest-1": {
-        "1x0x229x0xx86x64": "arn:aws-cn:lambda:cn-northwest-1:488211338238:layer:LambdaInsightsExtension:29",
-      },
-      "eu-central-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-central-1:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "eu-central-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-central-2:033019950311:layer:LambdaInsightsExtension:11",
-      },
-      "eu-north-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-north-1:580247275435:layer:LambdaInsightsExtension:35",
-      },
-      "eu-south-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-south-1:339249233099:layer:LambdaInsightsExtension:28",
-      },
-      "eu-south-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-south-2:352183217350:layer:LambdaInsightsExtension:12",
-      },
-      "eu-west-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-west-1:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "eu-west-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-west-2:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "eu-west-3": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:eu-west-3:580247275435:layer:LambdaInsightsExtension:37",
-      },
-      "il-central-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:il-central-1:459530977127:layer:LambdaInsightsExtension:12",
-      },
-      "me-central-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:me-central-1:732604637566:layer:LambdaInsightsExtension:11",
-      },
-      "me-south-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:me-south-1:285320876703:layer:LambdaInsightsExtension:28",
-      },
-      "sa-east-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:sa-east-1:580247275435:layer:LambdaInsightsExtension:37",
-      },
-      "us-east-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:us-east-1:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "us-east-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:us-east-2:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "us-west-1": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:us-west-1:580247275435:layer:LambdaInsightsExtension:38",
-      },
-      "us-west-2": {
-        "1x0x229x0xx86x64": "arn:aws:lambda:us-west-2:580247275435:layer:LambdaInsightsExtension:38",
-      },
-    },
     "LatestNodeRuntimeMap": {
       "af-south-1": {
         "value": "nodejs20.x",
@@ -17207,15 +17115,6 @@ function handler(event) {
           {
             "Ref": "ConstructHubWebAppDeployWebsiteAwsCliLayer23CFFBC1",
           },
-          {
-            "Fn::FindInMap": [
-              "CloudwatchlambdainsightsversionMap",
-              {
-                "Ref": "AWS::Region",
-              },
-              "1x0x229x0xx86x64",
-            ],
-          },
         ],
         "MemorySize": 512,
         "Role": {
@@ -17253,18 +17152,6 @@ function handler(event) {
                   "Ref": "AWS::Partition",
                 },
                 ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/CloudWatchLambdaInsightsExecutionRolePolicy",
               ],
             ],
           },

--- a/src/webapp/index.ts
+++ b/src/webapp/index.ts
@@ -2,8 +2,6 @@ import * as path from 'path';
 import { CfnOutput } from 'aws-cdk-lib';
 import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
 import * as origins from 'aws-cdk-lib/aws-cloudfront-origins';
-import * as iam from 'aws-cdk-lib/aws-iam';
-import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as r53 from 'aws-cdk-lib/aws-route53';
 import * as r53targets from 'aws-cdk-lib/aws-route53-targets';
 import * as s3 from 'aws-cdk-lib/aws-s3';
@@ -319,7 +317,7 @@ export class WebApp extends Construct {
     // "website" contains the static react app
     const webappDir = path.join(__dirname, '..', '..', 'website');
 
-    const webAppDeploy = new s3deploy.BucketDeployment(this, 'DeployWebsite', {
+    new s3deploy.BucketDeployment(this, 'DeployWebsite', {
       destinationBucket: this.bucket,
       distribution: this.distribution,
       prune: false,
@@ -329,32 +327,6 @@ export class WebApp extends Construct {
         .toArray()
         .map(s3deploy.CacheControl.fromString),
     });
-
-    const lambdaInsightsArn =
-      lambda.LambdaInsightsVersion.VERSION_1_0_229_0.layerVersionArn;
-    
-    // Escape hatch to find the underlying Lambda Function
-    const cfnFunction = webAppDeploy.node.findChild(
-      'CustomResourceHandler'
-    ) as lambda.SingletonFunction;
-
-    // Add Lambda Insights to the Lambda Function
-    cfnFunction.addLayers(
-      lambda.LayerVersion.fromLayerVersionArn(
-        this,
-        'LambdaInsights',
-        lambdaInsightsArn
-      )
-    );
-
-    // Add Lambda Insights IAM role permissions
-    // role can only be undefined when the function is imported, which
-    // is not the case here
-    cfnFunction.role!.addManagedPolicy(
-      iam.ManagedPolicy.fromAwsManagedPolicyName(
-        'CloudWatchLambdaInsightsExecutionRolePolicy'
-      )
-    );
 
     // Generate config.json to customize frontend behavior
     const config = new WebappConfig({


### PR DESCRIPTION
In https://github.com/aws/aws-cdk/pull/37174, the architecture of `S3BucketDeployment` was switched to `arm64`.

In ConstructHub, we add in the [Lambda Insights Extension Layer](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Lambda-Insights-extension-versions.html), but the version we added was for x86. This means the S3BucketDeployment Lambda now fails to start up.

Since there is no easy way for the construct to pick the correct ARN to automatically switch between x86 and ARM depending on the architecture of the Lambda, and wholesale switching to ARM will break consumers that are on an old version of `aws-cdk-lib` where the platform is still x86, we opt for the next best solution: remove the layer altogether.

When it was introduced it was stated that it was in order to track memory consumption. Since nothing much is changing here and the memory is already 512 MB, seems safe enough to remove this if and until we see problems with the custom resource again.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*